### PR TITLE
Update policy to point to open-cluster-management helm charts

### DIFF
--- a/community/CM-Configuration-Management/policy-persistent-data-management.yaml
+++ b/community/CM-Configuration-Management/policy-persistent-data-management.yaml
@@ -68,8 +68,8 @@ spec:
                   name: volsync
                   namespace: volsync-system 
                 spec:
-                  pathname: https://backube.github.io/helm-charts/
-                  type: HelmRepo
+                  pathname: https://github.com/open-cluster-management/volsync-chart.git
+                  type: Git
           remediationAction: enforce
           severity: low
     - objectDefinition:
@@ -84,6 +84,9 @@ spec:
                 apiVersion: apps.open-cluster-management.io/v1
                 kind: Subscription
                 metadata:
+                  annotations:
+                    apps.open-cluster-management.io/git-branch: release-2.4
+                    apps.open-cluster-management.io/git-path: volsync
                   labels:
                     app: volsync
                   name: volsync-subscription
@@ -94,6 +97,17 @@ spec:
                   packageOverrides:
                     - packageAlias: volsync
                       packageName: volsync
+                      packageOverrides:
+                      - path: spec
+                        value:
+                          image:
+                            image: quay.io/open-cluster-management/volsync:ocm-2.4
+                          rclone:
+                            image: quay.io/open-cluster-management/volsync-mover-rclone:ocm-2.4
+                          restic:
+                            image: quay.io/open-cluster-management/volsync-mover-restic:ocm-2.4
+                          rsync:
+                            image: quay.io/open-cluster-management/volsync-mover-rsync:ocm-2.4
                   placement:
                     placementRef:
                       name: volsync-placement 


### PR DESCRIPTION
Signed-off-by: Tesshu Flower <tflower@redhat.com>

Policy used to deploy volsync previously pointed to backube/volsync
upstream repo - updating to use open-cluster-management/volsync-charts.

Policy will pull from the release-2.4 branch right now and images
are set to image locations at quay.io/open-cluster-management.

Ultimately the image locations will be updated to use the official
redhat.registry locations.