### PR TITLE
Move community operator to unrestricted namespace

### DIFF
--- a/community/CM-Configuration-Management/policy-gatekeeper-operator.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-operator.yaml
@@ -24,7 +24,7 @@ spec:
               apiVersion: v1
               kind: Namespace
               metadata:
-                name: gatekeeper-operator
+                name: gatekeeper-system
   - objectDefinition:
       apiVersion: policy.open-cluster-management.io/v1
       kind: ConfigurationPolicy
@@ -40,7 +40,7 @@ spec:
               kind: CatalogSource
               metadata:
                 name: gatekeeper-operator
-                namespace: gatekeeper-operator
+                namespace: gatekeeper-system
               spec:
                 displayName: Gatekeeper Operator Upstream
                 publisher: github.com/font/gatekeeper-operator
@@ -64,7 +64,7 @@ spec:
               kind: OperatorGroup
               metadata:
                 name: gatekeeper-operator
-                namespace: gatekeeper-operator
+                namespace: gatekeeper-system
   - objectDefinition:
       apiVersion: policy.open-cluster-management.io/v1
       kind: ConfigurationPolicy
@@ -80,12 +80,12 @@ spec:
               kind: Subscription
               metadata:
                 name: gatekeeper-operator-sub
-                namespace: gatekeeper-operator
+                namespace: gatekeeper-system
               spec:
                 channel: stable
                 name: gatekeeper-operator
                 source: gatekeeper-operator
-                sourceNamespace: gatekeeper-operator
+                sourceNamespace: gatekeeper-system
   - objectDefinition:
       apiVersion: policy.open-cluster-management.io/v1
       kind: ConfigurationPolicy

--- a/community/CM-Configuration-Management/policy-gatekeeper-operator.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-operator.yaml
@@ -24,7 +24,7 @@ spec:
               apiVersion: v1
               kind: Namespace
               metadata:
-                name: openshift-gatekeeper-operator
+                name: gatekeeper-operator
   - objectDefinition:
       apiVersion: policy.open-cluster-management.io/v1
       kind: ConfigurationPolicy
@@ -40,7 +40,7 @@ spec:
               kind: CatalogSource
               metadata:
                 name: gatekeeper-operator
-                namespace: openshift-gatekeeper-operator
+                namespace: gatekeeper-operator
               spec:
                 displayName: Gatekeeper Operator Upstream
                 publisher: github.com/font/gatekeeper-operator
@@ -64,7 +64,7 @@ spec:
               kind: OperatorGroup
               metadata:
                 name: gatekeeper-operator
-                namespace: openshift-gatekeeper-operator
+                namespace: gatekeeper-operator
   - objectDefinition:
       apiVersion: policy.open-cluster-management.io/v1
       kind: ConfigurationPolicy
@@ -80,12 +80,12 @@ spec:
               kind: Subscription
               metadata:
                 name: gatekeeper-operator-sub
-                namespace: openshift-gatekeeper-operator
+                namespace: gatekeeper-operator
               spec:
                 channel: stable
                 name: gatekeeper-operator
                 source: gatekeeper-operator
-                sourceNamespace: openshift-gatekeeper-operator
+                sourceNamespace: gatekeeper-operator
   - objectDefinition:
       apiVersion: policy.open-cluster-management.io/v1
       kind: ConfigurationPolicy


### PR DESCRIPTION
Managed OpenShift clusters might restrict the ability to create/modify
namespaces starting with `openshift-`, and resources inside them. The
gatekeeper operator should be able to run in any namespace, so it would
be good to create it in a namespace where there won't be any issues.

Refs:
 - https://github.com/open-cluster-management/backlog/issues/13759

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>