### PR TITLE
Undeploy script

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -24,7 +24,7 @@ Usage:
 
 # `remove.sh`
 
-## Remove resources from Red Hat Advanced Cluster Management created via `deploy.sh`
+## Find and remove resources from Red Hat Advanced Cluster Management created via `deploy.sh`
 ```
 Prerequisites:
  - oc CLI should be pointing to the cluster to remove from

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,11 +1,17 @@
-# `deploy.sh`
+# Deploy policies to Red Hat Advanced Cluster Management 
 
-## Deploy policies to Red Hat Advanced Cluster Management via GitOps
+Deploy policies to Red Hat Advanced Cluster Management with the `deploy.sh` script.
+
+## Deploying policies with GitOps
+
+You must meet the following prerequisites before you deploy policies with the script:
+
+- `oc` or `kubectl` CLI must point to the cluster in which you want to deploy. 
+- The cluster that you select to deploy to must have an existing cluster namespace.
+
+View the following example on how to use the script:
+ 
 ```
-Prerequisites:
- - oc or kubectl CLI should be pointing to the cluster to deploy to
- - The desired cluster namespace should already exist
-
 Usage:
   ./deploy.sh [-u <url>] [-b <branch>] [-p <path>] [-n <namespace>] [-a|--name <resource-name]
 
@@ -22,15 +28,16 @@ Usage:
                                 (Default name: "demo-stable-policies")
 ```
 
-# `remove.sh`
+## Remove resources 
 
-## Find and remove resources from Red Hat Advanced Cluster Management created via `deploy.sh`
+Find and remove resources that are created with the `deploy.sh` script from Red Hat Advanced Cluster Management. You must meet the following prerequisites before you remove resources with the `remove.sh` script:
+
+- `oc` or `kubectl` CLI must point to the cluster in which you want to remove resources.
+- Verify that Channel and Subscription were deployed using the `deploy.sh` script. Channel and Subscription must match the pattern for `<prefix>-chan` and `<prefix>-sub)`.
+
+View the following example on how to use the script:
+
 ```
-Prerequisites:
- - oc or kubectl CLI should be pointing to the cluster to remove from
- - Channel and Subscription should have been deployed using the deploy.sh script
-   (or match the pattern <prefix>-chan and <prefix>-sub)
-
 Usage:
   ./remove.sh [-n <namespace>] [-a|--name <resource-name>]
 
@@ -38,3 +45,4 @@ Usage:
   -n|--namespace <namespace>  Namespace on the cluster that resources are located
   -a|--name <resource-name>   Prefix for the Channel and Subscription resources
 ```
+

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -24,7 +24,7 @@ Usage:
 
 # `remove.sh`
 
-## Remove resources from Red Hat Advanced Cluster Management created via deploy.sh
+## Remove resources from Red Hat Advanced Cluster Management created via `deploy.sh`
 ```
 Prerequisites:
  - oc CLI should be pointing to the cluster to remove from

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -35,7 +35,7 @@ Find and remove resources that are created with the `deploy.sh` script from Red 
 - Your `oc` or `kubectl` CLI must be configured and able to access to the resources that you want to remove from the cluster.
 - Verify that Channel and Subscription were deployed using the `deploy.sh` script. Channel and Subscription must match the pattern `<prefix>-chan` and `<prefix>-sub` respectively.
 
-View the following guidance on how to use the script (all parameters are optional--script will query the cluster for parameters not provided):
+View the following guidance on how to use the script (all parameters are optional--the script will query the cluster to get options for parameters not provided):
 
 ```
 Usage:

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -3,7 +3,7 @@
 ## Deploy policies to Red Hat Advanced Cluster Management via GitOps
 ```
 Prerequisites:
- - oc CLI should be pointing to the cluster to deploy to
+ - oc or kubectl CLI should be pointing to the cluster to deploy to
  - The desired cluster namespace should already exist
 
 Usage:
