### PR TITLE
Revert "Revert "Add additional checks to detect if operator is running (#202)""

### DIFF
--- a/community/CM-Configuration-Management/policy-automation-operator.yaml
+++ b/community/CM-Configuration-Management/policy-automation-operator.yaml
@@ -17,10 +17,10 @@ spec:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
         metadata:
-          name: ansible-automation-platform-ns
+          name: ansible-automation-platform
         spec:
           remediationAction: inform
-          severity: low
+          severity: high
           object-templates:
             - complianceType: musthave
               objectDefinition:
@@ -35,7 +35,6 @@ spec:
                 metadata:
                   name: ansible-automation-operator-gp
                   namespace: ansible-automation-platform
-                spec: {}
             - complianceType: musthave
               objectDefinition:
                 apiVersion: operators.coreos.com/v1alpha1
@@ -49,6 +48,25 @@ spec:
                   name: ansible-automation-platform-operator
                   source: redhat-operators
                   sourceNamespace: openshift-marketplace
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: ansible-automation-platform-status
+        spec:
+          remediationAction: inform 
+          severity: high
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operators.coreos.com/v1alpha1
+                kind: ClusterServiceVersion
+                metadata:
+                  namespace: ansible-automation-platform
+                spec:
+                  displayName: Ansible Automation Platform (early access)
+                status:
+                  phase: Succeeded   # check the csv status to determine if operator is running or not
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/stable/CA-Security-Assessment-and-Authorization/policy-compliance-operator-install.yaml
+++ b/stable/CA-Security-Assessment-and-Authorization/policy-compliance-operator-install.yaml
@@ -71,6 +71,25 @@ spec:
                   name: compliance-operator
                   source: redhat-operators
                   sourceNamespace: openshift-marketplace
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: comp-operator-status
+        spec:
+          remediationAction: inform  # will be overridden by remediationAction in parent policy
+          severity: high
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operators.coreos.com/v1alpha1
+                kind: ClusterServiceVersion
+                metadata:
+                  namespace: openshift-compliance
+                spec:
+                  displayName: Compliance Operator
+                status:
+                  phase: Succeeded   # check the csv status to determine if operator is running or not
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/stable/CM-Configuration-Management/policy-gatekeeper-operator-downstream.yaml
+++ b/stable/CM-Configuration-Management/policy-gatekeeper-operator-downstream.yaml
@@ -40,6 +40,25 @@ spec:
       apiVersion: policy.open-cluster-management.io/v1
       kind: ConfigurationPolicy
       metadata:
+        name: gatekeeper-operator-status
+      spec:
+        remediationAction: inform
+        severity: high
+        object-templates:
+          - complianceType: musthave
+            objectDefinition:
+              apiVersion: operators.coreos.com/v1alpha1
+              kind: ClusterServiceVersion
+              metadata:
+                namespace: openshift-gatekeeper-system
+              spec:
+                displayName: Gatekeeper Operator
+              status:
+                phase: Succeeded   # check the csv status to determine if operator is running or not
+  - objectDefinition:
+      apiVersion: policy.open-cluster-management.io/v1
+      kind: ConfigurationPolicy
+      metadata:
         name: gatekeeper
       spec:
         remediationAction: inform
@@ -61,6 +80,35 @@ spec:
                   emitAdmissionEvents: Enabled
                   logLevel: INFO
                   replicas: 2
+  - objectDefinition:
+      apiVersion: policy.open-cluster-management.io/v1
+      kind: ConfigurationPolicy
+      metadata:
+        name: gatekeeper-status
+      spec:
+        remediationAction: inform
+        severity: high
+        object-templates:
+          - complianceType: musthave
+            objectDefinition:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                namespace: openshift-gatekeeper-system
+                labels:
+                  control-plane: audit-controller
+              status:
+                phase: Running   # check the pod status to determine if operator is running or not
+          - complianceType: musthave
+            objectDefinition:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                namespace: openshift-gatekeeper-system
+                labels:
+                  control-plane: controller-manager
+              status:
+                phase: Running   # check the pod status to determine if operator is running or not
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/stable/SI-System-and-Information-Integrity/policy-imagemanifestvuln.yaml
+++ b/stable/SI-System-and-Information-Integrity/policy-imagemanifestvuln.yaml
@@ -36,6 +36,25 @@ spec:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
         metadata:
+          name: policy-imagemanifestvuln-status
+        spec:
+          remediationAction: inform  # will be overridden by remediationAction in parent policy
+          severity: high
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operators.coreos.com/v1alpha1
+                kind: ClusterServiceVersion
+                metadata:
+                  namespace: openshift-operators
+                spec:
+                  displayName: Quay Container Security
+                status:
+                  phase: Succeeded   # check the csv status to determine if operator is running or not
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
           name: policy-imagemanifestvuln-example-imv
         spec:
           remediationAction: inform # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.


### PR DESCRIPTION
Reverts open-cluster-management/policy-collection#206

The original goal in reverting the policy changes was to fix tests in the canaries (tests that had also been updated). However, the tests hadn't actually arrived in the canaries when the change was reverted, so after these changes were reverted the canaries also failed. Restoring the original change should make all tests pass again.