### PR TITLE
add additional checks for compliace operator scans

### DIFF
--- a/community/CA-Security-Assessment-and-Authorization/policy-compliance-operator-install-upstream.yaml
+++ b/community/CA-Security-Assessment-and-Authorization/policy-compliance-operator-install-upstream.yaml
@@ -69,9 +69,8 @@ spec:
                   name: compliance-operator
                   namespace: openshift-compliance
                 spec:
-                  selector:
-                    matchLabels:
-                      policy.open-cluster-management.io/isClusterNamespace: "true"
+                  targetNamespaces:
+                    - openshift-compliance
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy

--- a/community/CM-Configuration-Management/policy-compliance-operator-e8-scan.yaml
+++ b/community/CM-Configuration-Management/policy-compliance-operator-e8-scan.yaml
@@ -49,7 +49,7 @@ spec:
           remediationAction: inform
           severity: high
           object-templates:
-            - complianceType: musthave # this template checks if scan is complete by checking the status field
+            - complianceType: musthave # this template checks if scan has completed by checking the status field
               objectDefinition:
                 apiVersion: compliance.openshift.io/v1alpha1
                 kind: ComplianceSuite

--- a/community/CM-Configuration-Management/policy-compliance-operator-e8-scan.yaml
+++ b/community/CM-Configuration-Management/policy-compliance-operator-e8-scan.yaml
@@ -62,7 +62,7 @@ spec:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
         metadata:
-          name: compliance-remeidation-e8
+          name: compliance-remediation-e8
         spec:
           remediationAction: inform
           severity: low

--- a/community/CM-Configuration-Management/policy-compliance-operator-e8-scan.yaml
+++ b/community/CM-Configuration-Management/policy-compliance-operator-e8-scan.yaml
@@ -22,7 +22,7 @@ spec:
           remediationAction: inform
           severity: high
           object-templates:
-            - complianceType: musthave # this template creates ScanSettingBinding
+            - complianceType: musthave # this template creates ScanSettingBinding e8
               objectDefinition:
                 apiVersion: compliance.openshift.io/v1alpha1
                 kind: ScanSettingBinding

--- a/community/CM-Configuration-Management/policy-compliance-operator-e8-scan.yaml
+++ b/community/CM-Configuration-Management/policy-compliance-operator-e8-scan.yaml
@@ -20,7 +20,7 @@ spec:
           name: compliance-e8-scan
         spec:
           remediationAction: inform
-          severity: low
+          severity: high
           object-templates:
             - complianceType: musthave # this template creates ScanSettingBinding
               objectDefinition:
@@ -47,7 +47,7 @@ spec:
           name: compliance-suite-e8
         spec:
           remediationAction: inform
-          severity: low
+          severity: high
           object-templates:
             - complianceType: musthave # this template checks if scan is complete by checking the status field
               objectDefinition:
@@ -65,7 +65,7 @@ spec:
           name: compliance-remediation-e8
         spec:
           remediationAction: inform
-          severity: low
+          severity: high
           object-templates:
             - complianceType: mustnothave # this template checks for ComplianceRemediation CRs for scan suite: e8
               objectDefinition:

--- a/community/CM-Configuration-Management/policy-compliance-operator-e8-scan.yaml
+++ b/community/CM-Configuration-Management/policy-compliance-operator-e8-scan.yaml
@@ -10,7 +10,7 @@ metadata:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-6 Configuration Settings
 spec:
-  remediationAction: enforce
+  remediationAction: inform
   disabled: false
   policy-templates:
     - objectDefinition:

--- a/community/CM-Configuration-Management/policy-compliance-operator-e8-scan.yaml
+++ b/community/CM-Configuration-Management/policy-compliance-operator-e8-scan.yaml
@@ -49,7 +49,7 @@ spec:
           remediationAction: inform
           severity: low
           object-templates:
-            - complianceType: musthave # this template checks if scan is complete
+            - complianceType: musthave # this template checks if scan is complete by checking the status field
               objectDefinition:
                 apiVersion: compliance.openshift.io/v1alpha1
                 kind: ComplianceSuite
@@ -67,7 +67,7 @@ spec:
           remediationAction: inform
           severity: low
           object-templates:
-            - complianceType: mustnothave # this template checks for ComplianceRemediation for scan suite: e8
+            - complianceType: mustnothave # this template checks for ComplianceRemediation CRs for scan suite: e8
               objectDefinition:
                 apiVersion: compliance.openshift.io/v1alpha1
                 kind: ComplianceRemediation

--- a/community/CM-Configuration-Management/policy-compliance-operator-e8-scan.yaml
+++ b/community/CM-Configuration-Management/policy-compliance-operator-e8-scan.yaml
@@ -22,7 +22,7 @@ spec:
           remediationAction: inform
           severity: high
           object-templates:
