### PR TITLE
OpenShift Plus policy set needs these scripts for initializing

### DIFF
--- a/policygenerator/policy-sets/openshift-plus/README.md
+++ b/policygenerator/policy-sets/openshift-plus/README.md
@@ -1,0 +1,20 @@
+# OpenShift Plus PolicySet
+
+## Installation
+
+The OpenShift Plus PolicySet contains two `PolicySets` that will be deployed.  The OpenShift Plus PolicySet installs everything onto the Advanced Cluster Management hub cluster.  The Advanced Cluster Security Secured Cluster Services and the Compliance Operator are deployed onto all OpenShift managed clusters.
+
+You must perform the steps below to complete the installation of OpenShift Plus after the PolicySets have been
+applied and the policies have all become compliant except the policies:
+
+- policy-advanced-managed-cluster-security
+- policy-acs-central-ca-bundle
+
+**Perform these steps**
+Run the scripts located in the [scripts](scripts) directory.
+
+1. Create the certificate bundle for securely communicating with the Advanced Cluster Security Central server.  Run the command: `./scripts/acs-bundle-secret.sh -i acs-bundle.yaml | oc apply -n policies -f -`  **NOTE** The bundle is saved locally since it cannot be obtained again.  Since this file contains private keys for secure communications to Advanced Cluster Security, you must keep this file securely.
+
+2. Setup the default administrative user for Quay. The administrative username is set to `quayadmin`.  See the
+script for the default password which should be changed.  The script does not require any parameters so simply
+run: `./scripts/init-quay.sh`

