### PR TITLE
remove check for install config that isn't working

### DIFF
--- a/community/SC-System-and-Communications-Protection/policy-check-fips.yaml
+++ b/community/SC-System-and-Communications-Protection/policy-check-fips.yaml
@@ -18,11 +18,6 @@ spec:
       spec:
         remediationAction: inform
         severity: low
-        namespaceSelector:
-          exclude:
-            - kube-*
-          include:
-            - default
         object-templates:
           - complianceType: musthave
             objectDefinition:
@@ -33,34 +28,7 @@ spec:
                   machineconfiguration.openshift.io/role: master
                 name: 99-master-fips
               spec:
-                config:
-                  ignition:
-                    fips: true
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: ConfigurationPolicy
-      metadata:
-        name: checkfipscompliance2
-      spec:
-        remediationAction: inform
-        severity: low
-        namespaceSelector:
-          exclude:
-            - kube-*
-          include:
-            - default
-        object-templates:
-          - complianceType: musthave
-            objectDefinition:
-              kind: ConfigMap
-              metadata:
-                name: cluster-config-v1
-                namespace: kube-system
-              apiVersion: v1
-              data:
-                install-config: |
-                  fips: true                    
-                    
+                fips: true
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -86,4 +54,3 @@ spec:
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}
-


### PR DESCRIPTION
Signed-off-by: Gus Parvin <gparvin@redhat.com>
Fix the fips policy. See issue: https://github.com/open-cluster-management/backlog/issues/15947

@ch-stark The install-config.yaml check doesn't work.  I thought we had checked that it did work so I'm not sure if we have a regression there.  To me it seems like the data in the configmap may have changed into one big string -- though I'm not sure if that wasn't the case before.