### PR TITLE
Add policy to scan clusters with the E8 benchmark

### DIFF
--- a/community/CM-Configuration-Management/policy-compliance-operator-e8-scan.yaml
+++ b/community/CM-Configuration-Management/policy-compliance-operator-e8-scan.yaml
@@ -1,0 +1,56 @@
+# This policy assumes that the Compliance Operator is installed and running on
+# the managed clusters. It deploys a scan that will check the master and worker
+# nodes and verifies for compliance with the E8 (Essential 8) security profile.
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: policy-e8-scan
+  annotations:
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-6 Configuration Settings
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: compliance.openshift.io/v1alpha1
+        kind: ScanSettingBinding
+        metadata:
+          name: e8
+        profiles:
+        - apiGroup: compliance.openshift.io/v1alpha1
+          kind: Profile
+          name: ocp4-e8
+        - apiGroup: compliance.openshift.io/v1alpha1
+          kind: Profile
+          name: rhcos4-e8
+        settingsRef:
+          apiGroup: compliance.openshift.io/v1alpha1
+          kind: ScanSetting
+          name: default
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: binding-policy-e8-scan
+placementRef:
+  name: placement-policy-e8-scan
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+- name: policy-e8-scan
+  kind: Policy
+  apiGroup: policy.open-cluster-management.io
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: placement-policy-e8-scan
+spec:
+  clusterConditions:
+  - status: "True"
+    type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      - {key: vendor, operator: In, values: ["OpenShift"]}

--- a/community/README.md
+++ b/community/README.md
@@ -29,7 +29,7 @@ Policies in this folder are organized by [NIST Special Publication 800-53](https
     <td>N/A</td>
   </tr>
   <tr>
-    <td rowspan="15">Configuration Management</td>
+    <td rowspan="16">Configuration Management</td>
     <td><a href="./CM-Configuration-Management/policy-trusted-container.yaml">Trusted Container policy</a>: Use the trusted container policy to detect if running pods are using trusted images.</td>
     <td><a href="https://github.com/ycao56/trusted-container-policy-controller">Trusted Container Policy Controller</a></td>
   </tr>
@@ -89,6 +89,10 @@ Policies in this folder are organized by [NIST Special Publication 800-53](https
     <td><a href="./CM-Configuration-Management/policy-deployment-sample.yaml">Example of creating a deployment object:</a> This example generates 5 replicas of `nginx-pods`. </td>
     <td>See the <a href="https://kubernetes.io/docs/concepts/workloads/controllers/deployment/"> Kubernetes Documentation </a> to learn more about Deployments.</td>
     </tr>
+  <tr>  
+    <td><a href="./CM-Configuration-Management/policy-compliance-operator-e8-scan.yaml">Scan your cluster with the E8 (Essential 8) security profile:</a> This example creates a ScanSettingBinding that the ComplianceOperator uses to scan the cluster for compliance with the E8 benchmark. </td>
+    <td>See the <a href="https://github.com/openshift/compliance-operator"> Compliance Operator repo </a> to learn more about the operator.</td>
+  </tr>
   <tr>
     <td>Contingency Planning</td>
     <td>N/A</td>


### PR DESCRIPTION
This will create a policy that creates a ScanSetting binding object on
the managed cluster. This will be taken into use by the Compliance
Operator to scan the clusters for compliance with the E8 benchmark.