### PR TITLE
Generate a secret for the quay administrator

### DIFF
--- a/policygenerator/policy-sets/openshift-plus/README.md
+++ b/policygenerator/policy-sets/openshift-plus/README.md
@@ -4,7 +4,9 @@
 
 The OpenShift Plus PolicySet contains two `PolicySets` that will be deployed.  The OpenShift Plus PolicySet installs everything onto the Advanced Cluster Management hub cluster.  The Advanced Cluster Security Secured Cluster Services and the Compliance Operator are deployed onto all OpenShift managed clusters.
 
-You must perform the steps below to complete the installation of OpenShift Plus after the PolicySets have been
+To apply this policy set make sure you have this repository and follow the policy generator instructions located (here)[../..] but making sure to point to this path instead of the default generator sample.
+
+You must also perform the steps below to complete the installation of OpenShift Plus after the PolicySets have been
 applied and the policies have all become compliant except the policies:
 
 - policy-advanced-managed-cluster-security
@@ -15,6 +17,6 @@ Run the scripts located in the [scripts](scripts) directory.
 
 1. Create the certificate bundle for securely communicating with the Advanced Cluster Security Central server.  Run the command: `./scripts/acs-bundle-secret.sh -i acs-bundle.yaml | oc apply -n policies -f -`  **NOTE** The bundle is saved locally since it cannot be obtained again.  Since this file contains private keys for secure communications to Advanced Cluster Security, you must keep this file securely.
 
-2. Setup the default administrative user for Quay. The administrative username is set to `quayadmin`.  See the
-script for the default password which should be changed.  The script does not require any parameters so simply
-run: `./scripts/init-quay.sh`
+2. Setup the default administrative user for Quay. The administrative username is set to `quayadmin`.  
+A password is generated and stored in the `quayadmin` secret in the `local-quay` namespace.
+Run the script with this command: `./scripts/init-quay.sh`

--- a/policygenerator/policy-sets/openshift-plus/scripts/init-quay.sh
+++ b/policygenerator/policy-sets/openshift-plus/scripts/init-quay.sh
@@ -5,13 +5,33 @@ if [ $? -ne 0 ]; then
 	echo "Quay route does not exist yet, please wait and try again."
 	exit 1
 fi
-RESULT=$(curl -X POST -k -s https://$QUAYHOST/api/v1/user/initialize --header 'Content-Type: application/json' --data '{ "username": "quayadmin", "password":"quaypass123", "email": "quayadmin@example.com", "access_token": true}')
+
+RESULT=$(oc get secret -n local-quay quayadmin)
 if [ $? -eq 0 ]; then
+	echo "Quay user configuration secret already exists: quayadmin in namespace local-quay"
+	exit 1
+fi
+
+ADMINPASS=`head -c 8 /dev/urandom | base64 | sed 's/=//'`
+
+RESULT=$(curl -X POST -k -s https://$QUAYHOST/api/v1/user/initialize --header 'Content-Type: application/json' --data "{ \"username\": \"quayadmin\", \"password\":\"${ADMINPASS}\", \"email\": \"quayadmin@example.com\", \"access_token\": true}")
+echo "$RESULT" | grep -q "non-empty database"
+if [ $? -eq 0 ]; then
+	echo "Quay user configuration failed, the database has been initialized."
+	exit 1
+else
+	cat <<EOF | kubectl create -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: quayadmin
+  namespace: local-quay
+type: Opaque
+data:
+  password: $(echo ${ADMINPASS} | base64)
+EOF
 	TOKEN=$(echo "$RESULT" | jq .access_token | sed s'/"//g')
 	# Uncomment the next line if you want the access token
 	# echo "Access token for quay: $TOKEN"
-	echo "Quay password successfully set for user quayadmin."
-else
-	echo "Quay user configuration failed"
-	exit 1
+	echo "Quay password successfully set for user quayadmin and stored in secret local-quay/quayadmin."
 fi


### PR DESCRIPTION
It's better to generate a secret for the quay admin user and put
it in a secret as opposed to relying on the user to modify the
init script and select their own quay administrative password.  This
change prevents a common password from being used.

Refs:
 - https://github.com/stolostron/backlog/issues/19783

Signed-off-by: Gus Parvin <gparvin@redhat.com>