@@ -27,7 +27,7 @@ Usage:
 ## Find and remove resources from Red Hat Advanced Cluster Management created via `deploy.sh`
 ```
 Prerequisites:
- - oc CLI should be pointing to the cluster to remove from
+ - oc or kubectl CLI should be pointing to the cluster to remove from
  - Channel and Subscription should have been deployed using the deploy.sh script
    (or match the pattern <prefix>-chan and <prefix>-sub)
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -6,10 +6,10 @@ Deploy policies to Red Hat Advanced Cluster Management with the `deploy.sh` scri
 
 You must meet the following prerequisites before you deploy policies with the script:
 
-- Your `oc` or `kubectl` CLI must be configured and able to access the cluster that you want to deploy. 
-- You must have an existing cluster namespace  for the cluster that you select to deploy.
+- Your `oc` or `kubectl` CLI must be configured and able to access the cluster to which you want to deploy. 
+- You must have an existing cluster namespace on the cluster to which you select to deploy.
 
-View the following example on how to use the script:
+View the following guidance on how to use the script (all parameters are optional--any parameters not provided will use the defaults specified):
  
 ```
 Usage:
@@ -33,9 +33,9 @@ Usage:
 Find and remove resources that are created with the `deploy.sh` script from Red Hat Advanced Cluster Management. You must meet the following prerequisites before you remove resources with the `remove.sh` script:
 
 - Your `oc` or `kubectl` CLI must be configured and able to access to the resources that you want to remove from the cluster.
-- Verify that Channel and Subscription were deployed using the `deploy.sh` script. Channel and Subscription must match the pattern for `<prefix>-chan` and `<prefix>-sub)`.
+- Verify that Channel and Subscription were deployed using the `deploy.sh` script. Channel and Subscription must match the pattern `<prefix>-chan` and `<prefix>-sub` respectively.
 
-View the following example on how to use the script:
+View the following guidance on how to use the script (all parameters are optional--script will query the cluster for parameters not provided):
 
 ```
 Usage:

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -6,8 +6,8 @@ Deploy policies to Red Hat Advanced Cluster Management with the `deploy.sh` scri
 
 You must meet the following prerequisites before you deploy policies with the script:
 
-- `oc` or `kubectl` CLI must point to the cluster in which you want to deploy. 
-- The cluster that you select to deploy to must have an existing cluster namespace.
+- Your `oc` or `kubectl` CLI must be configured and able to access the cluster that you want to deploy. 
+- You must have an existing cluster namespace  for the cluster that you select to deploy.
 
 View the following example on how to use the script:
  
@@ -32,7 +32,7 @@ Usage:
 
 Find and remove resources that are created with the `deploy.sh` script from Red Hat Advanced Cluster Management. You must meet the following prerequisites before you remove resources with the `remove.sh` script:
 
-- `oc` or `kubectl` CLI must point to the cluster in which you want to remove resources.
+- Your `oc` or `kubectl` CLI must be configured and able to access to the resources that you want to remove from the cluster.
 - Verify that Channel and Subscription were deployed using the `deploy.sh` script. Channel and Subscription must match the pattern for `<prefix>-chan` and `<prefix>-sub)`.
 
 View the following example on how to use the script:

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -3,7 +3,7 @@
 ## Deploy policies to Red Hat Advanced Cluster Management via GitOps
 ```
 Prerequisites:
