### PR TITLE
Add ApplyTo section to Assign gatekeeper policy

### DIFF
--- a/community/CM-Configuration-Management/policy-gatekeeper-image-pull-policy.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-image-pull-policy.yaml
@@ -26,6 +26,10 @@ spec:
                 metadata:
                   name: policy-gatekeeper-image-pull-policy
                 spec:
+                    applyTo:
+                      - groups: [""]
+                        kinds: ["Pod"]
+                        versions: ["v1"]
                     match:
                       scope: Namespaced
                       kinds:


### PR DESCRIPTION
This is now a required section for this kind in the gatekeeper CRD, see
https://open-policy-agent.github.io/gatekeeper/website/docs/mutation

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>