### PR TITLE
To use AAP with ACM we need to not have the targetNamespace set

### DIFF
--- a/community/CM-Configuration-Management/policy-automation-operator.yaml
+++ b/community/CM-Configuration-Management/policy-automation-operator.yaml
@@ -35,9 +35,7 @@ spec:
                 metadata:
                   name: ansible-automation-operator-gp
                   namespace: ansible-automation-platform
-                spec:
-                  targetNamespaces:
-                  - ansible-automation-platform
+                spec: {}
             - complianceType: musthave
               objectDefinition:
                 apiVersion: operators.coreos.com/v1alpha1


### PR DESCRIPTION
The targetNamespace causes the CSV to be deployed for AAP in namespace
mode instead of in cluster mode.  We need cluster mode so the
controllers will listen to AnsibleJob resource creations across all
namespaces.

Signed-off-by: Gus Parvin <gparvin@redhat.com>