### PR TITLE
Move the placement api version to v1beta1

### DIFF
--- a/policygenerator/policy-sets/acm-hardening/input/placement.yaml
+++ b/policygenerator/policy-sets/acm-hardening/input/placement.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.open-cluster-management.io/v1alpha1
+apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
   name: placement-acm-hardening

--- a/policygenerator/policy-sets/openshift-hardening/input/placement.yaml
+++ b/policygenerator/policy-sets/openshift-hardening/input/placement.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.open-cluster-management.io/v1alpha1
+apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: Placement
 metadata:
   name: placement-openshift-hardening


### PR DESCRIPTION
The v1alpha1 placement api is being deprecated so we want the samples
to all use the v1beta1 api.  I moved ocp plus to the new one, but forgot
to do these too.

Refs:
 - https://github.com/stolostron/backlog/issues/20094

Signed-off-by: Gus Parvin <gparvin@redhat.com>