### PR TITLE
update integrity-shield policies to v0.3.1

### DIFF
--- a/community/CM-Configuration-Management/policy-integrity-shield-observer.yaml
+++ b/community/CM-Configuration-Management/policy-integrity-shield-observer.yaml
@@ -1,0 +1,60 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-5 Access Restrictions for Change
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+  name: policy-integrity-shield-observer
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-integrity-shield-observer
+        spec:
+          namespaceSelector:
+            include:
+              - integrity-shield-operator-system
+          object-templates:
+            - complianceType: mustnothave
+              objectDefinition:
+                apiVersion: apis.integrityshield.io/v1
+                kind: ManifestIntegrityState
+                metadata:
+                  labels:
+                    integrityshield.io/verifyResourceIgnored: "false"
+                    integrityshield.io/verifyResourceViolation: "true"
+          remediationAction: inform
+          severity: low
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: binding-policy-integrity-shield-observer
+placementRef:
+  apiGroup: apps.open-cluster-management.io
+  kind: PlacementRule
+  name: placement-policy-integrity-shield-observer
+subjects:
+  - apiGroup: policy.open-cluster-management.io
+    kind: Policy
+    name: policy-integrity-shield-observer
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: placement-policy-integrity-shield-observer
+spec:
+  clusterConditions:
+    - status: "True"
+      type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      - key: environment
+        operator: In
+        values:
+          - dev

--- a/community/CM-Configuration-Management/policy-integrity-shield.yaml
+++ b/community/CM-Configuration-Management/policy-integrity-shield.yaml
@@ -65,12 +65,11 @@ spec:
                   name: integrity-shield-operator
                   namespace: integrity-shield-operator-system
                 spec:
-                  channel: alpha
-                  installPlanApproval: Automatic
+                  channel: alpha-0.3.1
                   name: integrity-shield-operator
                   source: community-operators
                   sourceNamespace: openshift-marketplace
-                  startingCSV: integrity-shield-operator.v0.1.6
+                  startingCSV: integrity-shield-operator.v0.3.1
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
@@ -82,81 +81,533 @@ spec:
           object-templates:
             - complianceType: musthave
               objectDefinition:
-                apiVersion: apis.integrityshield.io/v1alpha1
+                apiVersion: apis.integrityshield.io/v1
                 kind: IntegrityShield
                 metadata:
-                  name: integrity-shield-server
+                  name: integrity-shield
                   namespace: integrity-shield-operator-system
                   finalizers:
                     - cleanup.finalizers.integrityshield.io
                 spec:
-                  logger:
-                    image: quay.io/open-cluster-management/integrity-shield-logging:0.1.6
-                  server:
-                    image: quay.io/open-cluster-management/integrity-shield-server:0.1.6
+                  labels:
+                    app: ishield-api
                   affinity: {}
