### PR TITLE
add finalizers to policy-integrity-shield for k8s v1.20 and later

### DIFF
--- a/community/CM-Configuration-Management/policy-integrity-shield.yaml
+++ b/community/CM-Configuration-Management/policy-integrity-shield.yaml
@@ -87,6 +87,8 @@ spec:
             metadata:
               name: integrity-shield-server
               namespace: integrity-shield-operator-system
+              finalizers:
+              - cleanup.finalizers.integrityshield.io
             spec:
               logger:
                 image: quay.io/open-cluster-management/integrity-shield-logging:0.1.4


### PR DESCRIPTION
- On K8s v1.20 and later, kubernetes garbage collector will ignore cluster scope resources that have non-existing ownerReference. So Integrity Shield uses finalizer to delete its cluster scope operands.
- Also confirmed it can work on K8s 1.19 or earlier.