### PR TITLE
ignore gatekeeper operator namespace

### DIFF
--- a/community/CM-Configuration-Management/policy-gatekeeper-config-exclude-namespaces.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-config-exclude-namespaces.yaml
@@ -65,6 +65,7 @@ spec:
                         - openshift-dns-operator
                         - openshift-etcd
                         - openshift-etcd-operator
+                        - openshift-gatekeeper-operator
                         - openshift-gatekeeper-system
                         - openshift-image-registry
                         - openshift-infra


### PR DESCRIPTION
Signed-off-by: Gus Parvin <gparvin@redhat.com>
Added the gatekeeper operator namespace as one gatekeeper should ignore.