### PR TITLE
the allow list is not needed

### DIFF
--- a/deploy/subscription.yaml
+++ b/deploy/subscription.yaml
@@ -6,13 +6,6 @@ metadata:
     apps.open-cluster-management.io/git-path: stable
   name: demo-stable-policies-sub
 spec:
-  allow:
-  - apiVersion: policy.open-cluster-management.io/v1
-    kinds:
-    - '*'
-  - apiVersion: cluster.open-cluster-management.io/v1alpha1
-    kinds:
-    - '*'
   channel: policies/demo-stable-policies-chan
   placement:
     local: true


### PR DESCRIPTION
Signed-off-by: Gus Parvin <gparvin@redhat.com>
We determined the allow list is not needed, only being a subscription admin is required.
Removing the allow list.  It's currently causing a problem with pushing PlacementRules