### PR TITLE
use the default channel for the compliance operator

### DIFF
--- a/stable/CA-Security-Assessment-and-Authorization/policy-compliance-operator-install.yaml
+++ b/stable/CA-Security-Assessment-and-Authorization/policy-compliance-operator-install.yaml
@@ -67,7 +67,6 @@ spec:
                   name: compliance-operator
                   namespace: openshift-compliance
                 spec:
-                  channel: "4.6"
                   installPlanApproval: Automatic
                   name: compliance-operator
                   source: redhat-operators


### PR DESCRIPTION
Test automation found that the compliance operator using the 4.6 channel will not work when running on OCP 4.7.  Deleting the channel entry allows the default channel to be used which seems to work for both OCP 4.6.x and OCP 4.7.x.

Issue: https://github.com/open-cluster-management/backlog/issues/10184