### PR TITLE
Gatekeeper policies from Red Hat CoP

### DIFF
--- a/community/CM-Configuration-Management/policy-gatekeeper-container-image-latest.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-container-image-latest.yaml
@@ -1,0 +1,421 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: policy-gatekeeper-containerimagelatest
+  annotations:
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-gatekeeper-containerimagelatest
+        spec:
+          remediationAction: enforce
+          severity: low
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: templates.gatekeeper.sh/v1beta1
+                kind: ConstraintTemplate
+                metadata:
+                  creationTimestamp: null
+                  name: containerimagelatest
+                spec:
+                  crd:
+                    spec:
+                      names:
+                        kind: ContainerImageLatest
+                  targets:
+                    - libs:
+                        - |
+                          package lib.konstraint
+
+                          default is_gatekeeper = false
+
+                          is_gatekeeper {
+                            has_field(input, "review")
+                            has_field(input.review, "object")
+                          }
+
+                          object = input {
+                            not is_gatekeeper
+                          }
+
+                          object = input.review.object {
+                            is_gatekeeper
+                          }
+
+                          format(msg) = gatekeeper_format {
+                            is_gatekeeper
+                            gatekeeper_format = {"msg": msg}
+                          }
+
+                          format(msg) = msg {
+                            not is_gatekeeper
+                          }
+
+                          name = object.metadata.name
+
+                          kind = object.kind
+
+                          has_field(obj, field) {
+                            obj[field]
+                          }
+
+                          missing_field(obj, field) = true {
+                            obj[field] == ""
+                          }
+
+                          missing_field(obj, field) = true {
+                            not has_field(obj, field)
+                          }
+
+                          is_service {
+                            lower(kind) == "service"
+                          }
+
+                          is_statefulset {
+                            lower(kind) == "statefulset"
+                          }
+
+                          is_daemonset {
+                            lower(kind) == "daemonset"
+                          }
+
+                          is_deployment {
+                            lower(kind) == "deployment"
+                          }
+
+                          is_pod {
+                            lower(kind) == "pod"
+                          }
+
+                          is_namespace {
+                            lower(kind) == "namespace"
+                          }
+
+                          is_workload {
+                            containers[_]
+                          }
+
+                          pod_containers(pod) = all_containers {
+                            keys = {"containers", "initContainers"}
+                            all_containers = [c | keys[k]; c = pod.spec[k][_]]
+                          }
+
+                          containers[container] {
+                            pods[pod]
+                            all_containers = pod_containers(pod)
+                            container = all_containers[_]
+                          }
+
+                          containers[container] {
+                            all_containers = pod_containers(object)
+                            container = all_containers[_]
+                          }
+
+                          container_images[image] {
+                            containers[container]
+                            image = container.image
+                          }
+
+                          container_images[image] {
+                            image = object.spec.image
+                          }
+
+                          split_image(image) = [image, "latest"] {
+                            not contains(image, ":")
+                          }
+
+                          split_image(image) = [image_name, tag] {
+                            [image_name, tag] = split(image, ":")
+                          }
+
+                          pods[pod] {
+                            is_statefulset
+                            pod = object.spec.template
+                          }
+
+                          pods[pod] {
+                            is_daemonset
+                            pod = object.spec.template
+                          }
+
+                          pods[pod] {
+                            is_deployment
+                            pod = object.spec.template
+                          }
+
+                          pods[pod] {
+                            is_pod
+                            pod = object
+                          }
+
+                          volumes[volume] {
+                            pods[pod]
+                            volume = pod.spec.volumes[_]
+                          }
+
+                          mem_multiple("E") = 1000000000000000000000 { true }
+
+                          mem_multiple("P") = 1000000000000000000 { true }
+
+                          mem_multiple("T") = 1000000000000000 { true }
+
+                          mem_multiple("G") = 1000000000000 { true }
+
+                          mem_multiple("M") = 1000000000 { true }
+
+                          mem_multiple("k") = 1000000 { true }
+
+                          mem_multiple("") = 1000 { true }
+
+                          mem_multiple("m") = 1 { true }
+
+                          mem_multiple("Ki") = 1024000 { true }
+
+                          mem_multiple("Mi") = 1048576000 { true }
+
+                          mem_multiple("Gi") = 1073741824000 { true }
+
+                          mem_multiple("Ti") = 1099511627776000 { true }
+
+                          mem_multiple("Pi") = 1125899906842624000 { true }
+
+                          mem_multiple("Ei") = 1152921504606846976000 { true }
+
+                          get_suffix(mem) = suffix {
+                            not is_string(mem)
+                            suffix := ""
+                          }
+
+                          get_suffix(mem) = suffix {
+                            is_string(mem)
+                            count(mem) > 0
+                            suffix := substring(mem, count(mem) - 1, -1)
+                            mem_multiple(suffix)
+                          }
+
+                          get_suffix(mem) = suffix {
+                            is_string(mem)
+                            count(mem) > 1
+                            suffix := substring(mem, count(mem) - 2, -1)
+                            mem_multiple(suffix)
+                          }
+
+                          get_suffix(mem) = suffix {
+                            is_string(mem)
+                            count(mem) > 1
+                            not mem_multiple(substring(mem, count(mem) - 1, -1))
+                            not mem_multiple(substring(mem, count(mem) - 2, -1))
+                            suffix := ""
+                          }
+
+                          get_suffix(mem) = suffix {
+                            is_string(mem)
+                            count(mem) == 1
+                            not mem_multiple(substring(mem, count(mem) - 1, -1))
+                            suffix := ""
+                          }
+
+                          get_suffix(mem) = suffix {
+                            is_string(mem)
+                            count(mem) == 0
+                            suffix := ""
+                          }
+
+                          canonify_mem(orig) = new {
+                            is_number(orig)
+                            new := orig * 1000
+                          }
+
+                          canonify_mem(orig) = new {
+                            not is_number(orig)
+                            suffix := get_suffix(orig)
+                            raw := replace(orig, suffix, "")
+                            re_match("^[0-9]+$", raw)
+                            new := to_number(raw) * mem_multiple(suffix)
+                          }
+
+                          canonify_storage(orig) = new {
+                            is_number(orig)
+                            new := orig
+                          }
+
+                          canonify_storage(orig) = new {
+                            not is_number(orig)
+                            suffix := get_suffix(orig)
+                            raw := replace(orig, suffix, "")
+                            re_match("^[0-9]+$", raw)
+                            new := to_number(raw) * mem_multiple(suffix)
+                          }
+
+                          canonify_cpu(orig) = new {
+                            is_number(orig)
+                            new := orig * 1000
+                          }
+
+                          canonify_cpu(orig) = new {
+                            not is_number(orig)
+                            endswith(orig, "m")
+                            new := to_number(replace(orig, "m", ""))
+                          }
+
+                          canonify_cpu(orig) = new {
+                            not is_number(orig)
+                            not endswith(orig, "m")
+                            re_match("^[0-9]+$", orig)
+                            new := to_number(orig) * 1000
+                          }
+
+                          dropped_capability(container, cap) {
+                            container.securityContext.capabilities.drop[_] == cap
+                          }
+
+                          added_capability(container, cap) {
+                            container.securityContext.capabilities.add[_] == cap
+                          }
+
+                          no_read_only_filesystem(c) {
+                            not has_field(c, "securityContext")
+                          }
+
+                          no_read_only_filesystem(c) {
+                            has_field(c, "securityContext")
+                            not has_field(c.securityContext, "readOnlyRootFilesystem")
+                          }
+
+                          priviledge_escalation_allowed(c) {
+                            not has_field(c, "securityContext")
+                          }
+
+                          priviledge_escalation_allowed(c) {
+                            has_field(c, "securityContext")
+                            has_field(c.securityContext, "allowPrivilegeEscalation")
+                          }
+                        - |-
+                          package lib.openshift
+
+                          import data.lib.konstraint
+
+                          is_deploymentconfig {
+                            lower(konstraint.object.apiVersion) == "apps.openshift.io/v1"
+                            lower(konstraint.object.kind) == "deploymentconfig"
+                          }
+
+                          is_route {
+                            lower(konstraint.object.apiVersion) == "route.openshift.io/v1"
+                            lower(konstraint.object.kind) == "route"
+                          }
+
+                          is_workload_kind {
+                            is_deploymentconfig
+                          }
+
+                          is_workload_kind {
+                            konstraint.is_statefulset
+                          }
+
+                          is_workload_kind {
+                            konstraint.is_daemonset
+                          }
+
+                          is_workload_kind {
+                            konstraint.is_deployment
+                          }
+
+                          is_all_kind {
+                            is_workload_kind
+                          }
+
+                          is_all_kind {
+                            konstraint.is_service
+                          }
+
+                          is_all_kind {
+                            is_route
+                          }
+
+                          pods[pod] {
+                            is_deploymentconfig
+                            pod = konstraint.object.spec.template
+                          }
+
+                          pods[pod] {
+                            pod = konstraint.pods[_]
+                          }
+
+                          containers[container] {
+                            pods[pod]
+                            all_containers = konstraint.pod_containers(pod)
+                            container = all_containers[_]
+                          }
+
+                          containers[container] {
+                            container = konstraint.containers[_]
+                          }
+                      rego: |-
+                        package ocp.bestpractices.container_image_latest
+
+                        import data.lib.konstraint
+                        import data.lib.openshift
+
+                        violation[msg] {
+                          openshift.is_workload_kind
+
+                          container := openshift.containers[_]
+
+                          endswith(container.image, ":latest")
+                          obj := konstraint.object
+
+                          msg := konstraint.format(sprintf("%s/%s: container '%s' is using the latest tag for its image (%s), which is an anti-pattern.", [obj.kind, obj.metadata.name, container.name, container.image]))
+                        }
+                      target: admission.k8s.gatekeeper.sh
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: constraints.gatekeeper.sh/v1beta1
+                kind: ContainerImageLatest
+                metadata:
+                  name: containerimagelatest
+                spec:
+                  match:
+                    kinds:
+                      - apiGroups:
+                          - apps.openshift.io
+                          - apps
+                        kinds:
+                          - DeploymentConfig
+                          - DaemonSet
+                          - Deployment
+                          - StatefulSet
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: binding-policy-gatekeeper-containerimagelatest
+placementRef:
+  name: placement-policy-gatekeeper-containerimagelatest
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+  - name: policy-gatekeeper-containerimagelatest
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: placement-policy-gatekeeper-containerimagelatest
+spec:
+  clusterConditions:
+    - status: "True"
+      type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      - { key: environment, operator: In, values: ["dev"] }

