### PR TITLE
Added gatekeeper policy that disallows anonymous users in the cluster

### DIFF
--- a/community/AC-Access-Control/policy-gatekeeper-disallow-anonymous.yaml
+++ b/community/AC-Access-Control/policy-gatekeeper-disallow-anonymous.yaml
@@ -1,0 +1,126 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: policy-gatekeeper-disallow-anonymous
+  annotations:
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+    policy.open-cluster-management.io/categories: AC Access Control
+    policy.open-cluster-management.io/controls: AC-2 Account Management
+spec:
+  remediationAction: enforce 
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-gatekeeper-disallow-anonymous
+        spec:
+          remediationAction: enforce
+          severity: low
+          object-templates: 
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: templates.gatekeeper.sh/v1beta1
+                kind: ConstraintTemplate
+                metadata:
+                  name: k8sdisallowanonymous
+                  annotations:
+                    description: Disallows connections from anonymous users.
+                spec:
+                  crd:
+                    spec:
+                      names:
+                        kind: K8sDisallowAnonymous
+                  targets:
+                    - target: admission.k8s.gatekeeper.sh
+                      rego: |
+                        package k8sdisallowanonymous
+                        violation[{"msg": msg}] {
+                          review(input.review.object.subjects[_])
+                          msg := sprintf("Unauthenticated user reference is not allowed in %v %v ", [input.review.object.kind, input.review.object.metadata.name])
+                        }
+
+                        review(subject) = true {
+                          subject.name == "system:unauthenticated"
+                        }
+
+                        review(subject) = true {
+                          subject.name == "system:anonymous"
+                        }                
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: constraints.gatekeeper.sh/v1beta1
+                kind: K8sDisallowAnonymous
+                metadata:
+                  name: no-anonymous
+                spec:
+                  enforcementAction: dryrun
+                  match:
+                    kinds:
+                      - apiGroups: ["rbac.authorization.k8s.io"]
+                        kinds: ["ClusterRoleBinding"]
+                      - apiGroups: ["rbac.authorization.k8s.io"]
+                        kinds: ["RoleBinding"]
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-gatekeeper-audit-disallow-anonymous
+        spec:
+          remediationAction: inform # will be overridden by remediationAction in parent policy
+          severity: low
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: constraints.gatekeeper.sh/v1beta1
+                kind: K8sDisallowAnonymous
+                metadata:
+                  name: no-anonymous
+                status:
+                  totalViolations: 0
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-gatekeeper-admission-disallow-anonymous
+        spec:
+          remediationAction: inform # will be overridden by remediationAction in parent policy
+          severity: low
+          object-templates:
+            - complianceType: mustnothave
+              objectDefinition:
+                apiVersion: v1
+                kind: Event
+                metadata:
+                  namespace: openshift-gatekeeper-system # set it to the actual namespace where gatekeeper is running if different
+                  annotations:
+                    constraint_action: deny
+                    constraint_kind: K8sDisallowAnonymous
+                    constraint_name: no-anonymous
+                    event_type: violation       
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: binding-policy-gatekeeper-disallow-anonymous
+placementRef:
+  name: placement-policy-gatekeeper-disallow-anonymous
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+  - name: policy-gatekeeper-disallow-anonymous
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: placement-policy-gatekeeper-disallow-anonymous
+spec:
+  clusterConditions:
+    - status: "True"
+      type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      - { key: environment, operator: In, values: ["dev"] }

--- a/community/CM-Configuration-Management/policy-ansible-awx-operator.yaml
+++ b/community/CM-Configuration-Management/policy-ansible-awx-operator.yaml
@@ -26,14 +26,13 @@ spec:
           object-templates:
             - complianceType: musthave
               objectDefinition:
-                apiVersion: operators.coreos.com/v1alpha1
-                kind: Namespace
                 apiVersion: v1
+                kind: Namespace
                 metadata:
                   name: awx-resource-operator
             - complianceType: musthave
               objectDefinition:
-                apiVersion: operators.coreos.com/v1alpha1
+                apiVersion: operators.coreos.com/v1
                 kind: OperatorGroup
                 metadata:
                   name: awx-resource-operator-gp2w4

--- a/community/README.md
+++ b/community/README.md
@@ -34,6 +34,7 @@ Policies in this folder are organized by [NIST Special Publication 800-53](https
 Policy  | Description | Prerequisites
 ------- | ----------- | -------------
 [Disallowed roles policy](./AC-Access-Control/policy-roles-no-wildcards.yaml) | Use the disallowed roles policy to make sure no pods are being granted full access in violation of least privilege. | Check [Using RBAC Authorization](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) to learn more about Kubernetes RBAC authorization.
+[Disallowed anonymous authentication](./AC-Access-Control/policy-gatekeeper-disallow-anonymous.yaml) | Use the disallowed anonymous authentication policy to make sure that the system:anonymous user and system:unauthenticated group are not associated with any ClusterRole / Role in the environment | See the [Gatekeeper documentation](https://github.com/open-policy-agent/gatekeeper). **Note**: Gatekeeper controllers must be installed to use the gatekeeper policy. 
 
 ### Awareness and Training
 


### PR DESCRIPTION
The [NSA / CISA Kubernetes Hardening Guidance (August 2021)](https://media.defense.gov/2021/Aug/03/2002820425/-1/-1/1/CTR_KUBERNETES%20HARDENING%20GUIDANCE.PDF) [page 19] states that -

"
In Kubernetes 1.6 and newer, anonymous requests are enabled by default. When RBAC is enabled, anonymous requests require explicit authorization of the system:anonymous user or system:unauthenticated group. Anonymous requests should be disabled by passing the --anonymous-auth=false option to the API server. Leaving anonymous requests enabled could allow a cyber actor to access cluster resources without authentication.
"

The recommendation states that anonymous authentication should be disabled by default. Yet, many environments leave `--anonymous-auth` enabled for various reasons. The purpose of this policy is to control and reduce the usage of anonymous requests in Kubernetes environments.

***Scenario 1 - Policy is not deployed*** - 

```
# as user-1, local namespace admin -

$ cat disallowed-binding.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: dangerous-rolebinding
  namespace: application-1
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: admin
subjects:
- apiGroup: rbac.authorization.k8s.io
  kind: Group
  name: system:unauthenticated

$ kubectl apply -f /tmp/disallowed-binding.yaml 
rolebinding.rbac.authorization.k8s.io/dangerous-rolebinding created

$ kubectl get pods --as="system:anonymous" -n application-1
NAME                         READY   STATUS    RESTARTS   AGE
webserver-7cccc68cc6-dmkt5   1/1     Running   0          8m28s
```

***Scenario 2 - Policy is deployed*** -

```
# as user-1, local namespace admin -

$ kubectl apply -f disallowed-binding.yaml 
Error from server ([denied by no-anonymous] Unauthenticated user reference is not allowed in RoleBinding dangerous-rolebinding ): error when creating "/tmp/disallowed-binding.yaml": admission webhook "validation.gatekeeper.sh" denied the request: [denied by no-anonymous] Unauthenticated user reference is not allowed in RoleBinding dangerous-rolebinding
```

Note that the policy is set to `enforcementAction` is set to `dryrun` - the Gatekeeper policy is not enforced by default.

Feel free to share feedback or edit the contents of the PR :)