### PR TITLE
Sync rate

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -13,7 +13,7 @@ View the following guidance on how to use the script (all parameters are optiona
  
 ```
 Usage:
-  ./deploy.sh [-u <url>] [-b <branch>] [-p <path/to/dir>] [-n <namespace>] [-a|--name <resource-name>]
+  ./deploy.sh [-u <url>] [-b <branch>] [-p <path/to/dir>] [-n <namespace>] [-a|--name <resource-name>] [-s|--sync <rate>]
 
   -h|--help                   Display this menu
   -u|--url <url>              URL to the Git repository

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -26,7 +26,11 @@ Usage:
                                 (Default namespace: "policies")
   -a|--name <resource-name>   Prefix for the Channel and Subscription resources
                                 (Default name: "demo-stable-policies")
+  -s|--sync <rate>            How frequently the github resources are compared to the hub resources"
+                                (Default rate: "medium") Rates: "high", "medium", "low", "off"'
 ```
+
+For more details on the `sync` parameter values, see the git subscription chapter [Resource reconciliation rate settings](https://github.com/open-cluster-management/multicloud-operators-subscription/blob/main/docs/gitrepo_subscription.md#resource-reconciliation-rate-settings).
 
 ## Remove resources 
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -27,7 +27,7 @@ Usage:
   -a|--name <resource-name>   Prefix for the Channel and Subscription resources
                                 (Default name: "demo-stable-policies")
   -s|--sync <rate>            How frequently the github resources are compared to the hub resources"
-                                (Default rate: "medium") Rates: "high", "medium", "low", "off"'
+                                (Default rate: "medium") Rates: "high", "medium", "low", "off"
 ```
 
 For more details on the `sync` parameter values, see the git subscription chapter [Resource reconciliation rate settings](https://github.com/open-cluster-management/multicloud-operators-subscription/blob/main/docs/gitrepo_subscription.md#resource-reconciliation-rate-settings).

--- a/deploy/channel.yaml
+++ b/deploy/channel.yaml
@@ -2,6 +2,8 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: Channel
 metadata:
   name: demo-stable-policies-chan
+  annotations:
+    apps.open-cluster-management.io/reconcile-rate: medium
 spec:
   type: GitHub
   pathname: https://github.com/open-cluster-management/policy-collection.git

--- a/deploy/channel_template.json
+++ b/deploy/channel_template.json
@@ -8,5 +8,10 @@
         "op": "replace",
         "path": "/spec/pathname",
         "value": "##GH_URL##"
+    },
+    {
+        "op": "replace",
+        "path": "/metadata/pathname/apps.open-cluster-management.ioi\/reconcile-rate",
+        "value": "##RATE##"
     }
 ]

--- a/deploy/channel_template.json
+++ b/deploy/channel_template.json
@@ -11,7 +11,7 @@
     },
     {
         "op": "replace",
-        "path": "/metadata/pathname/apps.open-cluster-management.ioi\/reconcile-rate",
+        "path": "/metadata/annotations/apps.open-cluster-management.io~1reconcile-rate",
         "value": "##RATE##"
     }
 ]

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -25,6 +25,8 @@ help () {
   echo '                                (Default namespace: "policies")'
   echo "  -a|--name <resource-name>   Prefix for the Channel and Subscription resources"
   echo '                                (Default name: "demo-stable-policies")'
+  echo "  -s|--sync <rate>            How frequently the github resources are compared to the hub resources"
+  echo '                                (Default rate: "medium") Rates: "high", "medium", "low"'
   echo ""
 }
 
@@ -61,6 +63,11 @@ while [[ $# -gt 0 ]]; do
             NAME=${1}
             shift
             ;;
+            -s|--sync)
+            shift
+            RATE=${1}
+            shift
+            ;;
             *)    # default
             echo "Invalid input: ${1}"
             exit 1
@@ -79,6 +86,7 @@ echo "Resource Prefix:    ${NAME:=demo-stable-policies}"
 echo "Git URL:            ${GH_URL:=https://github.com/open-cluster-management/policy-collection.git}"
 echo "Git Branch:         ${GH_BRANCH:=main}"
 echo "Git Path:           ${GH_PATH:=stable}"
+echo "Sync Rate:          ${RATE:=medium}"
 echo "====================================================="
 
 while read -r -p "Would you like to proceed (y/n)? " response; do
@@ -94,6 +102,7 @@ done
 CHAN_CFG=$(cat "channel_template.json" |
   sed "s/##NAME##/${NAME}/g" |
   sed "s%##GH_URL##%${GH_URL}%g")
+  sed "s%##RATE##%${RATE}%g")
 echo "$CHAN_CFG" > channel_patch.json
 
 # Populate the Subscription template

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -101,7 +101,7 @@ done
 # Populate the Channel template
 CHAN_CFG=$(cat "channel_template.json" |
   sed "s/##NAME##/${NAME}/g" |
-  sed "s%##GH_URL##%${GH_URL}%g")
+  sed "s%##GH_URL##%${GH_URL}%g" |
   sed "s%##RATE##%${RATE}%g")
 echo "$CHAN_CFG" > channel_patch.json
 

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -26,7 +26,7 @@ help () {
   echo "  -a|--name <resource-name>   Prefix for the Channel and Subscription resources"
   echo '                                (Default name: "demo-stable-policies")'
   echo "  -s|--sync <rate>            How frequently the github resources are compared to the hub resources"
-  echo '                                (Default rate: "medium") Rates: "high", "medium", "low"'
+  echo '                                (Default rate: "medium") Rates: "high", "medium", "low", "off"'
   echo ""
 }
 


### PR DESCRIPTION
adding a sync rate to the deploy options.
The sync rate controls how frequently the github repo is synced with ACM's resources. 
Reasoning:
1. Policies may need a higher sync rate to make sure any compliance requirements are updated quickly
2. Using PolicyAutomation with subscriptions to force re-running noncompliant automations when configured in `once` mode.