### PR TITLE
Kyverno policies do not use unique placement and binding names

### DIFF
--- a/community/CM-Configuration-Management/policy-kyverno-config-exclude-resources.yaml
+++ b/community/CM-Configuration-Management/policy-kyverno-config-exclude-resources.yaml
@@ -45,9 +45,9 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-  name: binding-policy-kyverno
+  name: binding-policy-kyverno-config-exclude-resources
 placementRef:
-  name: placement-policy-kyverno
+  name: placement-policy-kyverno-config-exclude-resources
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
@@ -58,7 +58,7 @@ subjects:
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
-  name: placement-policy-kyverno
+  name: placement-policy-kyverno-config-exclude-resources
 spec:
   clusterConditions:
     - status: "True"

--- a/community/CM-Configuration-Management/policy-kyverno-container-tgps.yaml
+++ b/community/CM-Configuration-Management/policy-kyverno-container-tgps.yaml
@@ -55,9 +55,9 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-  name: binding-policy-kyverno
+  name: binding-policy-kyverno-container-tgps
 placementRef:
-  name: placement-policy-kyverno
+  name: placement-policy-kyverno-container-tgps
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
@@ -68,7 +68,7 @@ subjects:
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
-  name: placement-policy-kyverno
+  name: placement-policy-kyverno-container-tgps
 spec:
   clusterConditions:
     - status: "True"

--- a/community/CM-Configuration-Management/policy-kyverno-image-pull-policy.yaml
+++ b/community/CM-Configuration-Management/policy-kyverno-image-pull-policy.yaml
@@ -54,9 +54,9 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-  name: binding-policy-kyverno
+  name: binding-policy-kyverno-image-pull-policy
 placementRef:
-  name: placement-policy-kyverno
+  name: placement-policy-kyverno-image-pull-policy
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
@@ -67,7 +67,7 @@ subjects:
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
-  name: placement-policy-kyverno
+  name: placement-policy-kyverno-image-pull-policy
 spec:
   clusterConditions:
     - status: "True"

--- a/community/CM-Configuration-Management/policy-kyverno-sample.yaml
+++ b/community/CM-Configuration-Management/policy-kyverno-sample.yaml
@@ -14,7 +14,7 @@ spec:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
         metadata:
-          name: policy-kyverno
+          name: policy-kyverno-sample
         spec:
           remediationAction: inform
           severity: low
@@ -43,9 +43,9 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-  name: binding-policy-kyverno
+  name: binding-policy-kyverno-sample
 placementRef:
-  name: placement-policy-kyverno
+  name: placement-policy-kyverno-sample
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
@@ -56,7 +56,7 @@ subjects:
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
-  name: placement-policy-kyverno
+  name: placement-policy-kyverno-sample
 spec:
   clusterConditions:
   - status: "True"


### PR DESCRIPTION
I tried to use the kyverno config policy and determined its placement
and bindings use the same naming as some other kyverno policies.  This
update changes the kyverno policies so they use names based off of the
policy name which is the precedent we have set.

Signed-off-by: Gus Parvin <gparvin@redhat.com>