### PR TITLE
Fix problems with ODF and eliminate need for scripts

### DIFF
--- a/policygenerator/policy-sets/openshift-plus/README.md
+++ b/policygenerator/policy-sets/openshift-plus/README.md
@@ -4,17 +4,13 @@
 
 The OpenShift Plus PolicySet contains two `PolicySets` that will be deployed.  The OpenShift Plus PolicySet installs everything onto the Advanced Cluster Management hub cluster.  The Advanced Cluster Security Secured Cluster Services and the Compliance Operator are deployed onto all OpenShift managed clusters.
 
-You must perform the steps below to complete the installation of OpenShift Plus after the PolicySets have been
-applied and the policies have all become compliant except the policies:
+Prior to applying the `PolicySet`, perform these steps:
 
-- policy-advanced-managed-cluster-security
-- policy-acs-central-ca-bundle
+1. Create the namespace `policies`: `oc create ns policies`
+2. Prepare for Red Hat OpenShift Data Foundation by adding worker nodes for storage described [here](https://red-hat-storage.github.io/ocs-training/training/ocs4/ocs.html#_scale_ocp_cluster_and_add_new_worker_nodes)
+3. Create the namespace `openshift-storage`: `oc create ns openshift-storage`
+4. Label the storage namespace: `oc label namespace openshift-storage "openshift.io/cluster-monitoring=true"`
+5. Policies are installed to the `policies` namespace.  Make sure the placement bindings match this namespace for the hub and other managed clusters.
 
-**Perform these steps**
-Run the scripts located in the [scripts](scripts) directory.
-
-1. Create the certificate bundle for securely communicating with the Advanced Cluster Security Central server.  Run the command: `./scripts/acs-bundle-secret.sh -i acs-bundle.yaml | oc apply -n policies -f -`  **NOTE** The bundle is saved locally since it cannot be obtained again.  Since this file contains private keys for secure communications to Advanced Cluster Security, you must keep this file securely.
-
-2. Setup the default administrative user for Quay. The administrative username is set to `quayadmin`.  See the
-script for the default password which should be changed.  The script does not require any parameters so simply
-run: `./scripts/init-quay.sh`
+Apply the policies using the kustomize command or subscribing to a fork of the repository and pointing to this directory.  See 
+the details for using the Policy Generator for more information.  The command to run is `kustomize build --enable-alpha-plugins  | oc apply -f -`

--- a/policygenerator/policy-sets/openshift-plus/input-acm-observability/policy-ocm-observability.yaml
+++ b/policygenerator/policy-sets/openshift-plus/input-acm-observability/policy-ocm-observability.yaml
@@ -8,7 +8,7 @@ stringData:
   thanos.yaml: |
     type: s3
     config:
-      bucket: first.bucket
+      bucket: {{ (lookup "objectbucket.io/v1alpha1" "ObjectBucket" "openshift-storage" "obc-openshift-storage-obc-observability").spec.endpoint.bucketName }}
       endpoint: {{ (index (lookup "noobaa.io/v1alpha1" "NooBaa" "openshift-storage" "noobaa").status.endpoints.virtualHosts 1) }}
       insecure: true
       access_key: {{ fromSecret "openshift-storage" "noobaa-admin" "AWS_ACCESS_KEY_ID" | base64dec }}

--- a/policygenerator/policy-sets/openshift-plus/input-acs-central/policy-acs-operator-central.yaml
+++ b/policygenerator/policy-sets/openshift-plus/input-acs-central/policy-acs-operator-central.yaml
@@ -41,5 +41,5 @@ spec:
         autoScaling: Enabled
         maxReplicas: 5
         minReplicas: 2
-        replicas: 3
+        replicas: 2
     scannerComponent: Enabled

--- a/policygenerator/policy-sets/openshift-plus/input-odf/policy-object-storage.yaml
+++ b/policygenerator/policy-sets/openshift-plus/input-odf/policy-object-storage.yaml
@@ -4,15 +4,53 @@ metadata:
   name: noobaa
   namespace: openshift-storage
 spec:
-dbResources:
-  requests:
-    cpu: '0.1'
-    memory: 1Gi
-dbType: postgres
-coreResources:
-  requests:
-    cpu: '0.1'
-    memory: 1Gi
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: cluster.ocs.openshift.io/openshift-storage
+            operator: Exists
+  cleanupPolicy: {}
+  coreResources:
+    limits:
+      cpu: "1"
+      memory: 4Gi
+    requests:
+      cpu: "1"
+      memory: 4Gi
+  dbResources:
+    limits:
+      cpu: 500m
+      memory: 4Gi
+    requests:
+      cpu: 500m
+      memory: 2Gi
+  dbStorageClass: ocs-storagecluster-ceph-rbd
+  dbType: postgres
+  dbVolumeResources:
+    requests:
+      storage: 50Gi
+  endpoints:
+    maxCount: 2
+    minCount: 1
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+  labels:
+    monitoring: {}
+  pvPoolDefaultStorageClass: ocs-storagecluster-ceph-rbd
+  security:
+    kms: {}
+  tolerations:
+  - effect: NoSchedule
+    key: node.ocs.openshift.io/storage
+    operator: Equal
+    value: "true"
 ---
 apiVersion: noobaa.io/v1alpha1
 kind: BackingStore
@@ -34,7 +72,7 @@ spec:
 apiVersion: noobaa.io/v1alpha1
 kind: BucketClass
 metadata:
-  name: noobaa-default-bucket-class
+  name: noobaa-pv-bucket-class
   namespace: openshift-storage
   labels:
     app: noobaa
@@ -45,3 +83,12 @@ spec:
     tiers:
       - backingStores:
           - noobaa-pv-backing-store
+---
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: obc-observability
+  namespace: openshift-storage
+spec:
+  generateBucketName: obc-observability-bucket
+  storageClassName: openshift-storage.noobaa.io

--- a/policygenerator/policy-sets/openshift-plus/input-odf/policy-odf.yaml
+++ b/policygenerator/policy-sets/openshift-plus/input-odf/policy-odf.yaml
@@ -23,12 +23,35 @@ spec:
   name: odf-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: odf-operator.v4.9.1
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: ocs-operator
+  namespace: openshift-storage
+spec:
+  channel: stable-4.9
+  installPlanApproval: Automatic
+  name: ocs-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: mcg-operator
+  namespace: openshift-storage
+spec:
+  channel: stable-4.9
+  installPlanApproval: Automatic
+  name: mcg-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
 ---
 apiVersion: odf.openshift.io/v1alpha1
 kind: StorageSystem
 metadata:
-  name: odf-storagecluster-storagesystem
+  name: ocs-storagecluster-storagesystem
   namespace: openshift-storage
 spec:
   kind: storagecluster.ocs.openshift.io/v1
@@ -44,17 +67,37 @@ metadata:
   name: ocs-storagecluster
   namespace: openshift-storage
 spec:
+  arbiter: {}
+  encryption:
+    kms: {}
+  externalStorage: {}
+  managedResources:
+    cephBlockPools: {}
+    cephConfig: {}
+    cephDashboard: {}
+    cephFilesystems: {}
+    cephObjectStoreUsers: {}
+    cephObjectStores: {}
+  mirroring: {}
+  nodeTopologies: {}
   storageDeviceSets:
-    - count: 1
-      dataPVCTemplate:
-        spec:
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 512Gi
-          storageClassName: gp2
-          volumeMode: Block
-      name: ocs-deviceset-gp2
-      portable: true
-      replica: 3
+  - config: {}
+    count: 1
+    dataPVCTemplate:
+      metadata: {}
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 2Ti
+        storageClassName: gp2
+        volumeMode: Block
+      status: {}
+    name: ocs-deviceset-gp2
+    placement: {}
+    portable: true
+    preparePlacement: {}
+    replica: 3
+    resources: {}
+  version: 4.9.0

--- a/policygenerator/policy-sets/openshift-plus/input-quay/policy-config-quay.yaml
+++ b/policygenerator/policy-sets/openshift-plus/input-quay/policy-config-quay.yaml
@@ -49,3 +49,118 @@ spec:
       managed: true
     - managed: true
       kind: tls
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: create-admin-user
+  namespace: local-quay
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: create-admin-user
+  namespace: local-quay
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - create
+  - patch
+  - update
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: create-admin-user
+  namespace: local-quay
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: create-admin-user
+subjects:
+- kind: ServiceAccount
+  name: create-admin-user
+  namespace: local-quay
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-admin-user
+  namespace: local-quay
+spec:
+  template:
+    spec:
+      containers:
+      - command:
+        - /bin/bash
+        - -c
+        - |
+          #!/usr/bin/env bash
+
+          # Wait for quay to be ready
+          attempt_counter=0
+          max_attempts=20
+          echo "Waiting for quay to be available..."
+          until $(curl --output /dev/null --silent --head --fail http://registry-quay-app); do
+              if [ ${attempt_counter} -eq ${max_attempts} ];then
+                echo "Max attempts reached"
+                exit 1
+              fi
+
+              printf '.'
+              attempt_counter=$(($attempt_counter+1))
+              echo "Made attempt $attempt_counter, waiting..."
+              sleep 5
+          done
+
+          QUAYHOST=$(oc get route -n local-quay registry-quay -o jsonpath='{.spec.host}')
+          if [ $? -ne 0 ]; then
+            echo "Quay route does not exist yet, please wait and try again."
+            exit 1
+          fi
+          RESULT=$(oc get secret -n local-quay quayadmin)
+          if [ $? -eq 0 ]; then
+            echo "Quay user configuration secret already exists: quayadmin in namespace local-quay"
+            exit 1
+          fi
+
+          ADMINPASS=`head -c 8 /dev/urandom | base64 | sed 's/=//'`
+          
+          RESULT=$(curl -X POST -k -s https://$QUAYHOST/api/v1/user/initialize --header 'Content-Type: application/json' --data "{ \"username\": \"quayadmin\", \"password\":\"${ADMINPASS}\", \"email\": \"quayadmin@example.com\", \"access_token\": true}")
+          echo "$RESULT" | grep -q "non-empty database"
+          if [ $? -eq 0 ]; then
+            echo "Quay user configuration failed, the database has been initialized."
+            exit 1
+          else
+            cat <<EOF | kubectl create -f -
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: quayadmin
+            namespace: local-quay
+          type: Opaque
+          data:
+            password: $(echo ${ADMINPASS} | base64)
+          EOF
+            echo "Quay password successfully set for user quayadmin and stored in secret local-quay/quayadmin."
+          fi
+        image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+        imagePullPolicy: Always
+        name: create-admin-user
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never
+      serviceAccount: create-admin-user
+      serviceAccountName: create-admin-user
+      terminationGracePeriodSeconds: 30

--- a/policygenerator/policy-sets/openshift-plus/input-sensor/policy-acs-central-ca-bundle.yaml
+++ b/policygenerator/policy-sets/openshift-plus/input-sensor/policy-acs-central-ca-bundle.yaml
@@ -1,33 +1,211 @@
 apiVersion: v1
+kind: Namespace
+metadata:
+  name: stackrox
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  name: create-cluster-init
+  namespace: stackrox
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "1"
+  name: create-cluster-init
+  namespace: stackrox
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - create
+  - patch
+  - update
+- apiGroups:
+  - platform.stackrox.io
+  resources:
+  - securedclusters
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  name: create-cluster-init
+  namespace: stackrox
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: create-cluster-init
+subjects:
+- kind: ServiceAccount
+  name: create-cluster-init
+  namespace: stackrox
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "2"
+  name: create-cluster-init-bundle
+  namespace: stackrox
+spec:
+  template:
+    metadata:
+      annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    spec:
+      containers:
+      - command:
+        - /bin/bash
+        - -c
+        - |
+          #!/usr/bin/env bash
+          if kubectl get secret/sensor-tls &> /dev/null; then
+            echo "cluster-init bundle has already been configured, doing nothing"
+            exit 0
+          else
+
+            # Wait for central to be ready
+            attempt_counter=0
+            max_attempts=20
+            echo "Waiting for central to be available..."
+            until $(curl -k --output /dev/null --silent --head --fail https://central); do
+                if [ ${attempt_counter} -eq ${max_attempts} ];then
+                  echo "Max attempts reached"
+                  exit 1
+                fi
+
+                printf '.'
+                attempt_counter=$(($attempt_counter+1))
+                echo "Made attempt $attempt_counter, waiting..."
+                sleep 5
+            done
+
+            echo "Configuring cluster-init bundle"
+            export DATA={\"name\":\"local-cluster\"}
+            curl -k -o /tmp/bundle.json -X POST -u "admin:$PASSWORD" -H "Content-Type: application/json" --data $DATA https://central/v1/cluster-init/init-bundles
+
+            echo "Bundle received"
+            cat /tmp/bundle.json
+
+            if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+                BASE='base64 -w 0'
+            elif [[ "$OSTYPE" == "darwin"* ]]; then
+                BASE='base64'
+            fi
+
+            echo "Applying bundle"
+            # No jq in container, python to the rescue
+            cat /tmp/bundle.json | python3 -c "import sys, json; print(json.load(sys.stdin)['kubectlBundle'])" | ${BASE} -d | oc apply -f -
+            # Touch SecuredCluster to force operator to reconcile
+            oc label SecuredCluster local-cluster cluster-init-job-status=created
+            ACS_HOST="$(oc get route central -o custom-columns=HOST:.spec.host --no-headers):443"
+            oc patch secret sensor-tls --type='json' -p="[{\"op\" : \"add\", \"path\" : \"/data/acs-host\", \"value\" : \"$(echo $ACS_HOST | ${BASE})\"}]"
+
+            echo "ACS Cluster init bundle generated and applied"
+          fi
+        env:
+        - name: PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: central-htpasswd
+        image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+        imagePullPolicy: Always
+        name: create-cluster-init-bundle
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never
+      serviceAccount: create-cluster-init
+      serviceAccountName: create-cluster-init
+      terminationGracePeriodSeconds: 30
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: rhacs-operator
+  namespace: openshift-operators
+spec:
+  channel: latest
+  installPlanApproval: Automatic
+  name: rhacs-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+---
+apiVersion: platform.stackrox.io/v1alpha1
+kind: SecuredCluster
+metadata:
+  name: stackrox-secured-cluster-services
+  namespace: stackrox
+spec:
+  clusterName: |
+    {{ fromSecret "open-cluster-management-agent" "hub-kubeconfig-secret" "cluster-name" | base64dec }}
+  auditLogs:
+    collection: Auto
+  centralEndpoint: |
+    {{ fromSecret "stackrox" "sensor-tls" "acs-host" | base64dec }}
+  admissionControl:
+    listenOnCreates: false
+    listenOnEvents: true
+    listenOnUpdates: false
+  perNode:
+    collector:
+      collection: KernelModule
+      imageFlavor: Regular
+    taintToleration: TolerateTaints
+---
+apiVersion: v1
 data:
-  admission-control-cert.pem: '{{hub fromSecret "" "admission-control-tls" "admission-control-cert.pem" hub}}'
-  admission-control-key.pem: '{{hub fromSecret "" "admission-control-tls" "admission-control-key.pem" hub}}'
-  ca.pem: '{{hub fromSecret "" "admission-control-tls" "ca.pem" hub}}'
+  admission-control-cert.pem: '{{ fromSecret "stackrox" "admission-control-tls" "admission-control-cert.pem" }}'
+  admission-control-key.pem: '{{ fromSecret "stackrox" "admission-control-tls" "admission-control-key.pem" }}'
+  ca.pem: '{{ fromSecret "stackrox" "admission-control-tls" "ca.pem" }}'
 kind: Secret
 metadata:
   name: admission-control-tls
-  namespace: stackrox
+  namespace: policies
 type: Opaque
 ---
 apiVersion: v1
 data:
-  collector-cert.pem: '{{hub fromSecret "" "collector-tls" "collector-cert.pem" hub}}'
-  collector-key.pem: '{{hub fromSecret "" "collector-tls" "collector-key.pem" hub}}'
-  ca.pem: '{{hub fromSecret "" "collector-tls" "ca.pem" hub}}'
+  collector-cert.pem: '{{ fromSecret "stackrox" "collector-tls" "collector-cert.pem" }}'
+  collector-key.pem: '{{ fromSecret "stackrox" "collector-tls" "collector-key.pem" }}'
+  ca.pem: '{{ fromSecret "stackrox" "collector-tls" "ca.pem" }}'
 kind: Secret
 metadata:
   name: collector-tls
-  namespace: stackrox
+  namespace: policies
 type: Opaque
 ---
 apiVersion: v1
 data:
-  sensor-cert.pem: '{{hub fromSecret "" "sensor-tls" "sensor-cert.pem" hub}}'
-  sensor-key.pem: '{{hub fromSecret "" "sensor-tls" "sensor-key.pem" hub}}'
-  ca.pem: '{{hub fromSecret "" "sensor-tls" "ca.pem" hub}}'
-  acs-host: '{{hub fromSecret "" "sensor-tls" "acs-host" hub}}'
+  sensor-cert.pem: '{{ fromSecret "stackrox" "sensor-tls" "sensor-cert.pem" }}'
+  sensor-key.pem: '{{ fromSecret "stackrox" "sensor-tls" "sensor-key.pem" }}'
+  ca.pem: '{{ fromSecret "stackrox" "sensor-tls" "ca.pem" }}'
+  acs-host: '{{ fromSecret "stackrox" "sensor-tls" "acs-host" }}'
 kind: Secret
 metadata:
   name: sensor-tls
-  namespace: stackrox
+  namespace: policies
 type: Opaque

--- a/policygenerator/policy-sets/openshift-plus/input-sensor/policy-advanced-managed-cluster-security.yaml
+++ b/policygenerator/policy-sets/openshift-plus/input-sensor/policy-advanced-managed-cluster-security.yaml
@@ -36,3 +36,37 @@ spec:
       collection: KernelModule
       imageFlavor: Regular
     taintToleration: TolerateTaints
+---
+apiVersion: v1
+data:
+  admission-control-cert.pem: '{{hub fromSecret "stackrox" "admission-control-tls" "admission-control-cert.pem" hub}}'
+  admission-control-key.pem: '{{hub fromSecret "stackrox" "admission-control-tls" "admission-control-key.pem" hub}}'
+  ca.pem: '{{hub fromSecret "stackrox" "admission-control-tls" "ca.pem" hub}}'
+kind: Secret
+metadata:
+  name: admission-control-tls
+  namespace: stackrox
+type: Opaque
+---
+apiVersion: v1
+data:
+  collector-cert.pem: '{{hub fromSecret "stackrox" "collector-tls" "collector-cert.pem" hub}}'
+  collector-key.pem: '{{hub fromSecret "stackrox" "collector-tls" "collector-key.pem" hub}}'
+  ca.pem: '{{hub fromSecret "stackrox" "collector-tls" "ca.pem" hub}}'
+kind: Secret
+metadata:
+  name: collector-tls
+  namespace: stackrox
+type: Opaque
+---
+apiVersion: v1
+data:
+  sensor-cert.pem: '{{hub fromSecret "stackrox" "sensor-tls" "sensor-cert.pem" hub}}'
+  sensor-key.pem: '{{hub fromSecret "stackrox" "sensor-tls" "sensor-key.pem" hub}}'
+  ca.pem: '{{hub fromSecret "stackrox" "sensor-tls" "ca.pem" hub}}'
+  acs-host: '{{hub fromSecret "stackrox" "sensor-tls" "acs-host" hub}}'
+kind: Secret
+metadata:
+  name: sensor-tls
+  namespace: stackrox
+type: Opaque

--- a/policygenerator/policy-sets/openshift-plus/input/clusters-placement.yaml
+++ b/policygenerator/policy-sets/openshift-plus/input/clusters-placement.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.open-cluster-management.io/v1alpha1
+apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
   name: placement-openshift-plus-clusters
@@ -9,3 +9,4 @@ spec:
       labelSelector:
         matchExpressions:
           - {key: vendor, operator: In, values: ["OpenShift"]}
+          - {key: name, operator: NotIn, values: ["local-cluster"]}

--- a/policygenerator/policy-sets/openshift-plus/input/hub-placement.yaml
+++ b/policygenerator/policy-sets/openshift-plus/input/hub-placement.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.open-cluster-management.io/v1alpha1
+apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
   name: placement-openshift-plus-hub

--- a/policygenerator/policy-sets/openshift-plus/policyGenerator.yaml
+++ b/policygenerator/policy-sets/openshift-plus/policyGenerator.yaml
@@ -61,6 +61,7 @@ policies:
     - path: input-compliance/
   policySets:
     - openshift-plus-clusters
+    - openshift-plus-hub
 - name: policy-advanced-managed-cluster-security
   categories:
     - SI System and Information Integrity


### PR DESCRIPTION
There were some problems with the ODF install.  The operator now
installs and the storagesystem and the storagecluster are properly
setup.  Observability I think is still have trouble writing to noobaa,
but there are statistics and details that show things are closer to
working properly.  While I made those changes I also eliminated the
scripts required by taking Andrew's advice and incorporating the post
scripts as jobs that run in the local-quay and stackrox namespaces
to setup secrets those apps need.

Signed-off-by: Gus Parvin <gparvin@redhat.com>