-                  shieldConfig:
-                    verifyType: pgp # x509
-                    iShieldAdminUserName: "system:serviceaccount:open-cluster-management-agent-addon:klusterlet-addon-policyctrl"
-                    inScopeNamespaceSelector:
-                      include:
-                        - "*"
-                      exclude:
-                        - "kube-*"
-                        - "openshift-*"
-                  signerConfig:
-                    policies:
-                      - namespaces:
-                          - "*"
-                        signers:
-                          - SampleSigner
-                      - scope: Cluster
-                        signers:
-                          - SampleSigner
+                  security:
+                    serviceAccountName: integrity-shield-sa
+                    role: integrity-shield-role
+                    roleBinding: integrity-shield-rolebinding
+                    podSecurityPolicyName: integrity-shield-psp
+                    observerServiceAccountName: integrity-shield-observer-sa
+                    observerRole: integrity-shield-observer-role
+                    observerRoleBinding: integrity-shield-observer-rolebinding
+                    securityContext: {}
+                  shieldApiTlsSecretName: integrity-shield-api-tls
+                  shieldApiServiceName: integrity-shield-api
+                  shieldApiServicePort: 8123
+                  shieldApi:
+                    name: integrity-shield-api
+                    imagePullPolicy: Always
+                    image: quay.io/open-cluster-management/integrity-shield-api
+                    port: 8080
+                    selector:
+                      app: integrity-shield-api
+                  requestHandlerConfigKey: config.yaml
+                  requestHandlerConfigName: request-handler-config
+                  requestHandlerConfig: |
+                    defaultConstraintAction:
+                      mode: detect
+                      admissionOnly: false
+                    sideEffect: 
+                      createDenyEvent: true
+                    log:
+                      level: info
+                      manifestSigstoreLogLevel: info
+                      format: json
+                    requestFilterProfile: 
+                      skipObjects:
+                      - kind: ConfigMap
+                        name: kube-root-ca.crt
+                      - kind: ConfigMap
+                        name: openshift-service-ca.crt
+                      ignoreFields:
+                      - fields:
+                        - spec.host
+                        objects:
+                        - kind: Route
+                      - fields:
+                        - metadata.namespace
+                        objects:
+                        - kind: ClusterServiceVersion
+                      - fields:
+                        - metadata.labels.app.kubernetes.io/instance
+                        - metadata.managedFields.*
+                        - metadata.resourceVersion
+                        - metadata.selfLink
+                        - metadata.annotations.control-plane.alpha.kubernetes.io/leader
+                        - metadata.annotations.kubectl.kubernetes.io/last-applied-configuration
+                        - metadata.finalizers*
+                        - metadata.annotations.namespace
+                        - metadata.annotations.deprecated.daemonset.template.generation
+                        - metadata.creationTimestamp
+                        - metadata.uid
+                        - metadata.generation
+                        - status
+                        - metadata.annotations.deployment.kubernetes.io/revision
+                        - metadata.annotations.cosign.sigstore.dev/imageRef
+                        - metadata.annotations.cosign.sigstore.dev/bundle
+                        - metadata.annotations.cosign.sigstore.dev/message
+                        - metadata.annotations.cosign.sigstore.dev/certificate
+                        - metadata.annotations.cosign.sigstore.dev/signature
+                        objects:
+                        - name: '*'
+                      - fields:
+                        - secrets.*.name
+                        - imagePullSecrets.*.name
+                        objects:
+                        - kind: ServiceAccount
+                      - fields:
+                        - spec.ports.*.nodePort
+                        - spec.clusterIP
+                        - spec.clusterIPs.0
+                        objects:
+                        - kind: Service
+                      - fields:
+                        - metadata.labels.olm.api.*
+                        - metadata.labels.operators.coreos.com/*
+                        - metadata.annotations.*
+                        - spec.install.spec.deployments.*.spec.template.spec.containers.*.resources.limits.cpu
+                        - spec.cleanup.enabled
+                        objects:
+                        - kind: ClusterServiceVersion
+                      skipUsers:
+                      - users: 
+                        - system:admin
+                        - system:apiserver
+                        - system:kube-scheduler
+                        - system:kube-controller-manager
+                        - system:serviceaccount:kube-system:generic-garbage-collector
+                        - system:serviceaccount:kube-system:attachdetach-controller
+                        - system:serviceaccount:kube-system:certificate-controller
+                        - system:serviceaccount:kube-system:clusterrole-aggregation-controller
+                        - system:serviceaccount:kube-system:cronjob-controller
+                        - system:serviceaccount:kube-system:disruption-controller
+                        - system:serviceaccount:kube-system:endpoint-controller
+                        - system:serviceaccount:kube-system:horizontal-pod-autoscaler
+                        - system:serviceaccount:kube-system:ibm-file-plugin
+                        - system:serviceaccount:kube-system:ibm-keepalived-watcher
+                        - system:serviceaccount:kube-system:ibmcloud-block-storage-plugin
+                        - system:serviceaccount:kube-system:job-controller
+                        - system:serviceaccount:kube-system:namespace-controller
+                        - system:serviceaccount:kube-system:node-controller
+                        - system:serviceaccount:kube-system:job-controller
+                        - system:serviceaccount:kube-system:pod-garbage-collector
+                        - system:serviceaccount:kube-system:pv-protection-controller
+                        - system:serviceaccount:kube-system:pvc-protection-controller
+                        - system:serviceaccount:kube-system:replication-controller
+                        - system:serviceaccount:kube-system:resourcequota-controller
+                        - system:serviceaccount:kube-system:service-account-controller
+                        - system:serviceaccount:kube-system:statefulset-controller
+                      - objects: 
+                        - kind: ControllerRevision
+                        - kind: Pod
+                        users: 
+                        - system:serviceaccount:kube-system:daemon-set-controller
+                      - objects: 
+                        - kind: Pod
+                        - kind: PersistentVolumeClaim
+                        users: 
+                        - system:serviceaccount:kube-system:persistent-volume-binder
+                      - objects: 
+                        - kind: ReplicaSet
+                        users: 
+                        - system:serviceaccount:kube-system:deployment-controller
+                      - objects: 
+                        - kind: Pod
+                        users:  
+                        - system:serviceaccount:kube-system:replicaset-controller
+                      - objects: 
+                        - kind: PersistentVolumeClaim
+                        users: 
+                        - system:serviceaccount:kube-system:statefulset-controller
+                      - objects: 
+                        - kind: ServiceAccount
+                        users: 
+                        - system:kube-controller-manager
+                      - objects: 
+                        - kind: EndpointSlice
+                        users: 
+                        - system:serviceaccount:kube-system:endpointslice-controller
+                      - objects: 
+                        - kind: Secret
+                        users: 
+                        - system:kube-controller-manager
+                      - users: 
+                        - system:serviceaccount:openshift-marketplace:marketplace-operator
+                        - system:serviceaccount:openshift-monitoring:cluster-monitoring-operator
+                        - system:serviceaccount:openshift-network-operator:default
+                        - system:serviceaccount:openshift-monitoring:prometheus-operator
+                        - system:serviceaccount:openshift-cloud-credential-operator:default
+                        - system:serviceaccount:openshift-machine-config-operator:default
+                        - system:serviceaccount:openshift-infra:namespace-security-allocation-controller
+                        - system:serviceaccount:openshift-cluster-version:default
+                        - system:serviceaccount:openshift-authentication-operator:authentication-operator
+                        - system:serviceaccount:openshift-apiserver-operator:openshift-apiserver-operator
+                        - system:serviceaccount:openshift-kube-scheduler-operator:openshift-kube-scheduler-operator
+                        - system:serviceaccount:openshift-kube-controller-manager-operator:kube-controller-manager-operator
+                        - system:serviceaccount:openshift-controller-manager:openshift-controller-manager-sa
+                        - system:serviceaccount:openshift-controller-manager-operator:openshift-controller-manager-operator
+                        - system:serviceaccount:openshift-kube-apiserver-operator:kube-apiserver-operator
+                        - system:serviceaccount:openshift-sdn:sdn-controller
+                        - system:serviceaccount:openshift-machine-api:cluster-autoscaler-operator
+                        - system:serviceaccount:openshift-machine-api:machine-api-operator
+                        - system:serviceaccount:openshift-machine-config-operator:machine-config-controller
+                        - system:serviceaccount:openshift-machine-api:machine-api-controllers
+                        - system:serviceaccount:openshift-cluster-storage-operator:csi-snapshot-controller-operator
+                        - system:serviceaccount:openshift-kube-controller-manager:localhost-recovery-client
+                        - system:serviceaccount:openshift-kube-storage-version-migrator-operator:kube-storage-version-migrator-operator
+                        - system:serviceaccount:openshift-etcd-operator:etcd-operator
+                        - system:serviceaccount:openshift-service-ca:service-ca
+                        - system:serviceaccount:openshift-config-operator:openshift-config-operator
+                        - system:serviceaccount:openshift-kube-apiserver:localhost-recovery-client
+                        - system:serviceaccount:openshift-cluster-node-tuning-operator:cluster-node-tuning-operator
+                      - objects:
+                        - namespace: openshift-service-ca, openshift-network-operator
+                          kind: ConfigMap
+                        users: 
+                        - system:serviceaccount:openshift-service-ca:configmap-cabundle-injector-sa
+                      - objects: 
+                        - namespace: openshift-service-ca-operator
+                          kind: ConfigMap
+                        users: 
+                        - system:serviceaccount:openshift-service-ca-operator:service-ca-operator
+                      - objects: 
+                        - namespace: openshift-service-catalog-controller-manager-operator
+                          kind: ConfigMap
+                        users: 
+                        - system:serviceaccount:openshift-service-catalog-controller-manager-operator:openshift-service-catalog-controller-manager-operator
+                      - objects: 
+                        - namespace: openshift-console-operator, openshift-console
+                        users: 
+                        - system:serviceaccount:openshift-console-operator:console-operator
+                      - objects: 
+                        - namespace: openshift-service-ca
+                          kind: ConfigMap
+                        users: 
+                        - system:serviceaccount:openshift-service-ca:apiservice-cabundle-injector-sa
+                        - namespace: openshift-service-ca
+                          kind: ConfigMap
+                        users: 
+                        - system:serviceaccount:openshift-service-ca:service-serving-cert-signer-sa
+                      - objects: 
+                        - namespace: openshift-service-catalog-apiserver-operator
+                          kind: ConfigMap
+                        users: 
+                        - system:serviceaccount:openshift-service-catalog-apiserver-operator:openshift-service-catalog-apiserver-operator
+                      - objects: 
+                        - namespace: openshift-operator-lifecycle-manager
+                        users: 
+                        - system:serviceaccount:openshift-operator-lifecycle-manager:olm-operator-serviceaccount
+                      - objects: 
+                        - namespace: openshift-cluster-node-tuning-operator
+                          kind: ConfigMap,DaemonSet
+                        users: 
+                        - system:serviceaccount:openshift-cluster-node-tuning-operator:cluster-node-tuning-operator
+                      - objects: 
+                        - namespace: openshift
+                          kind: Secret
+                        users: 
+                        - system:serviceaccount:openshift-cluster-samples-operator:cluster-samples-operator
+                      - objects: 
+                        - namespace: openshift-ingress
+                          kind: Deployment
+                        users: 
+                        - system:serviceaccount:openshift-ingress-operator:ingress-operator
+                      - objects: 
+                        - kind: ServiceAccount, Secret
+                        users: 
+                        - system:serviceaccount:openshift-infra:serviceaccount-pull-secrets-controller
+                      - objects: 
+                        - namespace: openshift-marketplace
+                          kind: Pod
+                        users: 
+                        - system:node:*
+                      - objects: 
+                        - kind: ServiceAccount, InstallPlan, OperatorGroup, Role, RoleBinding, Deployment
+                        users: 
+                        - system:serviceaccount:openshift-operator-lifecycle-manager:olm-operator-serviceaccount
+                      - objects: 
+                        - kind: InstallPlan, Role, RoleBinding, Deployment
+                        users: 
+                        - system:serviceaccount:openshift-operator-lifecycle-manager:olm-operator-serviceaccount
+                  useGatekeeper: true
+                  rego: |
+                    package integrityshieldcheck
+                    violation[{"msg": msg}] {
+                      not is_allowed_kind
+                      not is_excluded
+                      is_create_or_update
+                      ishield_input := {"parameters":input.parameters, "request":input.review}
+                      reqdata := json.marshal(ishield_input)
+                      url := "https://integrity-shield-api.REPLACE_WITH_SERVER_NAMESPSCE.svc:8123/api/request"
+                      resp := http_post(url, reqdata)
+                      resp.status_code == 200
+                      result := json.unmarshal(resp.raw_body)
+                      result.allow == false
+                      not is_detect_mode
+                      msg := sprintf("denied; %v", [result])
+                    }
+
+                    http_post(url, postdata) = resp {
+                      resp := http.send({
+                        "url": url,
+                        "method": "POST",
+                        "headers": {
+                          "Accept": "application/json",
+                          "Content-type": "application/json",
+                        },
+                        "raw_body": postdata,
+                        "tls_insecure_skip_verify": true
+                      })
+                    }
+                    
+                    # request check
+                    is_create_or_update { is_create }
+                    is_create_or_update { is_update }
+                    is_create { input.review.operation == "CREATE" }
+                    is_update { input.review.operation == "UPDATE" }
+
+                    # shield config: allow
+                    is_allowed_kind { skip_kinds[_].kind == input.review.kind.kind }
+                    # shield config: inScopeNamespaceSelector
+                    is_excluded { exclude_namespaces[_] = input.review.namespace}
+
+                    # detect mode
+                    is_detect_mode { enforce_mode == "detect" }
+
+                    ################### 
+                    # Default setting #
+                    ###################
+
+                    # Mode whether to deny a invalid request [enforce/detect]
+                    enforce_mode = "enforce"
+
+                    # kinds to be skipped
+                    skip_kinds = [
+                              {
+                                "kind": "Event"
+                              },
+                              {
+                                "kind": "Lease"
+                              },
+                              {
+                                "kind": "Endpoints"
+                              },
+                              {
+                                "kind": "TokenReview"
+                              },
+                              {
+                                "kind": "SubjectAccessReview"
+                              },
+                              {
+                                "kind": "SelfSubjectAccessReview"
+                              }
+                            ]
+
+                    # exclude namespaces
+                    exclude_namespaces = [
+                                          "kube-node-lease",
+                                          "kube-public",
+                                          "kube-storage-version-migrator-operator",
+                                          "kube-system",
+                                          "open-cluster-management",
+                                          "open-cluster-management-hub",
+                                          "open-cluster-management-agent",
+                                          "open-cluster-management-agent-addon",
+                                          "openshift",
+                                          "openshift-apiserver",
+                                          "openshift-apiserver-operator",
+                                          "openshift-authentication",
+                                          "openshift-authentication-operator",
+                                          "openshift-cloud-credential-operator",
+                                          "openshift-cluster-csi-drivers",
+                                          "openshift-cluster-machine-approver",
+                                          "openshift-cluster-node-tuning-operator",
+                                          "openshift-cluster-samples-operator",
+                                          "openshift-cluster-storage-operator",
+                                          "openshift-cluster-version",
+                                          "openshift-compliance",
+                                          "openshift-config",
+                                          "openshift-config-managed",
+                                          "openshift-config-operator",
+                                          "openshift-console",
+                                          "openshift-console-operator",
+                                          "openshift-console-user-settings",
+                                          "openshift-controller-manager",
+                                          "openshift-controller-manager-operator",
+                                          "openshift-dns",
+                                          "openshift-dns-operator",
+                                          "openshift-etcd",
+                                          "openshift-etcd-operator",
+                                          "openshift-gatekeeper-system",
+                                          "openshift-image-registry",
+                                          "openshift-infra",
+                                          "openshift-ingress",
+                                          "openshift-ingress-canary",
+                                          "openshift-ingress-operator",
+                                          "openshift-insights",
+                                          "openshift-kni-infra",
+                                          "openshift-kube-apiserver",
+                                          "openshift-kube-apiserver-operator",
+                                          "openshift-kube-controller-manager",
+                                          "openshift-kube-controller-manager-operator",
+                                          "openshift-kube-scheduler",
+                                          "openshift-kube-scheduler-operator",
+                                          "openshift-kube-storage-version-migrator",
+                                          "openshift-kube-storage-version-migrator-operator",
+                                          "openshift-kubevirt-infra",
+                                          "openshift-machine-api",
+                                          "openshift-machine-config-operator",
+                                          "openshift-marketplace",
+                                          "openshift-monitoring",
+                                          "openshift-multus",
+                                          "openshift-network-diagnostics",
+                                          "openshift-network-operator",
+                                          "openshift-node",
+                                          "openshift-oauth-apiserver",
+                                          "openshift-openstack-infra",
+                                          "openshift-operators",
+                                          "openshift-operator-lifecycle-manager",
+                                          "openshift-ovirt-infra",
+                                          "openshift-ovn-kubernetes",
+                                          "openshift-sdn",
+                                          "openshift-service-ca",
+                                          "openshift-service-ca-operator",
+                                          "openshift-user-workload-monitoring",
+                                          "openshift-vsphere-infra"
+                                      ]
+                  observer:
+                    enabled: true
+                    name: integrity-shield-observer
+                    imagePullPolicy: Always
+                    image: quay.io/open-cluster-management/integrity-shield-observer
+                    selector:
+                      app: integrity-shield-observer
+                    logLevel: info
+                    interval: "5"
+                    # exportDetailResult: false
+                    # resultDetailConfigName: verify-resource-result
+                    # resultDetailConfigKey: "config.yaml"
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-integrity-shield-policy-constraint
+        spec:
+          remediationAction: enforce # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
+          severity: high
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: constraints.gatekeeper.sh/v1beta1
+                kind: ManifestIntegrityConstraint
+                metadata:
+                  name: policy-constraint
+                spec:
+                  match:
+                    kinds:
+                      - apiGroups:
+                          - policy.open-cluster-management.io
+                        kinds:
+                          - Policy
+                    namespaceSelector:
+                      matchExpressions:
+                        - key: policy.open-cluster-management.io/isClusterNamespace
+                          operator: In
+                          values:
+                            - "true"
+                  parameters:
+                    constraintName: policy-constraint
+                    action:
+                      mode: detect
+                    ignoreFields:
+                      - fields:
+                          - metadata.labels.policy.open-cluster-management.io/root-policy
+                          - metadata.labels.policy.open-cluster-management.io/cluster-name
+                          - metadata.annotations.apps.open-cluster-management.io/sync-source
+                          - metadata.annotations.apps.open-cluster-management.io/reconcile-option
+                          - metadata.annotations.apps.open-cluster-management.io/hosting-subscription
+                          - metadata.annotations.apps.open-cluster-management.io/hosting-deployable
+                          - metadata.labels.policy.open-cluster-management.io/cluster-namespace
+                        objects:
+                          - apiGroup: policy.open-cluster-management.io
+                      - fields:
+                          - namespace
+                        objects:
+                          - apiGroup: policy.open-cluster-management.io
+                            kind: Policy
                     signers:
-                      - name: SampleSigner
-                        keyConfig: sample-signer-keyconfig
-                        subjects:
-                          - email: "*"
-                  keyConfig:
-                    - name: sample-signer-keyconfig
-                      secretName: keyring-secret
-                  resourceSigningProfiles:
-                    - name: policy-rsp
-                      protectRules:
-                        - match:
-                            - apiGroup: policy.open-cluster-management.io
-                      ignoreRules:
-                        - match:
-                            - username: "system:serviceaccount:open-cluster-management-agent:*"
-                            - username: "system:serviceaccount:open-cluster-management-agent-addon:*"
-                      forceCheckRules:
-                        - match:
-                            - apiGroup: policy.open-cluster-management.io
-                              kind: Policy
-                      kustomizePatterns:
-                        - match:
-                            - apiGroup: policy.open-cluster-management.io
-                              kind: Policy
-                          namePrefix: '*.'
-                          allowNamespaceChange: true
-                      ignoreAttrs:
-                        - match:
-                            - apiGroup: policy.open-cluster-management.io
-                          attrs:
-                            - "metadata.annotations.\"apps.open-cluster-management.io/hosting-deployable\""
-                            - "metadata.annotations.\"apps.open-cluster-management.io/hosting-subscription\""
-                            - "metadata.annotations.\"apps.open-cluster-management.io/sync-source\""
-                            - "metadata.annotations.\"apps.open-cluster-management.io/reconcile-option\""
-                            - "metadata.labels.\"policy.open-cluster-management.io/cluster-name\""
-                            - "metadata.labels.\"policy.open-cluster-management.io/cluster-namespace\""
-                            - "metadata.labels.\"policy.open-cluster-management.io/root-policy\""
-                      targetNamespaceSelector:
-                        labelSelector:
-                          matchExpressions:
-                            - key: policy.open-cluster-management.io/isClusterNamespace
-                              operator: In
-                              values: ["true"]
+                      - "*"
+                    keyConfigs:
+                      - keySecretName: keyring-secret
+                        keySecretNamespace: integrity-shield-operator-system
+                    skipUsers:
+                      - users:
+                          - system:serviceaccount:open-cluster-management-agent:*
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-integrity-shield-sub-policy-constraint
+        spec:
+          remediationAction: enforce # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
+          severity: high
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: constraints.gatekeeper.sh/v1beta1
+                kind: ManifestIntegrityConstraint
+                metadata:
+                  name: sub-policy-constraint
+                spec:
+                  match:
+                    kinds:
+                      - apiGroups:
+                          - policy.open-cluster-management.io
+                        kinds:
+                          - ConfigurationPolicy
+                          - CertificatePolicy
+                          - IamPolicy
+                    namespaceSelector:
+                      matchExpressions:
+                        - key: policy.open-cluster-management.io/isClusterNamespace
+                          operator: In
+                          values:
+                            - "true"
+                  parameters:
+                    constraintName: sub-policy-constraint
+                    action:
+                      mode: detect
+                      admissionOnly: true
+                    ignoreFields:
+                      - fields:
+                          - metadata.labels.policy.open-cluster-management.io/root-policy
+                          - metadata.labels.policy.open-cluster-management.io/cluster-name
+                          - metadata.annotations.apps.open-cluster-management.io/sync-source
+                          - metadata.annotations.apps.open-cluster-management.io/reconcile-option
+                          - metadata.annotations.apps.open-cluster-management.io/hosting-subscription
+                          - metadata.annotations.apps.open-cluster-management.io/hosting-deployable
+                          - metadata.labels.policy.open-cluster-management.io/cluster-namespace
+                        objects:
+                          - apiGroup: policy.open-cluster-management.io
+                    signers:
+                      - "*"
+                    keyConfigs:
+                      - keySecretName: keyring-secret
+                        keySecretNamespace: integrity-shield-operator-system
+                    skipUsers:
+                      - users:
+                          - system:serviceaccount:open-cluster-management-agent:*
+                          - system:serviceaccount:open-cluster-management-agent-addon:*
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding


### PR DESCRIPTION
Signed-off-by: Ruriko Kudo <rurikudo@ibm.com>


- update Integrity Shield version to v0.3.1
- add integrity-shield-observer policy to show integrity status in rhacm console