--- a/community/CM-Configuration-Management/policy-gatekeeper-container-livenessprobenotset.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-container-livenessprobenotset.yaml
@@ -1,0 +1,421 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: policy-gatekeeper-containerlivenessprobenotset
+  annotations:
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-gatekeeper-containerlivenessprobenotset
+        spec:
+          remediationAction: enforce
+          severity: low
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: templates.gatekeeper.sh/v1beta1
+                kind: ConstraintTemplate
+                metadata:
+                  creationTimestamp: null
+                  name: containerlivenessprobenotset
+                spec:
+                  crd:
+                    spec:
+                      names:
+                        kind: ContainerLivenessprobeNotset
+                  targets:
+                    - libs:
+                        - |
+                          package lib.konstraint
+
+                          default is_gatekeeper = false
+
+                          is_gatekeeper {
+                            has_field(input, "review")
+                            has_field(input.review, "object")
+                          }
+
+                          object = input {
+                            not is_gatekeeper
+                          }
+
+                          object = input.review.object {
+                            is_gatekeeper
+                          }
+
+                          format(msg) = gatekeeper_format {
+                            is_gatekeeper
+                            gatekeeper_format = {"msg": msg}
+                          }
+
+                          format(msg) = msg {
+                            not is_gatekeeper
+                          }
+
+                          name = object.metadata.name
+
+                          kind = object.kind
+
+                          has_field(obj, field) {
+                            obj[field]
+                          }
+
+                          missing_field(obj, field) = true {
+                            obj[field] == ""
+                          }
+
+                          missing_field(obj, field) = true {
+                            not has_field(obj, field)
+                          }
+
+                          is_service {
+                            lower(kind) == "service"
+                          }
+
+                          is_statefulset {
+                            lower(kind) == "statefulset"
+                          }
+
+                          is_daemonset {
+                            lower(kind) == "daemonset"
+                          }
+
+                          is_deployment {
+                            lower(kind) == "deployment"
+                          }
+
+                          is_pod {
+                            lower(kind) == "pod"
+                          }
+
+                          is_namespace {
+                            lower(kind) == "namespace"
+                          }
+
+                          is_workload {
+                            containers[_]
+                          }
+
+                          pod_containers(pod) = all_containers {
+                            keys = {"containers", "initContainers"}
+                            all_containers = [c | keys[k]; c = pod.spec[k][_]]
+                          }
+
+                          containers[container] {
+                            pods[pod]
+                            all_containers = pod_containers(pod)
+                            container = all_containers[_]
+                          }
+
+                          containers[container] {
+                            all_containers = pod_containers(object)
+                            container = all_containers[_]
+                          }
+
+                          container_images[image] {
+                            containers[container]
+                            image = container.image
+                          }
+
+                          container_images[image] {
+                            image = object.spec.image
+                          }
+
+                          split_image(image) = [image, "latest"] {
+                            not contains(image, ":")
+                          }
+
+                          split_image(image) = [image_name, tag] {
+                            [image_name, tag] = split(image, ":")
+                          }
+
+                          pods[pod] {
+                            is_statefulset
+                            pod = object.spec.template
+                          }
+
+                          pods[pod] {
+                            is_daemonset
+                            pod = object.spec.template
+                          }
+
+                          pods[pod] {
+                            is_deployment
+                            pod = object.spec.template
+                          }
+
+                          pods[pod] {
+                            is_pod
+                            pod = object
+                          }
+
+                          volumes[volume] {
+                            pods[pod]
+                            volume = pod.spec.volumes[_]
+                          }
+
+                          mem_multiple("E") = 1000000000000000000000 { true }
+
+                          mem_multiple("P") = 1000000000000000000 { true }
+
+                          mem_multiple("T") = 1000000000000000 { true }
+
+                          mem_multiple("G") = 1000000000000 { true }
+
+                          mem_multiple("M") = 1000000000 { true }
+
+                          mem_multiple("k") = 1000000 { true }
+
+                          mem_multiple("") = 1000 { true }
+
+                          mem_multiple("m") = 1 { true }
+
+                          mem_multiple("Ki") = 1024000 { true }
+
+                          mem_multiple("Mi") = 1048576000 { true }
+
+                          mem_multiple("Gi") = 1073741824000 { true }
+
+                          mem_multiple("Ti") = 1099511627776000 { true }
+
+                          mem_multiple("Pi") = 1125899906842624000 { true }
+
+                          mem_multiple("Ei") = 1152921504606846976000 { true }
+
+                          get_suffix(mem) = suffix {
+                            not is_string(mem)
+                            suffix := ""
+                          }
+
+                          get_suffix(mem) = suffix {
+                            is_string(mem)
+                            count(mem) > 0
+                            suffix := substring(mem, count(mem) - 1, -1)
+                            mem_multiple(suffix)
+                          }
+
+                          get_suffix(mem) = suffix {
+                            is_string(mem)
+                            count(mem) > 1
+                            suffix := substring(mem, count(mem) - 2, -1)
+                            mem_multiple(suffix)
+                          }
+
+                          get_suffix(mem) = suffix {
+                            is_string(mem)
+                            count(mem) > 1
+                            not mem_multiple(substring(mem, count(mem) - 1, -1))
+                            not mem_multiple(substring(mem, count(mem) - 2, -1))
+                            suffix := ""
+                          }
+
+                          get_suffix(mem) = suffix {
+                            is_string(mem)
+                            count(mem) == 1
+                            not mem_multiple(substring(mem, count(mem) - 1, -1))
+                            suffix := ""
+                          }
+
+                          get_suffix(mem) = suffix {
+                            is_string(mem)
+                            count(mem) == 0
+                            suffix := ""
+                          }
+
+                          canonify_mem(orig) = new {
+                            is_number(orig)
+                            new := orig * 1000
+                          }
+
+                          canonify_mem(orig) = new {
+                            not is_number(orig)
+                            suffix := get_suffix(orig)
+                            raw := replace(orig, suffix, "")
+                            re_match("^[0-9]+$", raw)
+                            new := to_number(raw) * mem_multiple(suffix)
+                          }
+
+                          canonify_storage(orig) = new {
+                            is_number(orig)
+                            new := orig
+                          }
+
+                          canonify_storage(orig) = new {
+                            not is_number(orig)
+                            suffix := get_suffix(orig)
+                            raw := replace(orig, suffix, "")
+                            re_match("^[0-9]+$", raw)
+                            new := to_number(raw) * mem_multiple(suffix)
+                          }
+
+                          canonify_cpu(orig) = new {
+                            is_number(orig)
+                            new := orig * 1000
+                          }
+
+                          canonify_cpu(orig) = new {
+                            not is_number(orig)
+                            endswith(orig, "m")
+                            new := to_number(replace(orig, "m", ""))
+                          }
+
+                          canonify_cpu(orig) = new {
+                            not is_number(orig)
+                            not endswith(orig, "m")
+                            re_match("^[0-9]+$", orig)
+                            new := to_number(orig) * 1000
+                          }
+
+                          dropped_capability(container, cap) {
+                            container.securityContext.capabilities.drop[_] == cap
+                          }
+
+                          added_capability(container, cap) {
+                            container.securityContext.capabilities.add[_] == cap
+                          }
+
+                          no_read_only_filesystem(c) {
+                            not has_field(c, "securityContext")
+                          }
+
+                          no_read_only_filesystem(c) {
+                            has_field(c, "securityContext")
+                            not has_field(c.securityContext, "readOnlyRootFilesystem")
+                          }
+
+                          priviledge_escalation_allowed(c) {
+                            not has_field(c, "securityContext")
+                          }
+
+                          priviledge_escalation_allowed(c) {
+                            has_field(c, "securityContext")
+                            has_field(c.securityContext, "allowPrivilegeEscalation")
+                          }
+                        - |-
+                          package lib.openshift
+
+                          import data.lib.konstraint
+
+                          is_deploymentconfig {
+                            lower(konstraint.object.apiVersion) == "apps.openshift.io/v1"
+                            lower(konstraint.object.kind) == "deploymentconfig"
+                          }
+
+                          is_route {
+                            lower(konstraint.object.apiVersion) == "route.openshift.io/v1"
+                            lower(konstraint.object.kind) == "route"
+                          }
+
+                          is_workload_kind {
+                            is_deploymentconfig
+                          }
+
+                          is_workload_kind {
+                            konstraint.is_statefulset
+                          }
+
+                          is_workload_kind {
+                            konstraint.is_daemonset
+                          }
+
+                          is_workload_kind {
+                            konstraint.is_deployment
+                          }
+
+                          is_all_kind {
+                            is_workload_kind
+                          }
+
+                          is_all_kind {
+                            konstraint.is_service
+                          }
+
+                          is_all_kind {
+                            is_route
+                          }
+
+                          pods[pod] {
+                            is_deploymentconfig
+                            pod = konstraint.object.spec.template
+                          }
+
+                          pods[pod] {
+                            pod = konstraint.pods[_]
+                          }
+
+                          containers[container] {
+                            pods[pod]
+                            all_containers = konstraint.pod_containers(pod)
+                            container = all_containers[_]
+                          }
+
+                          containers[container] {
+                            container = konstraint.containers[_]
+                          }
+                      rego: |-
+                        package ocp.bestpractices.container_livenessprobe_notset
+
+                        import data.lib.konstraint
+                        import data.lib.openshift
+
+                        violation[msg] {
+                          openshift.is_workload_kind
+
+                          container := openshift.containers[_]
+
+                          konstraint.missing_field(container, "livenessProbe")
+                          obj := konstraint.object
+
+                          msg := konstraint.format(sprintf("%s/%s: container '%s' has no livenessProbe. See: https://docs.openshift.com/container-platform/latest/applications/application-health.html", [obj.kind, obj.metadata.name, container.name]))
+                        }
+                      target: admission.k8s.gatekeeper.sh
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: constraints.gatekeeper.sh/v1beta1
+                kind: ContainerLivenessprobeNotset
+                metadata:
+                  name: containerlivenessprobenotset
+                spec:
+                  match:
+                    kinds:
+                      - apiGroups:
+                          - apps.openshift.io
+                          - apps
+                        kinds:
+                          - DeploymentConfig
+                          - DaemonSet
+                          - Deployment
+                          - StatefulSet
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: binding-policy-gatekeeper-containerlivenessprobenotset
+placementRef:
+  name: placement-policy-gatekeeper-containerlivenessprobenotset
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+  - name: policy-gatekeeper-containerlivenessprobenotset
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: placement-policy-gatekeeper-containerlivenessprobenotset
+spec:
+  clusterConditions:
+    - status: "True"
+      type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      - { key: environment, operator: In, values: ["dev"] }

