### PR TITLE
Switch gatekeeper policies to use dryrun enforcement

### DIFF
--- a/community/CM-Configuration-Management/policy-gatekeeper-allowed-external-ips.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-allowed-external-ips.yaml
@@ -58,6 +58,7 @@ spec:
                 metadata:
                   name: external-ips
                 spec:
+                  enforcementAction: dryrun
                   match:
                     kinds:
                       - apiGroups: [""]

--- a/community/CM-Configuration-Management/policy-gatekeeper-container-image-latest.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-container-image-latest.yaml
@@ -384,6 +384,7 @@ spec:
                 metadata:
                   name: containerimagelatest
                 spec:
+                  enforcementAction: dryrun
                   match:
                     kinds:
                       - apiGroups:

--- a/community/CM-Configuration-Management/policy-gatekeeper-container-livenessprobenotset.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-container-livenessprobenotset.yaml
@@ -384,6 +384,7 @@ spec:
                 metadata:
                   name: containerlivenessprobenotset
                 spec:
+                  enforcementAction: dryrun
                   match:
                     kinds:
                       - apiGroups:

--- a/community/CM-Configuration-Management/policy-gatekeeper-container-readinessprobenotset.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-container-readinessprobenotset.yaml
@@ -384,6 +384,7 @@ spec:
                 metadata:
                   name: containerreadinessprobenotset
                 spec:
+                  enforcementAction: dryrun
                   match:
                     kinds:
                       - apiGroups:

--- a/community/CM-Configuration-Management/policy-gatekeeper-sample.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-sample.yaml
@@ -54,6 +54,7 @@ spec:
                 metadata:
                   name: ns-must-have-gk
                 spec:
+                  enforcementAction: dryrun
                   match:
                     kinds:
                       - apiGroups: [""]


### PR DESCRIPTION
To make the gatekeeper policies "inform" by default, they need to use
the dryrun `enforcementAction`.  This way you can learn the impacts to
your cluster before removing the `dryrun` and requiring enforcement.

Refs:
 - https://github.com/open-cluster-management/policy-collection/issues/127

Signed-off-by: Gus Parvin <gparvin@redhat.com>