- - oc or kubectl CLI should be pointing to the cluster to deploy to
+ - oc CLI should be pointing to the cluster to deploy to
  - The desired cluster namespace should already exist
 
 Usage:

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,4 +1,6 @@
-# Deploy policies to Red Hat Advanced Cluster Management via GitOps
+# `deploy.sh`
+
+## Deploy policies to Red Hat Advanced Cluster Management via GitOps
 ```
 Prerequisites:
  - oc or kubectl CLI should be pointing to the cluster to deploy to
@@ -18,4 +20,21 @@ Usage:
                                 (Default namespace: "policies")
   -a|--name <resource-name>   Prefix for the Channel and Subscription resources
                                 (Default name: "demo-stable-policies")
+```
+
+# `remove.sh`
+
+## Remove resources from Red Hat Advanced Cluster Management created via deploy.sh
+```
+Prerequisites:
+ - oc CLI should be pointing to the cluster to remove from
+ - Channel and Subscription should have been deployed using the deploy.sh script
+   (or match the pattern <prefix>-chan and <prefix>-sub)
+
+Usage:
+  ./remove.sh [-n <namespace>] [-a|--name <resource-name>]
+
+  -h|--help                   Display this menu
+  -n|--namespace <namespace>  Namespace on the cluster that resources are located
+  -a|--name <resource-name>   Prefix for the Channel and Subscription resources
 ```

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -8,7 +8,7 @@ help () {
   echo "## Deploy policies to Red Hat Advanced Cluster Management via GitOps"
   echo '```'
   echo "Prerequisites:"
-  echo " - oc CLI should be pointing to the cluster to deploy to"
+  echo " - oc or kubectl CLI should be pointing to the cluster to deploy to"
   echo " - The desired cluster namespace should already exist"
   echo ""
   echo "Usage:"
@@ -73,7 +73,7 @@ set -- "${POSITIONAL[@]}" # restore positional parameters
 # Display configuration and set default values if needed
 echo "Deploying policies using the following configuration:"
 echo "====================================================="
-echo "oc config:          $(oc config get-contexts | awk '/^\052/ {print $4"/"$3}')"
+echo "kubectl config:     $(kubectl config get-contexts | awk '/^\052/ {print $4"/"$3}')"
 echo "Cluster Namespace:  ${NAMESPACE:=policies}"
 echo "Resource Prefix:    ${NAME:=demo-stable-policies}"
 echo "Git URL:            ${GH_URL:=https://github.com/open-cluster-management/policy-collection.git}"
@@ -111,8 +111,8 @@ KUST_CFG=$(cat "kustomization_template.yaml" |
 echo "$KUST_CFG" > kustomization.yaml
 
 # Deploy the resources to the cluster
-oc kustomize . > resources.yaml
-oc apply -f resources.yaml
+kubectl kustomize . > resources.yaml
+kubectl apply -f resources.yaml
 
 # Remove artifacts
 rm channel_patch.json

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -8,18 +8,18 @@ help () {
   echo "# Deploy policies to Red Hat Advanced Cluster Management via GitOps"
   echo '```'
   echo "Prerequisites:"
-  echo " - oc or kubectl CLI should be pointing to the cluster to deploy to"
+  echo " - oc CLI should be pointing to the cluster to deploy to"
   echo " - The desired cluster namespace should already exist"
   echo ""
   echo "Usage:"
-  echo "  ./deploy.sh [-u <url>] [-b <branch>] [-p <path>] [-n <namespace>] [-a|--name <resource-name]"
+  echo "  ./deploy.sh [-u <url>] [-b <branch>] [-p <path/to/dir>] [-n <namespace>] [-a|--name <resource-name>]"
   echo ""
   echo "  -h|--help                   Display this menu"
   echo "  -u|--url <url>              URL to the Git repository"
   echo '                                (Default URL: "https://github.com/open-cluster-management/policy-collection.git")'
   echo "  -b|--branch <branch>        Branch of the Git repository to point to"
   echo '                                (Default branch: "master")'
-  echo "  -p|--path <path>            Path to the desired subdirectory of the Git repository"
+  echo "  -p|--path <path/to/dir>     Path to the desired subdirectory of the Git repository"
   echo "                                (Default path: stable)"
   echo "  -n|--namespace <namespace>  Namespace on the cluster to deploy policies to (must exist already)"
   echo '                                (Default namespace: "policies")'
@@ -73,7 +73,7 @@ set -- "${POSITIONAL[@]}" # restore positional parameters
 # Display configuration and set default values if needed
 echo "Deploying policies using the following configuration:"
 echo "====================================================="
-echo "kubectl config:     $(kubectl config get-contexts | awk '/^\052/ {print $4"/"$3}')"
+echo "oc config:     $(oc config get-contexts | awk '/^\052/ {print $4"/"$3}')"
 echo "Cluster Namespace:  ${NAMESPACE:=policies}"
 echo "Resource Prefix:    ${NAME:=demo-stable-policies}"
 echo "Git URL:            ${GH_URL:=https://github.com/open-cluster-management/policy-collection.git}"
@@ -111,8 +111,8 @@ KUST_CFG=$(cat "kustomization_template.yaml" |
 echo "$KUST_CFG" > kustomization.yaml
 
 # Deploy the resources to the cluster
-kubectl kustomize . > resources.yaml
-kubectl apply -f resources.yaml
+oc kustomize . > resources.yaml
+oc apply -f resources.yaml
 
 # Remove artifacts
 rm channel_patch.json

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -73,7 +73,7 @@ set -- "${POSITIONAL[@]}" # restore positional parameters
 # Display configuration and set default values if needed
 echo "Deploying policies using the following configuration:"
 echo "====================================================="
-echo "oc config:     $(oc config get-contexts | awk '/^\052/ {print $4"/"$3}')"
+echo "oc config:          $(oc config get-contexts | awk '/^\052/ {print $4"/"$3}')"
 echo "Cluster Namespace:  ${NAMESPACE:=policies}"
 echo "Resource Prefix:    ${NAME:=demo-stable-policies}"
 echo "Git URL:            ${GH_URL:=https://github.com/open-cluster-management/policy-collection.git}"

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -5,10 +5,10 @@ set -o pipefail
 
 # Display help information
 help () {
-  echo "## Deploy policies to Red Hat Advanced Cluster Management via GitOps"
-  echo '```'
+  echo "Deploy policies to Red Hat Advanced Cluster Management via GitOps"
+  echo ""
   echo "Prerequisites:"
-  echo " - oc or kubectl CLI should be pointing to the cluster to deploy to"
+  echo " - oc or kubectl CLI must be pointing to the cluster to which to deploy policies"
   echo " - The desired cluster namespace should already exist"
   echo ""
   echo "Usage:"
@@ -25,7 +25,7 @@ help () {
   echo '                                (Default namespace: "policies")'
   echo "  -a|--name <resource-name>   Prefix for the Channel and Subscription resources"
   echo '                                (Default name: "demo-stable-policies")'
-  echo '```'
+  echo ""
 }
 
 # Parse arguments

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -5,7 +5,7 @@ set -o pipefail
 
 # Display help information
 help () {
-  echo "# Deploy policies to Red Hat Advanced Cluster Management via GitOps"
+  echo "## Deploy policies to Red Hat Advanced Cluster Management via GitOps"
   echo '```'
   echo "Prerequisites:"
   echo " - oc CLI should be pointing to the cluster to deploy to"

--- a/deploy/remove.sh
+++ b/deploy/remove.sh
@@ -2,7 +2,7 @@
 
 # Display help information
 help () {
-  echo "## Remove resources from Red Hat Advanced Cluster Management created via deploy.sh"
+  echo "## Find and remove resources from Red Hat Advanced Cluster Management created via `deploy.sh`"
   echo '```'
   echo "Prerequisites:"
   echo " - oc CLI should be pointing to the cluster to remove from"

--- a/deploy/remove.sh
+++ b/deploy/remove.sh
@@ -60,7 +60,7 @@ SEARCH_ALL="(Search-all-available-namespaces)"
 
 if [ -z "${NAMESPACE}" ]; then
   # Check for `oc` CLI--if it exists, we can use it to iterate over available namespaces (AKA projects)
-  if [ which oc &>/dev/null ]; then
+  if which oc &>/dev/null; then
     PS3='Enter the namespace of the resources to remove (Option 1 searches all namespaces): '
     options=($(echo ${SEARCH_ALL}))
     namespaces=($(oc get projects --no-headers -o custom-columns=NAME:.metadata.name))

--- a/deploy/remove.sh
+++ b/deploy/remove.sh
@@ -2,7 +2,7 @@
 
 # Display help information
 help () {
-  echo "# Remove resources from Red Hat Advanced Cluster Management created via deploy.sh"
+  echo "## Remove resources from Red Hat Advanced Cluster Management created via deploy.sh"
   echo '```'
   echo "Prerequisites:"
   echo " - oc CLI should be pointing to the cluster to remove from"

--- a/deploy/remove.sh
+++ b/deploy/remove.sh
@@ -5,10 +5,10 @@ set -o pipefail
 
 # Display help information
 help () {
-  echo "## Find and remove resources from Red Hat Advanced Cluster Management created via `deploy.sh`"
-  echo '```'
+  echo "Find and remove resources from Red Hat Advanced Cluster Management created via deploy.sh"
+  echo ""
   echo "Prerequisites:"
-  echo " - oc or kubectl CLI should be pointing to the cluster to remove from"
+  echo " - oc or kubectl CLI should be pointing to the cluster from which to remove resources"
   echo " - Channel and Subscription should have been deployed using the deploy.sh script"
   echo "   (or match the pattern <prefix>-chan and <prefix>-sub)"
   echo ""
@@ -18,7 +18,7 @@ help () {
   echo "  -h|--help                   Display this menu"
   echo "  -n|--namespace <namespace>  Namespace on the cluster that resources are located"
   echo "  -a|--name <resource-name>   Prefix for the Channel and Subscription resources"
-  echo '```'
+  echo ""
 }
 
 # Parse through resources to find matching Subscription and Channel
@@ -83,6 +83,9 @@ fi
 
 # Print parameters to use for finding resources
 echo "====="
+echo "Searching for resources using the following configuration:"
+echo "----------------------------------------------------------"
+echo "kubectl config:  $(kubectl config get-contexts | awk '/^\052/ {print $4"/"$3}')"
 echo "Using namespace: ${NAMESPACE}"
 if [ -n "${NAME}" ]; then
   echo "Using prefix:    ${NAME}"

--- a/deploy/remove.sh
+++ b/deploy/remove.sh
@@ -1,0 +1,133 @@
+#! /bin/bash
+
+# Display help information
+help () {
+  echo "# Remove resources from Red Hat Advanced Cluster Management created via deploy.sh"
+  echo '```'
+  echo "Prerequisites:"
+  echo " - oc CLI should be pointing to the cluster to remove from"
+  echo " - Channel and Subscription should have been deployed using the deploy.sh script"
+  echo "   (or match the pattern <prefix>-chan and <prefix>-sub)"
+  echo ""
+  echo "Usage:"
+  echo "  ./remove.sh [-n <namespace>] [-a|--name <resource-name>]"
+  echo ""
+  echo "  -h|--help                   Display this menu"
+  echo "  -n|--namespace <namespace>  Namespace on the cluster that resources are located"
+  echo "  -a|--name <resource-name>   Prefix for the Channel and Subscription resources"
+  echo '```'
+}
+
+# Parse through resources to find matching Subscription and Channel
+collectResources () {
+  subprefix=($(oc -n ${ns} get appsub --no-headers -o custom-columns=NAME:.metadata.name | awk '/'${NAME}'-sub$/ {print "'${ns}'/"$1}' | sed "s/-sub\$//"))
+  chanprefix=($(oc -n ${ns} get channels --no-headers -o custom-columns=NAME:.metadata.name | awk '/'${NAME}'-chan$/ {print "'${ns}'/"$1}' | sed "s/-chan\$//"))
+  matchprefix=("${matchprefix[@]}" $(comm -1 -2 <(printf '%s\n' ${subprefix[@]}) <(printf '%s\n' ${chanprefix[@]})))
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+        key="$1"
+        case $key in
+            -h|--help)
+            help
+            exit 0
+            ;;
+            -a|--name)
+            shift
+            NAME=${1}
+            shift
+            ;;
+            -n|--namespace)
+            shift
+            NAMESPACE=${1}
+            shift
+            ;;
+            *)    # default
+            echo "Invalid input: ${1}"
+            exit 1
+            shift
+            ;;
+        esac
+done
+set -- "${POSITIONAL[@]}" # restore positional parameters
+
+# Determine namespace (or ask if user wants to search all namespaces)
+SEARCH_ALL="(Search-all-available-namespaces)"
+
+if [ -z "${NAMESPACE}" ]; then
+  PS3='Enter the namespace of the resources to remove (Option 1 searches all namespaces): '
+  options=($(echo ${SEARCH_ALL}))
+  namespaces=($(oc get projects --no-headers -o custom-columns=NAME:.metadata.name))
+  options=("${options[@]}" "${namespaces[@]}")
+  echo 'NAMESPACES:'
+  select opt in "${options[@]}"; do
+      if [[ ! -z $opt ]]; then
+          NAMESPACE=${opt}
+          break
+      else
+          echo "Invalid selection"
+      fi
+  done
+fi
+
+echo "====="
+echo "Using namespace: ${NAMESPACE}"
+if [ -n "${NAME}" ]; then
+  echo "Using prefix: ${NAME}"
+fi
+echo "====="
+
+# Find matching Subscriptions and Channels with '-sub' and '-chan' suffix
+# See if user wants to check all namespaces
+if [[ "${NAMESPACE}" == "${SEARCH_ALL}" ]]; then
+  # Determine whether user has clusterwide access
+  if oc get appsub --all-namespaces &>/dev/null && oc get channels --all-namespaces &>/dev/null; then
+    subprefix=$(oc get appsub --all-namespaces --no-headers -o custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name 2>/dev/null | awk '/'${NAME}'-sub$/ {print $1"/"$2}' | sed "s/-sub\$//")
+    chanprefix=$(oc get channels --all-namespaces --no-headers -o custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name 2>/dev/null | awk '/'${NAME}'-chan$/  {print $1"/"$2}' | sed "s/-chan\$//")
+    matchprefix=($(comm -1 -2 <(printf '%s\n' ${subprefix[@]}) <(printf '%s\n' ${chanprefix[@]})))
+  else
+    # No clusterwide access--iterate through each namespace individually
+    for ns in "${namespaces[@]}"; do
+      echo "Searching namespace: ${ns}..."
+      collectResources
+    done
+  fi
+else
+  # Check specific namespace
+  ns=${NAMESPACE}
+  collectResources
+fi
+
+# Check for matches and have user choose match to remove
+if [ "${#matchprefix[@]}" -ne 0 ]; then
+  PS3='Enter the resources to remove from the list of namespace/prefix pairs: '
+  echo 'NAMESPACE / RESOURCE-PREFIX:'
+  select opt in "${matchprefix[@]}"; do
+      if [[ ! -z $opt ]]; then
+          RESOURCE=${opt}
+          break
+      else
+          echo "Invalid selection"
+      fi
+  done
+  echo "====="
+
+  # Parse matches and double check that Subscription still points to Channel
+  NAMESPACE=$(echo "${opt}" | awk -F/ '{print $1}')
+  PREFIX=$(echo "${opt}" | awk -F/ '{print $2}')
+  CHANREF=$(oc get appsub -n ${NAMESPACE} ${PREFIX}-sub -o jsonpath='{.spec.channel}')
+  if [[ "${opt}-chan" != "${CHANREF}" ]]; then
+    echo 'WARNING: The Subscription "'${PREFIX}'-sub" points to an unexpected Channel, "'${CHANREF}'".'
+    echo "Please verify this resource pair and then you can use these commands if you would like to proceed with removing them:"
+    echo "oc delete appsub -n ${NAMESPACE} ${PREFIX}-sub"
+    echo "oc delete channels -n ${NAMESPACE} ${PREFIX}-chan"
+    exit 1
+  fi
+
+  # Delete Subscription and Channel resources
+  oc delete appsub -n ${NAMESPACE} ${PREFIX}-sub
+  oc delete channels -n ${NAMESPACE} ${PREFIX}-chan
+else
+  echo "No deploy.sh Subscription and Channel resource pairs found."
+fi


### PR DESCRIPTION
This undeploy script (AKA `remove.sh`) will look for matching `<prefix>-chan` Channel and `<prefix>-sub` Subscription resources and remove them in tandem.

Neither a namespace nor a prefix is required--the script will poll the cluster for both if not provided.

If the Subscription has been changed and no longer points to the Channel, the script refuses to delete the resource but gives the user a warning and the commands to do it themselves.