### PR TITLE
use the default channel for the operator

### DIFF
--- a/stable/SI-System-and-Information-Integrity/policy-imagemanifestvuln.yaml
+++ b/stable/SI-System-and-Information-Integrity/policy-imagemanifestvuln.yaml
@@ -27,7 +27,7 @@ spec:
                   name: container-security-operator
                   namespace: openshift-operators
                 spec:
-                  channel: quay-v3.3
+                  # channel: quay-v3.3 # specify a specific channel if desired
                   installPlanApproval: Automatic
                   name: container-security-operator
                   source: redhat-operators


### PR DESCRIPTION
We should use the default channel for this operator to make the default deploy scenario simpler.
Signed-off-by: Gus Parvin <gparvin@redhat.com>