### PR TITLE
update namespace for gatekeeper related policies 

### DIFF
--- a/community/CM-Configuration-Management/policy-gatekeeper-allowed-external-ips.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-allowed-external-ips.yaml
@@ -96,7 +96,7 @@ spec:
                 apiVersion: v1
                 kind: Event
                 metadata:
-                  namespace: gatekeeper-system
+                  namespace: openshift-gatekeeper-system # set this to the actual namespace where gatekeeper is running
                   annotations:
                     constraint_action: deny
                     constraint_kind: K8sExternalIPs

--- a/community/CM-Configuration-Management/policy-gatekeeper-allowed-external-ips.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-allowed-external-ips.yaml
@@ -96,7 +96,7 @@ spec:
                 apiVersion: v1
                 kind: Event
                 metadata:
-                  namespace: openshift-gatekeeper-system # set this to the actual namespace where gatekeeper is running
+                  namespace: openshift-gatekeeper-system # set it to the actual namespace where gatekeeper is running if different
                   annotations:
                     constraint_action: deny
                     constraint_kind: K8sExternalIPs

--- a/community/CM-Configuration-Management/policy-gatekeeper-container-image-latest.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-container-image-latest.yaml
@@ -425,7 +425,7 @@ spec:
                 apiVersion: v1
                 kind: Event
                 metadata:
-                  namespace: openshift-gatekeeper-system # set this to the actual namespace where gatekeeper is running
+                  namespace: openshift-gatekeeper-system # set it to the actual namespace where gatekeeper is running if different
                   annotations:
                     constraint_action: deny
                     constraint_kind: ContainerImageLatest

--- a/community/CM-Configuration-Management/policy-gatekeeper-container-image-latest.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-container-image-latest.yaml
@@ -411,7 +411,6 @@ spec:
                   name: containerimagelatest
                 status:
                   totalViolations: 0
-                  violations: []
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
@@ -426,7 +425,7 @@ spec:
                 apiVersion: v1
                 kind: Event
                 metadata:
-                  namespace: gatekeeper-system
+                  namespace: openshift-gatekeeper-system # set this to the actual namespace where gatekeeper is running
                   annotations:
                     constraint_action: deny
                     constraint_kind: ContainerImageLatest

--- a/community/CM-Configuration-Management/policy-gatekeeper-container-livenessprobenotset.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-container-livenessprobenotset.yaml
@@ -425,7 +425,7 @@ spec:
                 apiVersion: v1
                 kind: Event
                 metadata:
-                  namespace: openshift-gatekeeper-system # set this to the actual namespace where gatekeeper is running
+                  namespace: openshift-gatekeeper-system # set it to the actual namespace where gatekeeper is running if different
                   annotations:
                     constraint_action: deny
                     constraint_kind: ContainerLivenessprobeNotset

--- a/community/CM-Configuration-Management/policy-gatekeeper-container-livenessprobenotset.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-container-livenessprobenotset.yaml
@@ -411,7 +411,6 @@ spec:
                   name: containerlivenessprobenotset
                 status:
                   totalViolations: 0
-                  violations: []
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
@@ -426,7 +425,7 @@ spec:
                 apiVersion: v1
                 kind: Event
                 metadata:
-                  namespace: gatekeeper-system
+                  namespace: openshift-gatekeeper-system # set this to the actual namespace where gatekeeper is running
                   annotations:
                     constraint_action: deny
                     constraint_kind: ContainerLivenessprobeNotset

--- a/community/CM-Configuration-Management/policy-gatekeeper-container-readinessprobenotset.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-container-readinessprobenotset.yaml
@@ -411,7 +411,6 @@ spec:
                   name: containerreadinessprobenotset
                 status:
                   totalViolations: 0
-                  violations: []
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
@@ -426,7 +425,7 @@ spec:
                 apiVersion: v1
                 kind: Event
                 metadata:
-                  namespace: gatekeeper-system
+                  namespace: openshift-gatekeeper-system # set this to the actual namespace where gatekeeper is running
                   annotations:
                     constraint_action: deny
                     constraint_kind: ContainerReadinessprobeNotset

--- a/community/CM-Configuration-Management/policy-gatekeeper-container-readinessprobenotset.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-container-readinessprobenotset.yaml
@@ -425,7 +425,7 @@ spec:
                 apiVersion: v1
                 kind: Event
                 metadata:
-                  namespace: openshift-gatekeeper-system # set this to the actual namespace where gatekeeper is running
+                  namespace: openshift-gatekeeper-system # set it to the actual namespace where gatekeeper is running if different
                   annotations:
                     constraint_action: deny
                     constraint_kind: ContainerReadinessprobeNotset

--- a/community/CM-Configuration-Management/policy-gatekeeper-operator.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-operator.yaml
@@ -24,7 +24,7 @@ spec:
               apiVersion: v1
               kind: Namespace
               metadata:
-                name: gatekeeper-system
+                name: openshift-gatekeeper-system
   - objectDefinition:
       apiVersion: policy.open-cluster-management.io/v1
       kind: ConfigurationPolicy
@@ -40,7 +40,7 @@ spec:
               kind: CatalogSource
               metadata:
                 name: gatekeeper-operator
-                namespace: gatekeeper-system
+                namespace: openshift-gatekeeper-system
               spec:
                 displayName: Gatekeeper Operator Upstream
                 publisher: github.com/font/gatekeeper-operator
@@ -64,7 +64,7 @@ spec:
               kind: OperatorGroup
               metadata:
                 name: gatekeeper-operator
-                namespace: gatekeeper-system
+                namespace: openshift-gatekeeper-system
   - objectDefinition:
       apiVersion: policy.open-cluster-management.io/v1
       kind: ConfigurationPolicy
@@ -80,12 +80,12 @@ spec:
               kind: Subscription
               metadata:
                 name: gatekeeper-operator-sub
-                namespace: gatekeeper-system
+                namespace: openshift-gatekeeper-system
               spec:
                 channel: alpha
                 name: gatekeeper-operator
                 source: gatekeeper-operator
-                sourceNamespace: gatekeeper-system
+                sourceNamespace: openshift-gatekeeper-system
   - objectDefinition:
       apiVersion: policy.open-cluster-management.io/v1
       kind: ConfigurationPolicy
@@ -101,7 +101,7 @@ spec:
               kind: Gatekeeper
               metadata:
                 name: gatekeeper
-                namespace: gatekeeper-system
+                namespace: openshift-gatekeeper-system
               spec:
                 audit:
                   logLevel: INFO

--- a/community/CM-Configuration-Management/policy-gatekeeper-operator.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-operator.yaml
@@ -24,7 +24,7 @@ spec:
               apiVersion: v1
               kind: Namespace
               metadata:
-                name: openshift-gatekeeper-system
+                name: openshift-gatekeeper-operator
   - objectDefinition:
       apiVersion: policy.open-cluster-management.io/v1
       kind: ConfigurationPolicy
@@ -40,7 +40,7 @@ spec:
               kind: CatalogSource
               metadata:
                 name: gatekeeper-operator
-                namespace: openshift-gatekeeper-system
+                namespace: openshift-gatekeeper-operator
               spec:
                 displayName: Gatekeeper Operator Upstream
                 publisher: github.com/font/gatekeeper-operator
@@ -64,7 +64,7 @@ spec:
               kind: OperatorGroup
               metadata:
                 name: gatekeeper-operator
-                namespace: openshift-gatekeeper-system
+                namespace: openshift-gatekeeper-operator
   - objectDefinition:
       apiVersion: policy.open-cluster-management.io/v1
       kind: ConfigurationPolicy
@@ -80,12 +80,12 @@ spec:
               kind: Subscription
               metadata:
                 name: gatekeeper-operator-sub
-                namespace: openshift-gatekeeper-system
+                namespace: openshift-gatekeeper-operator
               spec:
                 channel: alpha
                 name: gatekeeper-operator
                 source: gatekeeper-operator
-                sourceNamespace: openshift-gatekeeper-system
+                sourceNamespace: openshift-gatekeeper-operator
   - objectDefinition:
       apiVersion: policy.open-cluster-management.io/v1
       kind: ConfigurationPolicy
@@ -101,7 +101,6 @@ spec:
               kind: Gatekeeper
               metadata:
                 name: gatekeeper
-                namespace: openshift-gatekeeper-system
               spec:
                 audit:
                   logLevel: INFO

--- a/community/CM-Configuration-Management/policy-gatekeeper-sample.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-sample.yaml
@@ -91,7 +91,7 @@ spec:
                 apiVersion: v1
                 kind: Event
                 metadata:
-                  namespace: openshift-gatekeeper-system # set this to the actual namespace where gatekeeper is running
+                  namespace: openshift-gatekeeper-system # set it to the actual namespace where gatekeeper is running if different
                   annotations:
                     constraint_action: deny
                     constraint_kind: K8sRequiredLabels

--- a/community/CM-Configuration-Management/policy-gatekeeper-sample.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-sample.yaml
@@ -77,7 +77,6 @@ spec:
                   name: ns-must-have-gk
                 status:
                   totalViolations: 0
-                  violations: []
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
@@ -92,7 +91,7 @@ spec:
                 apiVersion: v1
                 kind: Event
                 metadata:
-                  namespace: gatekeeper-system
+                  namespace: openshift-gatekeeper-system # set this to the actual namespace where gatekeeper is running
                   annotations:
                     constraint_action: deny
                     constraint_kind: K8sRequiredLabels


### PR DESCRIPTION
Due to https://github.com/gatekeeper/gatekeeper-operator/pull/95, on openshift, gatekeeper is now installed to `openshift-gatekeeper-namespace`. Thus updating the policy to point to `openshift-gatekeeper-namespace` for violations
Also update gatekeeper operator policy to install in `openshift-gatekeeper-operator` namespace