--- a/policygenerator/policy-sets/openshift-plus/scripts/acs-bundle-secret.sh
+++ b/policygenerator/policy-sets/openshift-plus/scripts/acs-bundle-secret.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+
+CMDNAME=`basename $0`
+
+# Display help information
+help () {
+  echo "Deploy ACS certificate bundles to all OpenShift managed clusters."
+  echo ""
+  echo "Prerequisites:"
+  echo " - kubectl CLI must be pointing to the cluster where ACS Central server is installed"
+  echo " - roxctl and yq commands must be installed"
+  echo " - ROX_API_TOKEN must be defined as an environment variable"
+  echo " - The init bundles and SecuredClusters must be in the stackrox namespace"
+  echo ""
+  echo "Usage:"
+  echo "  $CMDNAME [-i bundle-file] [-c central-namespace]"
+  echo ""
+  echo "  -h|--help                   Display this menu"
+  echo "  -i|--init <bundle-file>     The central init-bundles file name to save certs to."
+  echo "                                (Default name is cluster-init-bundle.yaml"
+  echo "  -c|--central <namespace>    The central server namespace"
+  echo "                                (Default namespace is stackrox"
+  echo ""
+} >&2
+
+NAMESPACE=stackrox
+CENTRALNS=stackrox
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+        key="$1"
+        case $key in
+            -h|--help)
+            help
+            exit 0
+            ;;
+            -i|--init)
+            shift
+            BUNDLE_FILE=${1}
+            shift
+            ;;
+            -c|--central)
+            shift
+            CENTRALNS=${1}
+            shift
+            ;;
+            *)    # default
+            echo "Invalid input: ${1}" >&2
+            exit 1
+            shift
+            ;;
+        esac
+done
+set -- "${POSITIONAL[@]}" # restore positional parameters
+
+ACS_HOST="$(oc get route -n $CENTRALNS central -o custom-columns=HOST:.spec.host --no-headers):443"
+if [[ -z "$ACS_HOST" ]]; then
+	echo "The ACS route has not been created yet. Deploy Central first." >&2
+	exit 1
+fi
+
+if [[ -z $BUNDLE_FILE ]]; then
+	echo "The '-i|--init <init-bundle>' parameter is required." >&2
+	exit 1
+fi
+
+if [[ -z "$NAMESPACE" ]]; then
+  NAMESPACE=stackrox
+fi
+
+
+if ! [ -x "$(command -v kubectl)" ]; then
+    echo 'Error: kubectl is not installed.' >&2
+    exit 1
+fi
+
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    BASE='base64 -w 0'
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    BASE='base64'
+fi
+
+if [ -f "${BUNDLE_FILE}" ]; then
+	echo "# Using existing bundle file." >&2
+else
+	echo "# Creating new bundle file." >&2
+	PASSWORD=$(oc get secret -n $CENTRALNS central-htpasswd -o jsonpath="{.data.password}" | $BASE -d)
+	DATA={\"name\":\"local-cluster\"}
+	curl -k -o "${BUNDLE_FILE}" -X POST -u "admin:$PASSWORD" -H "Content-Type: application/json" --data $DATA https://$ACS_HOST/v1/cluster-init/init-bundles
+
+	if [ $? -ne 0 ]; then
+		echo "Failed to create the init-bundles required for Secured Cluster services" >&2
+		exit 1
+	fi
+fi
+
+parsebundle() {
+	value="$1"
+	cat ${BUNDLE_FILE} | jq .helmValuesBundle | sed 's/\"//g' | $BASE -d | yq eval $value - | $BASE
+}
+
+cat <<EOF
+---
+apiVersion: v1
+data:
+  admission-control-cert.pem: `parsebundle '.admissionControl.serviceTLS.cert'`
+  admission-control-key.pem: `parsebundle '.admissionControl.serviceTLS.key'`
+  ca.pem: `parsebundle '.ca.cert'`
+kind: Secret
+metadata:
+  annotations:
+    apps.open-cluster-management.io/deployables: "true"
+  name: admission-control-tls
+type: Opaque
+---
+apiVersion: v1
+data:
+  collector-cert.pem: `parsebundle '.collector.serviceTLS.cert'`
+  collector-key.pem: `parsebundle '.collector.serviceTLS.key'`
+  ca.pem: `parsebundle '.ca.cert'`
+kind: Secret
+metadata:
+  annotations:
+    apps.open-cluster-management.io/deployables: "true"
+  name: collector-tls
+type: Opaque
+---
+apiVersion: v1
+data:
+  sensor-cert.pem: `parsebundle '.sensor.serviceTLS.cert'`
+  sensor-key.pem: `parsebundle '.sensor.serviceTLS.key'`
+  ca.pem: `parsebundle '.ca.cert'`
+  acs-host: `echo ${ACS_HOST} | ${BASE}`
+kind: Secret
+metadata:
+  annotations:
+    apps.open-cluster-management.io/deployables: "true"
+  name: sensor-tls
+type: Opaque
+---
+EOF

--- a/policygenerator/policy-sets/openshift-plus/scripts/init-quay.sh
+++ b/policygenerator/policy-sets/openshift-plus/scripts/init-quay.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+QUAYHOST=$(oc get route -n local-quay registry-quay -o jsonpath='{.spec.host}')
+if [ $? -ne 0 ]; then
+	echo "Quay route does not exist yet, please wait and try again."
+	exit 1
+fi
+RESULT=$(curl -X POST -k -s https://$QUAYHOST/api/v1/user/initialize --header 'Content-Type: application/json' --data '{ "username": "quayadmin", "password":"quaypass123", "email": "quayadmin@example.com", "access_token": true}')
+if [ $? -eq 0 ]; then
+	TOKEN=$(echo "$RESULT" | jq .access_token | sed s'/"//g')
+	# Uncomment the next line if you want the access token
+	# echo "Access token for quay: $TOKEN"
+	echo "Quay password successfully set for user quayadmin."
+else
+	echo "Quay user configuration failed"
+	exit 1
+fi


### PR DESCRIPTION
The OpenShift Plus policyset needs some extra help that cannot be
accomplished with just a policy.  An API call needs to be made to
Quay and to ACS in order to:
- initialize the quay admin
- create the CA bundles ACS Sensors use to securely communicate back to
  Central

Refs:
 - https://github.com/stolostron/backlog/issues/19724

Signed-off-by: Gus Parvin <gparvin@redhat.com>