--- a/community/CM-Configuration-Management/policy-gatekeeper-container-readinessprobenotset.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-container-readinessprobenotset.yaml
@@ -1,0 +1,421 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: policy-gatekeeper-containerreadinessprobenotset
+  annotations:
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-gatekeeper-containerreadinessprobenotset
+        spec:
+          remediationAction: enforce
+          severity: low
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: templates.gatekeeper.sh/v1beta1
+                kind: ConstraintTemplate
+                metadata:
+                  creationTimestamp: null
+                  name: containerreadinessprobenotset
+                spec:
+                  crd:
+                    spec:
+                      names:
+                        kind: ContainerReadinessprobeNotset
+                  targets:
+                    - libs:
+                        - |
+                          package lib.konstraint
+
+                          default is_gatekeeper = false
+
+                          is_gatekeeper {
+                            has_field(input, "review")
+                            has_field(input.review, "object")
+                          }
+
+                          object = input {
+                            not is_gatekeeper
+                          }
+
+                          object = input.review.object {
+                            is_gatekeeper
+                          }
+
+                          format(msg) = gatekeeper_format {
+                            is_gatekeeper
+                            gatekeeper_format = {"msg": msg}
+                          }
+
+                          format(msg) = msg {
+                            not is_gatekeeper
+                          }
+
+                          name = object.metadata.name
+
+                          kind = object.kind
+
+                          has_field(obj, field) {
+                            obj[field]
+                          }
+
+                          missing_field(obj, field) = true {
+                            obj[field] == ""
+                          }
+
+                          missing_field(obj, field) = true {
+                            not has_field(obj, field)
+                          }
+
+                          is_service {
+                            lower(kind) == "service"
+                          }
+
+                          is_statefulset {
+                            lower(kind) == "statefulset"
+                          }
+
+                          is_daemonset {
+                            lower(kind) == "daemonset"
+                          }
+
+                          is_deployment {
+                            lower(kind) == "deployment"
+                          }
+
+                          is_pod {
+                            lower(kind) == "pod"
+                          }
+
+                          is_namespace {
+                            lower(kind) == "namespace"
+                          }
+
+                          is_workload {
+                            containers[_]
+                          }
+
+                          pod_containers(pod) = all_containers {
+                            keys = {"containers", "initContainers"}
+                            all_containers = [c | keys[k]; c = pod.spec[k][_]]
+                          }
+
+                          containers[container] {
+                            pods[pod]
+                            all_containers = pod_containers(pod)
+                            container = all_containers[_]
+                          }
+
+                          containers[container] {
+                            all_containers = pod_containers(object)
+                            container = all_containers[_]
+                          }
+
+                          container_images[image] {
+                            containers[container]
+                            image = container.image
+                          }
+
+                          container_images[image] {
+                            image = object.spec.image
+                          }
+
+                          split_image(image) = [image, "latest"] {
+                            not contains(image, ":")
+                          }
+
+                          split_image(image) = [image_name, tag] {
+                            [image_name, tag] = split(image, ":")
+                          }
+
+                          pods[pod] {
+                            is_statefulset
+                            pod = object.spec.template
+                          }
+
+                          pods[pod] {
+                            is_daemonset
+                            pod = object.spec.template
+                          }
+
+                          pods[pod] {
+                            is_deployment
+                            pod = object.spec.template
+                          }
+
+                          pods[pod] {
+                            is_pod
+                            pod = object
+                          }
+
+                          volumes[volume] {
+                            pods[pod]
+                            volume = pod.spec.volumes[_]
+                          }
+
+                          mem_multiple("E") = 1000000000000000000000 { true }
+
+                          mem_multiple("P") = 1000000000000000000 { true }
+
+                          mem_multiple("T") = 1000000000000000 { true }
+
+                          mem_multiple("G") = 1000000000000 { true }
+
+                          mem_multiple("M") = 1000000000 { true }
+
+                          mem_multiple("k") = 1000000 { true }
+
+                          mem_multiple("") = 1000 { true }
+
+                          mem_multiple("m") = 1 { true }
+
+                          mem_multiple("Ki") = 1024000 { true }
+
+                          mem_multiple("Mi") = 1048576000 { true }
+
+                          mem_multiple("Gi") = 1073741824000 { true }
+
+                          mem_multiple("Ti") = 1099511627776000 { true }
+
+                          mem_multiple("Pi") = 1125899906842624000 { true }
+
+                          mem_multiple("Ei") = 1152921504606846976000 { true }
+
+                          get_suffix(mem) = suffix {
+                            not is_string(mem)
+                            suffix := ""
+                          }
+
+                          get_suffix(mem) = suffix {
+                            is_string(mem)
+                            count(mem) > 0
+                            suffix := substring(mem, count(mem) - 1, -1)
+                            mem_multiple(suffix)
+                          }
+
+                          get_suffix(mem) = suffix {
+                            is_string(mem)
+                            count(mem) > 1
+                            suffix := substring(mem, count(mem) - 2, -1)
+                            mem_multiple(suffix)
+                          }
+
+                          get_suffix(mem) = suffix {
+                            is_string(mem)
+                            count(mem) > 1
+                            not mem_multiple(substring(mem, count(mem) - 1, -1))
+                            not mem_multiple(substring(mem, count(mem) - 2, -1))
+                            suffix := ""
+                          }
+
+                          get_suffix(mem) = suffix {
+                            is_string(mem)
+                            count(mem) == 1
+                            not mem_multiple(substring(mem, count(mem) - 1, -1))
+                            suffix := ""
+                          }
+
+                          get_suffix(mem) = suffix {
+                            is_string(mem)
+                            count(mem) == 0
+                            suffix := ""
+                          }
+
+                          canonify_mem(orig) = new {
+                            is_number(orig)
+                            new := orig * 1000
+                          }
+
+                          canonify_mem(orig) = new {
+                            not is_number(orig)
+                            suffix := get_suffix(orig)
+                            raw := replace(orig, suffix, "")
+                            re_match("^[0-9]+$", raw)
+                            new := to_number(raw) * mem_multiple(suffix)
+                          }
+
+                          canonify_storage(orig) = new {
+                            is_number(orig)
+                            new := orig
+                          }
+
+                          canonify_storage(orig) = new {
+                            not is_number(orig)
+                            suffix := get_suffix(orig)
+                            raw := replace(orig, suffix, "")
+                            re_match("^[0-9]+$", raw)
+                            new := to_number(raw) * mem_multiple(suffix)
+                          }
+
+                          canonify_cpu(orig) = new {
+                            is_number(orig)
+                            new := orig * 1000
+                          }
+
+                          canonify_cpu(orig) = new {
+                            not is_number(orig)
+                            endswith(orig, "m")
+                            new := to_number(replace(orig, "m", ""))
+                          }
+
+                          canonify_cpu(orig) = new {
+                            not is_number(orig)
+                            not endswith(orig, "m")
+                            re_match("^[0-9]+$", orig)
+                            new := to_number(orig) * 1000
+                          }
+
+                          dropped_capability(container, cap) {
+                            container.securityContext.capabilities.drop[_] == cap
+                          }
+
+                          added_capability(container, cap) {
+                            container.securityContext.capabilities.add[_] == cap
+                          }
+
+                          no_read_only_filesystem(c) {
+                            not has_field(c, "securityContext")
+                          }
+
+                          no_read_only_filesystem(c) {
+                            has_field(c, "securityContext")
+                            not has_field(c.securityContext, "readOnlyRootFilesystem")
+                          }
+
+                          priviledge_escalation_allowed(c) {
+                            not has_field(c, "securityContext")
+                          }
+
+                          priviledge_escalation_allowed(c) {
+                            has_field(c, "securityContext")
+                            has_field(c.securityContext, "allowPrivilegeEscalation")
+                          }
+                        - |-
+                          package lib.openshift
+
+                          import data.lib.konstraint
+
+                          is_deploymentconfig {
+                            lower(konstraint.object.apiVersion) == "apps.openshift.io/v1"
+                            lower(konstraint.object.kind) == "deploymentconfig"
+                          }
+
+                          is_route {
+                            lower(konstraint.object.apiVersion) == "route.openshift.io/v1"
+                            lower(konstraint.object.kind) == "route"
+                          }
+
+                          is_workload_kind {
+                            is_deploymentconfig
+                          }
+
+                          is_workload_kind {
+                            konstraint.is_statefulset
+                          }
+
+                          is_workload_kind {
+                            konstraint.is_daemonset
+                          }
+
+                          is_workload_kind {
+                            konstraint.is_deployment
+                          }
+
+                          is_all_kind {
+                            is_workload_kind
+                          }
+
+                          is_all_kind {
+                            konstraint.is_service
+                          }
+
+                          is_all_kind {
+                            is_route
+                          }
+
+                          pods[pod] {
+                            is_deploymentconfig
+                            pod = konstraint.object.spec.template
+                          }
+
+                          pods[pod] {
+                            pod = konstraint.pods[_]
+                          }
+
+                          containers[container] {
+                            pods[pod]
+                            all_containers = konstraint.pod_containers(pod)
+                            container = all_containers[_]
+                          }
+
+                          containers[container] {
+                            container = konstraint.containers[_]
+                          }
+                      rego: |-
+                        package ocp.bestpractices.container_readinessprobe_notset
+
+                        import data.lib.konstraint
+                        import data.lib.openshift
+
+                        violation[msg] {
+                          openshift.is_workload_kind
+
+                          container := openshift.containers[_]
+
+                          konstraint.missing_field(container, "readinessProbe")
+                          obj := konstraint.object
+
+                          msg := konstraint.format(sprintf("%s/%s: container '%s' has no readinessProbe. See: https://docs.openshift.com/container-platform/4.4/applications/application-health.html", [obj.kind, obj.metadata.name, container.name]))
+                        }
+                      target: admission.k8s.gatekeeper.sh
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: constraints.gatekeeper.sh/v1beta1
+                kind: ContainerReadinessprobeNotset
+                metadata:
+                  name: containerreadinessprobenotset
+                spec:
+                  match:
+                    kinds:
+                      - apiGroups:
+                          - apps.openshift.io
+                          - apps
+                        kinds:
+                          - DeploymentConfig
+                          - DaemonSet
+                          - Deployment
+                          - StatefulSet
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: binding-policy-gatekeeper-containerreadinessprobenotset
+placementRef:
+  name: placement-policy-gatekeeper-containerreadinessprobenotset
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+  - name: policy-gatekeeper-containerreadinessprobenotset
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: placement-policy-gatekeeper-containerreadinessprobenotset
+spec:
+  clusterConditions:
+    - status: "True"
+      type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      - { key: environment, operator: In, values: ["dev"] }

