### PR TITLE
Update subscription-admin instructions and policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,7 @@ subjects:
     name: my-username
 ```
 
-After updating the `ClusterRoleBinding`, you can delete the subscription and run the deploy script
-again or simply wait for the subscription controller to synchronize the resources.
+After updating the `ClusterRoleBinding`, you need to delete the subscription and deploy the subscription again.
 
 ### Policy Generator
 

--- a/community/CM-Configuration-Management/policy-configure-subscription-admin-hub.yaml
+++ b/community/CM-Configuration-Management/policy-configure-subscription-admin-hub.yaml
@@ -59,7 +59,10 @@ spec:
                 subjects:
                 - apiGroup: rbac.authorization.k8s.io
                   kind: User
-                  name: kube:admin  
+                  name: kube:admin
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: system:admin
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/policygenerator/subscription.yaml
+++ b/policygenerator/subscription.yaml
@@ -12,7 +12,6 @@ spec:
   componentKinds:
     - group: apps.open-cluster-management.io
       kind: Subscription
-  descriptor: {}
   selector:
     matchExpressions:
       - key: app
@@ -43,13 +42,6 @@ metadata:
   name: policy-generator-demo-subscription
   namespace: policy-generator-demo
 spec:
-  allow:
-    - apiVersion: policy.open-cluster-management.io/v1
-      kinds:
-        - "*"
-    - apiVersion: apps.open-cluster-management.io/v1
-      kinds:
-        - PlacementRule
   channel: policy-generator-demo/policy-generator-demo
   placement:
     placementRef:


### PR DESCRIPTION
I found that when deploying a Subscription as `kube:admin`, the user is `system:admin`, so the Subscription never deploys, even with a binding to `kube:admin`.

Also clarify our docs that the Subscription will not self-reconcile when user permissions change. The Subscription needs to be redeployed.