-            - complianceType: musthave # this template creates ScanSettingBinding e8
+            - complianceType: musthave # this template creates ScanSettingBinding:e8
               objectDefinition:
                 apiVersion: compliance.openshift.io/v1alpha1
                 kind: ScanSettingBinding
@@ -62,18 +62,19 @@ spec:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
         metadata:
-          name: compliance-remediation-e8
+          name: compliance-suite-e8-results
         spec:
           remediationAction: inform
           severity: high
           object-templates:
-            - complianceType: mustnothave # this template checks for ComplianceRemediation CRs for scan suite: e8
+            - complianceType: mustnothave # this template reports the results for scan suite: e8 by looking at ComplianceCheckResult CRs
               objectDefinition:
                 apiVersion: compliance.openshift.io/v1alpha1
-                kind: ComplianceRemediation
+                kind: ComplianceCheckResult
                 metadata:
                   namespace: openshift-compliance
                   labels:
+                    compliance.openshift.io/check-status: FAIL
                     compliance.openshift.io/suite: e8
 ---
 apiVersion: policy.open-cluster-management.io/v1

--- a/community/CM-Configuration-Management/policy-compliance-operator-e8-scan.yaml
+++ b/community/CM-Configuration-Management/policy-compliance-operator-e8-scan.yaml
@@ -10,25 +10,71 @@ metadata:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-6 Configuration Settings
 spec:
-  remediationAction: inform
+  remediationAction: enforce
   disabled: false
   policy-templates:
     - objectDefinition:
-        apiVersion: compliance.openshift.io/v1alpha1
-        kind: ScanSettingBinding
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
         metadata:
-          name: e8
-        profiles:
-        - apiGroup: compliance.openshift.io/v1alpha1
-          kind: Profile
-          name: ocp4-e8
-        - apiGroup: compliance.openshift.io/v1alpha1
-          kind: Profile
-          name: rhcos4-e8
-        settingsRef:
-          apiGroup: compliance.openshift.io/v1alpha1
-          kind: ScanSetting
-          name: default
+          name: compliance-e8-scan
+        spec:
+          remediationAction: inform
+          severity: low
+          object-templates:
+            - complianceType: musthave # this template creates ScanSettingBinding
+              objectDefinition:
+                apiVersion: compliance.openshift.io/v1alpha1
+                kind: ScanSettingBinding
+                metadata:
+                  name: e8 
+                  namespace: openshift-compliance
+                profiles:
+                - apiGroup: compliance.openshift.io/v1alpha1
+                  kind: Profile
+                  name: ocp4-e8
+                - apiGroup: compliance.openshift.io/v1alpha1
+                  kind: Profile
+                  name: rhcos4-e8
+                settingsRef:
+                  apiGroup: compliance.openshift.io/v1alpha1
+                  kind: ScanSetting
+                  name: default
+    - objectDefinition: 
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: compliance-suite-e8
+        spec:
+          remediationAction: inform
+          severity: low
+          object-templates:
+            - complianceType: musthave # this template checks if scan is complete
+              objectDefinition:
+                apiVersion: compliance.openshift.io/v1alpha1
+                kind: ComplianceSuite
+                metadata:
+                  name: e8
+                  namespace: openshift-compliance
+                status:
+                  phase: DONE
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: compliance-remeidation-e8
+        spec:
+          remediationAction: inform
+          severity: low
+          object-templates:
+            - complianceType: mustnothave # this template checks for ComplianceRemediation for scan suite: e8
+              objectDefinition:
+                apiVersion: compliance.openshift.io/v1alpha1
+                kind: ComplianceRemediation
+                metadata:
+                  namespace: openshift-compliance
+                  labels:
+                    compliance.openshift.io/suite: e8
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/stable/CA-Security-Assessment-and-Authorization/policy-compliance-operator-install.yaml
+++ b/stable/CA-Security-Assessment-and-Authorization/policy-compliance-operator-install.yaml
@@ -48,9 +48,8 @@ spec:
                   name: compliance-operator
                   namespace: openshift-compliance
                 spec:
-                  selector:
-                    matchLabels:
-                      policy.open-cluster-management.io/isClusterNamespace: "true"
+                  targetNamespaces:
+                    - openshift-compliance
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy


### PR DESCRIPTION
With this PR we can achieve the goal to further integrate with compliance operator to report remediation. However, we lost the precise event message from scansettingbindings as now we use configuration policy to create it.

1. update compliance operator to watch for openshift-compliance ns
2. use configuration policy to create scansettingbindings
3. add additional policy templates to 
   1. check if the scan is complete
   2. if there is any failed result

<img width="1650" alt="image" src="https://user-images.githubusercontent.com/16092291/102239372-ca17c680-3ec4-11eb-9568-ea3d1d9fa965.png">

<img width="1638" alt="image" src="https://user-images.githubusercontent.com/16092291/102239406-d439c500-3ec4-11eb-9cc7-6bcde081f658.png">



