### PR TITLE
Add policy to install the Compliance Operator

### DIFF
--- a/community/CA-Security-Assessment-and-Authorization/policy-compliance-operator-install-upstream.yaml
+++ b/community/CA-Security-Assessment-and-Authorization/policy-compliance-operator-install-upstream.yaml
@@ -1,0 +1,132 @@
+# This policy verifies the installation of the upstream version of the
+# Compliance Operator on the managed clusters.
+#
+# If set to "enforce" it'll install the operator.
+#
+# Note that OpenShift 4.6 is required.
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: policy-comp-operator
+  annotations:
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+    policy.open-cluster-management.io/categories: CA Security Assessment and Authorization
+    policy.open-cluster-management.io/controls: CA-2 Security Assessments, CA-7 Continuous Monitoring
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: comp-operator-ns
+        spec:
+          remediationAction: inform # will be overridden by remediationAction in parent policy
+          severity: high
+          namespaceSelector:
+            exclude: ["kube-*"]
+            include: ["*"]
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Namespace
+                metadata:
+                  name: openshift-compliance
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: comp-operator-catalog-source
+        spec:
+          remediationAction: inform # will be overridden by remediationAction in parent policy
+          severity: high
+          namespaceSelector:
+            exclude: ["kube-*"]
+            include: ["*"]
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operators.coreos.com/v1alpha1
+                kind: CatalogSource
+                metadata:
+                  name: compliance-operator
+                  namespace: openshift-marketplace
+                spec:
+                  displayName: Compliance Operator Upstream
+                  publisher: github.com/openshift/compliance-operator
+                  sourceType: grpc
+                  image: quay.io/compliance-operator/compliance-operator-index:latest
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: comp-operator-operator-group
+        spec:
+          remediationAction: inform # will be overridden by remediationAction in parent policy
+          severity: high
+          namespaceSelector:
+            exclude: ["kube-*"]
+            include: ["*"]
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operators.coreos.com/v1
+                kind: OperatorGroup
+                metadata:
+                  name: compliance-operator
+                  namespace: openshift-compliance
+                spec:
+                  selector:
+                    matchLabels:
+                      policy.open-cluster-management.io/isClusterNamespace: "true"
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: comp-operator-subscription
+        spec:
+          remediationAction: inform # will be overridden by remediationAction in parent policy
+          severity: high
+          namespaceSelector:
+            exclude: ["kube-*"]
+            include: ["*"]
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operators.coreos.com/v1alpha1
+                kind: Subscription
+                metadata:
+                  name: compliance-operator-sub
+                  namespace: openshift-compliance
+                spec:
+                  channel: alpha
+                  name: compliance-operator
+                  source: compliance-operator
+                  sourceNamespace: openshift-marketplace
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: binding-policy-comp-operator
+placementRef:
+  name: placement-policy-comp-operator
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+- name: policy-comp-operator
+  kind: Policy
+  apiGroup: policy.open-cluster-management.io
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: placement-policy-comp-operator
+spec:
+  clusterConditions:
+  - status: "True"
+    type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      - {key: vendor, operator: In, values: ["OpenShift"]}

--- a/community/README.md
+++ b/community/README.md
@@ -25,8 +25,8 @@ Policies in this folder are organized by [NIST Special Publication 800-53](https
   </tr>
   <tr>
     <td>Security Assessment and Authorization</td>
-    <td>N/A</td>
-    <td>N/A</td>
+    <td><a href="./CA-Security-Assessment-and-Authorization/policy-compliance-operator-install-upstream.yaml">Install Upstream Compliance Operator policy</a>: Use the upstream compliance operator installation, <tt>policy-comp-operator</tt> policy, to enable continuous compliance monitoring for your cluster. After you install this operator, you must select what benchmark you want to comply to, and create an appropriate objects for the scans to be ran. </td>
+    <td><a href="https://github.com/openshift/compliance-operator">Compliance Operator</a></td>
   </tr>
   <tr>
     <td rowspan="15">Configuration Management</td>


### PR DESCRIPTION
This policy installs the Compliance Operator's upstream release in the
managed clusters. This is done through the OLM by installing the catalog
source pointing to the upstream release, and then installing the
operatorgroup and the subscription.

This addresses the NIST SP 800-53 controls CA-2 and CA-7.