--- a/community/README.md
+++ b/community/README.md
@@ -38,27 +38,27 @@ Policies in this folder are organized by [NIST Special Publication 800-53](https
     <td><a href="https://github.com/lumjjb/trusted-node-policy-controller">Trusted Node Policy Controller</a></td>
   </tr>
   <tr>
-    <td><a href="./CM-Configuration-Management/policy-opa-sample.yaml">OPA Sample policy</a>: Use the Open Policy Agent (OPA) Sample policy to view an example of how an OPA policy can be created. You can also view an example of adding a <i>REGO</i> script into a ConfigMap, which is evaluated by the OPA.</td>
+    <td><a href="./CM-Configuration-Management/policy-opa-sample.yaml">OPA sample policy</a>: Use the Open Policy Agent (OPA) Sample policy to view an example of how an OPA policy can be created. You can also view an example of adding a <i>REGO</i> script into a ConfigMap, which is evaluated by the OPA.</td>
     <td>See the <a href="https://github.com/ycao56/mcm-opa">OPA example repository</a>. <b>Note</b>: OPA must be installed to use the OPA ConfigMap policy.</td>
   </tr>
   <tr>
-    <td><a href="./CM-Configuration-Management/policy-gatekeeper-sample.yaml">Gatekeeper Sample policy</a>: Use the Gate Sample policy to view an example of how a gatekeeper policy can be applied to a managed cluster</td>
+    <td><a href="./CM-Configuration-Management/policy-gatekeeper-sample.yaml">Gatekeeper sample policy</a>: Use the Gatekeeper sample policy to view an example of how a gatekeeper policy can be applied to a managed cluster</td>
     <td>See the <a href="https://github.com/open-policy-agent/gatekeeper">Gatekeeper</a>. <b>Note</b>: Gatekeeper controllers must be installed to use the gatekeeper policy.</td>
   </tr>
   <tr>
-    <td><a href="./CM-Configuration-Management/policy-gatekeeper-container-image-latest.yaml">Gatekeeper Container Image Latest Tag</a>: Gatekeeper policy to enforce containers in deployable resources do not use images with the <i>latest</i> tag</td>
-    <td>See the <a href="https://github.com/open-policy-agent/gatekeeper">Gatekeeper</a>. <b>Note</b>: Gatekeeper controllers must be installed to use the gatekeeper policy.</td>
+    <td><a href="./CM-Configuration-Management/policy-gatekeeper-container-image-latest.yaml">Gatekeeper container image with the latest tag</a>: Use the Gatekeeper policy to enforce containers in deployable resources to not use images with the <i>latest</i> tag.</td>
+    <td>See the <a href="https://github.com/open-policy-agent/gatekeeper">Gatekeeper documentation</a>. <b>Note</b>: Gatekeeper controllers must be installed to use the gatekeeper policy.</td>
   </tr>
   <tr>
-    <td><a href="./CM-Configuration-Management/policy-gatekeeper-container-livenessprobenotset.yaml">Gatekeeper Liveness Probe Not Set</a>: Gatekeeper policy to enforce pods have a <a href="https://docs.openshift.com/container-platform/latest/applications/application-health.html">Liveness Probe</a></td>
-    <td>See the <a href="https://github.com/open-policy-agent/gatekeeper">Gatekeeper</a>. <b>Note</b>: Gatekeeper controllers must be installed to use the gatekeeper policy.</td>
+    <td><a href="./CM-Configuration-Management/policy-gatekeeper-container-livenessprobenotset.yaml">Gatekeeper liveness probe not set</a>: Use the Gatekeeper policy to enforce pods that have a <a href="https://docs.openshift.com/container-platform/latest/applications/application-health.html">liveness probe.</a></td>
+    <td>See the <a href="https://github.com/open-policy-agent/gatekeeper">Gatekeeper documentation</a>. <b>Note</b>: Gatekeeper controllers must be installed to use the gatekeeper policy.</td>
   </tr>
   <tr>
-    <td><a href="./CM-Configuration-Management/policy-gatekeeper-container-readinessprobenotset.yaml">Gatekeeper Readiness Probe Not Set</a>: Gatekeeper policy to enforce pods have a <a href="https://docs.openshift.com/container-platform/latest/applications/application-health.html">Readiness Probe</a></td>
-    <td>See the <a href="https://github.com/open-policy-agent/gatekeeper">Gatekeeper</a>. <b>Note</b>: Gatekeeper controllers must be installed to use the gatekeeper policy.</td>
+    <td><a href="./CM-Configuration-Management/policy-gatekeeper-container-readinessprobenotset.yaml">Gatekeeper readiness probe not set</a>: Use the Gatekeeper policy to enforce pods that have a <a href="https://docs.openshift.com/container-platform/latest/applications/application-health.html">readiness probe.</a></td>
+    <td>See the <a href="https://github.com/open-policy-agent/gatekeeper">Gatekeeper documentation</a>. <b>Note</b>: Gatekeeper controllers must be installed to use the gatekeeper policy.</td>
   </tr>
   <tr>
-    <td><a href="./CM-Configuration-Management/policy-machineconfig-chrony.yaml">MachineConfig Chrony Sample policy: </a> Use the MachineConfig Chrony policy to configure <i>/etc/chrony.conf</i> on certain machines </a>.</td> 
+    <td><a href="./CM-Configuration-Management/policy-machineconfig-chrony.yaml">MachineConfig Chrony sample policy: </a> Use the MachineConfig Chrony policy to configure <i>/etc/chrony.conf</i> on certain machines </a>.</td> 
     <td>For more information see, <a href="https://jaosorior.dev/2019/modifying-node-configurations-in-openshift-4.x/"> Modifying node configurations in OpenShift 4.x blog</a>. <b>Note</b>: The policy requires that the managed cluster is OpenShift Container Platform.</td>
     </tr>
   <tr>
@@ -66,7 +66,7 @@ Policies in this folder are organized by [NIST Special Publication 800-53](https
     <td>See the <a href="https://access.redhat.com/articles/5059881"> OpenShift Security Guide </a>. <b>Note</b>: The policy might be modified to the actual usecases </td>
     </tr>
   <tr>
-    <td><a href="./CM-Configuration-Management/policy-egress-firewall-sample.yaml">Egress-Policy-Sample:</a> With the egress firewall you can define rules (per project) to allow or deny traffic (TCP or UDP) to the external network.</td>
+    <td><a href="./CM-Configuration-Management/policy-egress-firewall-sample.yaml">Egress sample policy:</a> With the egress firewall you can define rules (per project) to allow or deny traffic (TCP or UDP) to the external network.</td>
     <td>See the <a href="https://access.redhat.com/articles/5059881"> OpenShift Security Guide.</a> Use the OpenShift Security Guide to secure your OpenShift cluster. </td>
     </tr>  
   <tr>

--- a/community/README.md
+++ b/community/README.md
@@ -46,6 +46,18 @@ Policies in this folder are organized by [NIST Special Publication 800-53](https
     <td>See the <a href="https://github.com/open-policy-agent/gatekeeper">Gatekeeper</a>. <b>Note</b>: Gatekeeper controllers must be installed to use the gatekeeper policy.</td>
   </tr>
   <tr>
+    <td><a href="./CM-Configuration-Management/policy-gatekeeper-container-image-latest.yaml">Gatekeeper Container Image Latest Tag</a>: Gatekeeper policy to enforce containers in deployable resources do not use images with the <i>latest</i> tag</td>
+    <td>See the <a href="https://github.com/open-policy-agent/gatekeeper">Gatekeeper</a>. <b>Note</b>: Gatekeeper controllers must be installed to use the gatekeeper policy.</td>
+  </tr>
+  <tr>
+    <td><a href="./CM-Configuration-Management/policy-gatekeeper-container-livenessprobenotset.yaml">Gatekeeper Liveness Probe Not Set</a>: Gatekeeper policy to enforce pods have a <a href="https://docs.openshift.com/container-platform/latest/applications/application-health.html">Liveness Probe</a></td>
+    <td>See the <a href="https://github.com/open-policy-agent/gatekeeper">Gatekeeper</a>. <b>Note</b>: Gatekeeper controllers must be installed to use the gatekeeper policy.</td>
+  </tr>
+  <tr>
+    <td><a href="./CM-Configuration-Management/policy-gatekeeper-container-readinessprobenotset.yaml">Gatekeeper Readiness Probe Not Set</a>: Gatekeeper policy to enforce pods have a <a href="https://docs.openshift.com/container-platform/latest/applications/application-health.html">Readiness Probe</a></td>
+    <td>See the <a href="https://github.com/open-policy-agent/gatekeeper">Gatekeeper</a>. <b>Note</b>: Gatekeeper controllers must be installed to use the gatekeeper policy.</td>
+  </tr>
+  <tr>
     <td><a href="./CM-Configuration-Management/policy-machineconfig-chrony.yaml">MachineConfig Chrony Sample policy: </a> Use the MachineConfig Chrony policy to configure <i>/etc/chrony.conf</i> on certain machines </a>.</td> 
     <td>For more information see, <a href="https://jaosorior.dev/2019/modifying-node-configurations-in-openshift-4.x/"> Modifying node configurations in OpenShift 4.x blog</a>. <b>Note</b>: The policy requires that the managed cluster is OpenShift Container Platform.</td>
     </tr>

--- a/community/README.md
+++ b/community/README.md
@@ -29,7 +29,7 @@ Policies in this folder are organized by [NIST Special Publication 800-53](https
     <td>N/A</td>
   </tr>
   <tr>
-    <td rowspan="12">Configuration Management</td>
+    <td rowspan="15">Configuration Management</td>
     <td><a href="./CM-Configuration-Management/policy-trusted-container.yaml">Trusted Container policy</a>: Use the trusted container policy to detect if running pods are using trusted images.</td>
     <td><a href="https://github.com/ycao56/trusted-container-policy-controller">Trusted Container Policy Controller</a></td>
   </tr>


### PR DESCRIPTION
Initial incorporation of Gatekeeper policies from the [Red Hat Community of Practice (CoP) policies repository](https://github.com/redhat-cop/rego-policies).

* Containers using the `latest` image tag
* Containers without Readiness Probes
* Containers without Liveness Probes

The CoP makes use of [Konstraint](https://github.com/plexsystems/konstraint) libraries. Improvements could be made to remove the functions that are not being used.