### PR TITLE
Wrong namespace used for new managed cluster hub templates

### DIFF
--- a/policygenerator/policy-sets/openshift-plus/input-sensor/policy-advanced-managed-cluster-security.yaml
+++ b/policygenerator/policy-sets/openshift-plus/input-sensor/policy-advanced-managed-cluster-security.yaml
@@ -15,6 +15,40 @@ spec:
   source: redhat-operators
   sourceNamespace: openshift-marketplace
 ---
+apiVersion: v1
+data:
+  admission-control-cert.pem: '{{hub fromSecret "policies" "admission-control-tls" "admission-control-cert.pem" hub}}'
+  admission-control-key.pem: '{{hub fromSecret "policies" "admission-control-tls" "admission-control-key.pem" hub}}'
+  ca.pem: '{{hub fromSecret "policies" "admission-control-tls" "ca.pem" hub}}'
+kind: Secret
+metadata:
+  name: admission-control-tls
+  namespace: stackrox
+type: Opaque
+---
+apiVersion: v1
+data:
+  collector-cert.pem: '{{hub fromSecret "policies" "collector-tls" "collector-cert.pem" hub}}'
+  collector-key.pem: '{{hub fromSecret "policies" "collector-tls" "collector-key.pem" hub}}'
+  ca.pem: '{{hub fromSecret "policies" "collector-tls" "ca.pem" hub}}'
+kind: Secret
+metadata:
+  name: collector-tls
+  namespace: stackrox
+type: Opaque
+---
+apiVersion: v1
+data:
+  sensor-cert.pem: '{{hub fromSecret "policies" "sensor-tls" "sensor-cert.pem" hub}}'
+  sensor-key.pem: '{{hub fromSecret "policies" "sensor-tls" "sensor-key.pem" hub}}'
+  ca.pem: '{{hub fromSecret "policies" "sensor-tls" "ca.pem" hub}}'
+  acs-host: '{{hub fromSecret "policies" "sensor-tls" "acs-host" hub}}'
+kind: Secret
+metadata:
+  name: sensor-tls
+  namespace: stackrox
+type: Opaque
+---
 apiVersion: platform.stackrox.io/v1alpha1
 kind: SecuredCluster
 metadata:
@@ -36,37 +70,3 @@ spec:
       collection: KernelModule
       imageFlavor: Regular
     taintToleration: TolerateTaints
----
-apiVersion: v1
-data:
-  admission-control-cert.pem: '{{hub fromSecret "stackrox" "admission-control-tls" "admission-control-cert.pem" hub}}'
-  admission-control-key.pem: '{{hub fromSecret "stackrox" "admission-control-tls" "admission-control-key.pem" hub}}'
-  ca.pem: '{{hub fromSecret "stackrox" "admission-control-tls" "ca.pem" hub}}'
-kind: Secret
-metadata:
-  name: admission-control-tls
-  namespace: stackrox
-type: Opaque
----
-apiVersion: v1
-data:
-  collector-cert.pem: '{{hub fromSecret "stackrox" "collector-tls" "collector-cert.pem" hub}}'
-  collector-key.pem: '{{hub fromSecret "stackrox" "collector-tls" "collector-key.pem" hub}}'
-  ca.pem: '{{hub fromSecret "stackrox" "collector-tls" "ca.pem" hub}}'
-kind: Secret
-metadata:
-  name: collector-tls
-  namespace: stackrox
-type: Opaque
----
-apiVersion: v1
-data:
-  sensor-cert.pem: '{{hub fromSecret "stackrox" "sensor-tls" "sensor-cert.pem" hub}}'
-  sensor-key.pem: '{{hub fromSecret "stackrox" "sensor-tls" "sensor-key.pem" hub}}'
-  ca.pem: '{{hub fromSecret "stackrox" "sensor-tls" "ca.pem" hub}}'
-  acs-host: '{{hub fromSecret "stackrox" "sensor-tls" "acs-host" hub}}'
-kind: Secret
-metadata:
-  name: sensor-tls
-  namespace: stackrox
-type: Opaque


### PR DESCRIPTION
The ACS Sensor secrets were pulling from the wrong namespace -- likely
a copy/paste issue from moving code around to support the job that
creates the secrets a little differently.  It worked fine on the hub,
but creating a managed cluster showed the issue.

I also had to move the SecuredCluster resource so that it was after
the secrets.  The SecuredCluster errored the policy out so the
secrets were never created, and they need to be there first.

Refs:
 - https://github.com/stolostron/backlog/issues/20093

Signed-off-by: Gus Parvin <gparvin@redhat.com>