### PR TITLE
fix label in chrony policy

### DIFF
--- a/community/CM-Configuration-Management/policy-machineconfig-chrony.yaml
+++ b/community/CM-Configuration-Management/policy-machineconfig-chrony.yaml
@@ -27,9 +27,9 @@ spec:
                 kind: MachineConfig
                 metadata:
                   name: 50-worker-chrony
-                spec:
                   labels:
                     machineconfiguration.openshift.io/role: worker
+                spec:
                   config:
                     ignition:
                       version: 2.2.0


### PR DESCRIPTION
Label in machineconfig for chrony policy needs to be moved under metadata.