### PR TITLE
added openshift-config namespace to the included namespaces

### DIFF
--- a/community/SC-System-and-Communications-Protection/policy-ocp4-certs.yaml
+++ b/community/SC-System-and-Communications-Protection/policy-ocp4-certs.yaml
@@ -29,6 +29,7 @@ spec:
           - openshift-cluster-samples-operator
           - openshift-cluster-storage-operator
           - openshift-cluster-version
+          - openshift-config
           - openshift-config-operator
           - openshift-console
           - openshift-console-operator


### PR DESCRIPTION
The "openshift-config" namespace contains the etcd-signer certificate, which is responsible to sign the etcd certificates; etcd certificates are used for encrypted communication between etcd member peers, as well as encrypted client traffic.
https://docs.openshift.com/container-platform/4.7/security/certificate_types_descriptions/etcd-certificates.html

Also, the "openshift-config" namespace includes the User-provided certificates for the API server; It is managed by the user.
https://docs.openshift.com/container-platform/4.7/security/certificate_types_descriptions/user-provided-certificates-for-api-server.html

