### PR TITLE
we need to allow policies in newer subscriptions

### DIFF
--- a/deploy/subscription.yaml
+++ b/deploy/subscription.yaml
@@ -6,6 +6,13 @@ metadata:
     apps.open-cluster-management.io/git-path: stable
   name: demo-stable-policies-sub
 spec:
+  allow:
+  - apiVersion: policy.open-cluster-management.io/v1
+    kinds:
+    - '*'
+  - apiVersion: cluster.open-cluster-management.io/v1alpha1
+    kinds:
+    - '*'
   channel: policies/demo-stable-policies-chan
   placement:
     local: true


### PR DESCRIPTION
Signed-off-by: Gus Parvin <gparvin@redhat.com>
This fixes issue https://github.com/open-cluster-management/backlog/issues/17102
In ACM 2.4 the subscription controller is more restrictive and requires the allow list in this changeset.
Older versions of the subscription controller will ignore this change.