### PR TITLE
fix pao operator so the new version is installed

### DIFF
--- a/community/CM-Configuration-Management/policy-pao-operator.yaml
+++ b/community/CM-Configuration-Management/policy-pao-operator.yaml
@@ -33,28 +33,6 @@ spec:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
         metadata:
-          name: policy-pao-operatorgroup
-        spec:
-          remediationAction: enforce # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
-          severity: low
-          namespaceSelector:
-            exclude: ["kube-*"]
-            include: ["*"]
-          object-templates:
-            - complianceType: musthave
-              objectDefinition:
-                apiVersion: operators.coreos.com/v1
-                kind: OperatorGroup
-                metadata:
-                  name: performance-addon-operator
-                  namespace: openshift-performance-addon
-                spec:
-                  targetNamespaces:
-                    - openshift-performance-addon
-    - objectDefinition:
-        apiVersion: policy.open-cluster-management.io/v1
-        kind: ConfigurationPolicy
-        metadata:
           name: policy-pao-subscription
         spec:
           remediationAction: enforce # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
@@ -69,9 +47,8 @@ spec:
                 kind: Subscription
                 metadata:
                   name: performance-addon-operator
-                  namespace: openshift-performance-addon
+                  namespace: openshift-operators
                 spec:
-                  channel: "4.5"
                   name: performance-addon-operator
                   source: redhat-operators
                   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Signed-off-by: Gus Parvin <gparvin@redhat.com>
Install the new version instead of the old 4.5 operator.