### PR TITLE
add a sample ocp certificate policy, tuning still needed

### DIFF
--- a/community/README.md
+++ b/community/README.md
@@ -117,8 +117,8 @@ Policies in this folder are organized by [NIST Special Publication 800-53](https
   </tr>
   <tr>
     <td>System and Communications Protection</td>
-    <td>N/A</td>
-    <td>N/A</td>
+    <td><a href="./SC-System-and-Communications-Protection/policy-ocp4-certs.yaml">OpenShift Certificate Expiration Policy</a>: Monitor the OpenShift 4.x namespaces to validate certificates managed by the infrastructure are rotated as expected.</td>
+    <td>OpenShift 4</td>
   </tr>
   <tr>
     <td rowspan="2">System and Information Integrity</td>

--- a/community/README.md
+++ b/community/README.md
@@ -117,7 +117,7 @@ Policies in this folder are organized by [NIST Special Publication 800-53](https
   </tr>
   <tr>
     <td>System and Communications Protection</td>
-    <td><a href="./SC-System-and-Communications-Protection/policy-ocp4-certs.yaml">OpenShift Certificate Expiration Policy</a>: Monitor the OpenShift 4.x namespaces to validate certificates managed by the infrastructure are rotated as expected.</td>
+    <td><a href="./SC-System-and-Communications-Protection/policy-ocp4-certs.yaml">OpenShift Certificate Expiration Policy</a>: Monitor the OpenShift 4.x namespaces to validate that certificates managed by the infrastructure are rotated as expected.</td>
     <td>OpenShift 4</td>
   </tr>
   <tr>

--- a/community/SC-System-and-Communications-Protection/policy-ocp4-certs.yaml
+++ b/community/SC-System-and-Communications-Protection/policy-ocp4-certs.yaml
@@ -3,9 +3,9 @@ kind: Policy
 metadata:
   name: policy-cert-ocp4
   annotations:
-    policy.open-cluster-management.io/standards: NIST-CSF
-    policy.open-cluster-management.io/categories: PR.DS Data Security
-    policy.open-cluster-management.io/controls: PR.DS-2 Data-in-transit
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+    policy.open-cluster-management.io/categories: SC System and Communications Protection
+    policy.open-cluster-management.io/controls: SC-12 Cryptographic Key Establishment and Management
 spec:
   remediationAction: inform
   disabled: false
@@ -29,7 +29,6 @@ spec:
           - openshift-cluster-samples-operator
           - openshift-cluster-storage-operator
           - openshift-cluster-version
-          - openshift-config-managed
           - openshift-config-operator
           - openshift-console
           - openshift-console-operator
@@ -40,14 +39,8 @@ spec:
           - openshift-etcd
           - openshift-etcd-operator
           - openshift-image-registry
-          - openshift-ingress
           - openshift-ingress-operator
           - openshift-insights
-          - openshift-kube-apiserver
-          - openshift-kube-apiserver-operator
-          - openshift-kube-controller-manager
-          - openshift-kube-controller-manager-operator
-          - openshift-kube-scheduler
           - openshift-kube-scheduler-operator
           - openshift-kube-storage-version-migrator-operator
           - openshift-machine-api
@@ -57,7 +50,45 @@ spec:
           - openshift-multus
         remediationAction: inform
         minimumDuration: 400h
+  - objectDefinition:
+      apiVersion: policy.open-cluster-management.io/v1
+      kind: CertificatePolicy
+      metadata:
+        name: openshift-cert-policy-ingress
+      spec:
+        namespaceSelector:
+          include:
+          - openshift-ingress
+        remediationAction: inform
+        minimumDuration: 24h
         minimumCADuration: 400h
+  - objectDefinition:
+      apiVersion: policy.open-cluster-management.io/v1
+      kind: CertificatePolicy
+      metadata:
+        name: openshift-cert-policy-csr
+      spec:
+        namespaceSelector:
+          include:
+          - openshift-kube-apiserver-operator
+          - openshift-kube-controller-manager-operator
+        remediationAction: inform
+        minimumDuration: 400h
+        minimumCADuration: 24h
+  - objectDefinition:
+      apiVersion: policy.open-cluster-management.io/v1
+      kind: CertificatePolicy
+      metadata:
+        name: openshift-cert-policy-mgr
+      spec:
+        namespaceSelector:
+          include:
+          - openshift-config-managed
+          - openshift-kube-apiserver
+          - openshift-kube-scheduler
+          - openshift-kube-controller-manager
+        remediationAction: inform
+        minimumDuration: 24h
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/community/SC-System-and-Communications-Protection/policy-ocp4-certs.yaml
+++ b/community/SC-System-and-Communications-Protection/policy-ocp4-certs.yaml
@@ -1,0 +1,85 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: policy-cert-ocp4
+  annotations:
+    policy.open-cluster-management.io/standards: NIST-CSF
+    policy.open-cluster-management.io/categories: PR.DS Data Security
+    policy.open-cluster-management.io/controls: PR.DS-2 Data-in-transit
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+  - objectDefinition:
+      apiVersion: policy.open-cluster-management.io/v1
+      kind: CertificatePolicy
+      metadata:
+        name: openshift-cert-policy
+      spec:
+        namespaceSelector:
+          include:
+          - openshift-service-ca-operator
+          - openshift-service-ca
+          - openshift-operator-lifecycle-manager
+          - openshift-apiserver
+          - openshift-apiserver-operator
+          - openshift-authentication
+          - openshift-authentication-operator
+          - openshift-cluster-machine-approver
+          - openshift-cluster-samples-operator
+          - openshift-cluster-storage-operator
+          - openshift-cluster-version
+          - openshift-config-managed
+          - openshift-config-operator
+          - openshift-console
+          - openshift-console-operator
+          - openshift-controller-manager
+          - openshift-controller-manager-operator
+          - openshift-dns
+          - openshift-dns-operator
+          - openshift-etcd
+          - openshift-etcd-operator
+          - openshift-image-registry
+          - openshift-ingress
+          - openshift-ingress-operator
+          - openshift-insights
+          - openshift-kube-apiserver
+          - openshift-kube-apiserver-operator
+          - openshift-kube-controller-manager
+          - openshift-kube-controller-manager-operator
+          - openshift-kube-scheduler
+          - openshift-kube-scheduler-operator
+          - openshift-kube-storage-version-migrator-operator
+          - openshift-machine-api
+          - openshift-machine-config-operator
+          - openshift-marketplace
+          - openshift-monitoring
+          - openshift-multus
+        remediationAction: inform
+        minimumDuration: 400h
+        minimumCADuration: 400h
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: binding-policy-cert-ocp4
+placementRef:
+  name: placement-policy-cert-ocp4
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+- name: policy-cert-ocp4
+  kind: Policy
+  apiGroup: policy.open-cluster-management.io
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: placement-policy-cert-ocp4
+spec:
+  clusterConditions:
+  - status: "True"
+    type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      - {key: vendor, operator: In, values: ["OpenShift"]}


### PR DESCRIPTION
This is a sample that monitors OCP certs.  OCP manages its own certs so this is really just a sample that uses the certificate policy controller.