### PR TITLE
Fixed: removed catalogresource from ACM policy for IShield, changed to community-operator catalogsource instead

### DIFF
--- a/community/CM-Configuration-Management/policy-integrity-shield.yaml
+++ b/community/CM-Configuration-Management/policy-integrity-shield.yaml
@@ -62,7 +62,7 @@ spec:
                   namespace: openshift-marketplace
                 spec:
                   displayName: Integrity Shield Operator
-                  image: quay.io/open-cluster-management/integrity-shield-operator-index:0.1.0
+                  image: quay.io/open-cluster-management/integrity-shield-operator-index:0.1.3
                   publisher: IBM
                   sourceType: grpc
                   updateStrategy:
@@ -90,7 +90,7 @@ spec:
                   name: integrity-shield-operator
                   source: integrity-shield-operator-catalog
                   sourceNamespace: openshift-marketplace
-                  startingCSV: integrity-shield-operator.v0.1.0
+                  startingCSV: integrity-shield-operator.v0.1.3
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
@@ -108,10 +108,12 @@ spec:
                   name: integrity-shield-server
                   namespace: integrity-shield-operator-system
                 spec:
+                  imagePullSecrets:
+                    - name: mappregkey
                   logger:
-                    image: quay.io/open-cluster-management/integrity-shield-logging:0.1.0
+                    image: quay.io/open-cluster-management/integrity-shield-logging:0.1.3
                   server:
-                    image: quay.io/open-cluster-management/integrity-shield-server:0.1.0
+                    image: quay.io/open-cluster-management/integrity-shield-server:0.1.3
                   affinity: {}
                   shieldConfig:
                     verifyType: pgp # x509
@@ -122,7 +124,7 @@ spec:
                       exclude:
                         - "kube-*"
                         - "openshift-*"
-                  signPolicy:
+                  signerConfig:
                     policies:
                       - namespaces:
                           - "*"
@@ -133,11 +135,12 @@ spec:
                           - "SampleSigner"
                     signers:
                       - name: "SampleSigner"
-                        secret: keyring-secret
+                        keyConfig: sample-signer-keyconfig
                         subjects:
                           - email: "signer@enterprise.com"
-                  keyRingConfigs:
-                    - name: keyring-secret
+                  keyConfig:
+                    - name: sample-signer-keyconfig
+                      secretName: keyring-secret
                   resourceSigningProfiles:
                     - name: policy-rsp
                       protectRules:

--- a/community/CM-Configuration-Management/policy-integrity-shield.yaml
+++ b/community/CM-Configuration-Management/policy-integrity-shield.yaml
@@ -108,8 +108,6 @@ spec:
                   name: integrity-shield-server
                   namespace: integrity-shield-operator-system
                 spec:
-                  imagePullSecrets:
-                    - name: mappregkey
                   logger:
                     image: quay.io/open-cluster-management/integrity-shield-logging:0.1.3
                   server:

--- a/community/CM-Configuration-Management/policy-integrity-shield.yaml
+++ b/community/CM-Configuration-Management/policy-integrity-shield.yaml
@@ -48,30 +48,6 @@ spec:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
         metadata:
-          name: policy-integrity-shield-catrsc
-        spec:
-          remediationAction: enforce
-          severity: high
-          object-templates:
-            - complianceType: musthave
-              objectDefinition:
-                apiVersion: operators.coreos.com/v1alpha1
-                kind: CatalogSource
-                metadata:
-                  name: integrity-shield-operator-catalog
-                  namespace: openshift-marketplace
-                spec:
-                  displayName: Integrity Shield Operator
-                  image: quay.io/open-cluster-management/integrity-shield-operator-index:0.1.3
-                  publisher: IBM
-                  sourceType: grpc
-                  updateStrategy:
-                    registryPoll:
-                      interval: 45m
-    - objectDefinition:
-        apiVersion: policy.open-cluster-management.io/v1
-        kind: ConfigurationPolicy
-        metadata:
           name: policy-integrity-shield-sub
         spec:
           remediationAction: enforce
@@ -88,7 +64,7 @@ spec:
                   channel: alpha
                   installPlanApproval: Automatic
                   name: integrity-shield-operator
-                  source: integrity-shield-operator-catalog
+                  source: community-operators
                   sourceNamespace: openshift-marketplace
                   startingCSV: integrity-shield-operator.v0.1.3
     - objectDefinition:


### PR DESCRIPTION
- removed catalogresource referencing ocm bundle/index images for IShield from ACM policy for IShield, 
- changed to community-operator catalogsource instead