### PR TITLE
Add status checks to the openshift plus policyset

### DIFF
--- a/policygenerator/policy-sets/openshift-plus/input-acs-central/policy-acs-central-status.yaml
+++ b/policygenerator/policy-sets/openshift-plus/input-acs-central/policy-acs-central-status.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: central
+  namespace: stackrox
+status:
+  conditions:
+    - status: "True"
+      type: Available
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scanner-db
+  namespace: stackrox
+status:
+  conditions:
+    - status: "True"
+      type: Available
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scanner
+  namespace: stackrox
+status:
+  conditions:
+    - status: "True"
+      type: Available

--- a/policygenerator/policy-sets/openshift-plus/input-odf/policy-odf-status.yaml
+++ b/policygenerator/policy-sets/openshift-plus/input-odf/policy-odf-status.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: noobaa-operator
+  namespace: openshift-storage
+status:
+  conditions:
+    - status: "True"
+      type: Available
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ocs-operator
+  namespace: openshift-storage
+status:
+  conditions:
+    - status: "True"
+      type: Available
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: odf-operator-controller-manager
+  namespace: openshift-storage
+status:
+  conditions:
+    - status: "True"
+      type: Available

--- a/policygenerator/policy-sets/openshift-plus/input-quay/policy-quay-status.yaml
+++ b/policygenerator/policy-sets/openshift-plus/input-quay/policy-quay-status.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: registry-quay-app
+  namespace: local-quay
+status:
+  conditions:
+    - status: "True"
+      type: Available
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: registry-quay-database
+  namespace: local-quay
+status:
+  conditions:
+    - status: "True"
+      type: Available

--- a/policygenerator/policy-sets/openshift-plus/input-sensor/policy-advanced-managed-cluster-status.yaml
+++ b/policygenerator/policy-sets/openshift-plus/input-sensor/policy-advanced-managed-cluster-status.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sensor
+  namespace: stackrox
+status:
+  conditions:
+    - status: "True"
+      type: Available
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: collector
+  namespace: stackrox
+status:
+  numberMisscheduled: 0

--- a/policygenerator/policy-sets/openshift-plus/kustomization.yml
+++ b/policygenerator/policy-sets/openshift-plus/kustomization.yml
@@ -1,4 +1,4 @@
 generators:
 - ./policyGenerator.yaml
 commonLabels:
-  open-cluster-management.io/policy-set: openshift-plus-hub
+  open-cluster-management.io/policy-set: openshift-plus

--- a/policygenerator/policy-sets/openshift-plus/policyGenerator.yaml
+++ b/policygenerator/policy-sets/openshift-plus/policyGenerator.yaml
@@ -30,21 +30,45 @@ policies:
   controls: 
     - SC-1 Policy and Procedures
   manifests:
-    - path: input-acs-central/
+    - path: input-acs-central/policy-acs-operator-central.yaml
+- name: policy-acs-central-status
+  categories:
+    - SI System and Information Integrity
+  controls:
+    - SI-5 Security Alerts, Advisories, and Directives
+  manifests:
+    - path: input-acs-central/policy-acs-central-status.yaml
+  remediationAction: inform
 - name: policy-odf
   categories:
     - SI System and Information Integrity
   controls: 
     - SI-7 Software, Firmware, and Information Integrity
   manifests:
-    - path: input-odf/
+    - path: input-odf/policy-odf.yaml
+- name: policy-odf-status
+  categories:
+    - SI System and Information Integrity
+  controls: 
+    - SI-7 Software, Firmware, and Information Integrity
+  manifests:
+    - path: input-odf/policy-odf-status.yaml
+  remediationAction: inform
 - name: policy-config-quay
   categories:
     - SI System and Information Integrity
   controls: 
     - SI-7 Software, Firmware, and Information Integrity
   manifests:
-    - path: input-quay/
+    - path: input-quay/policy-config-quay.yaml
+- name: policy-quay-status
+  categories:
+    - SI System and Information Integrity
+  controls:
+    - SI-7 Software, Firmware, and Information Integrity
+  manifests:
+    - path: input-quay/policy-quay-status.yaml
+  remediationAction: inform
 - name: policy-acs-central-ca-bundle
   categories:
     - SI System and Information Integrity
@@ -71,6 +95,17 @@ policies:
     - path: input-sensor/policy-advanced-managed-cluster-security.yaml
   policySets:
     - openshift-plus-clusters
+- name: policy-advanced-managed-cluster-status
+  categories:
+    - SI System and Information Integrity
+  controls:
+    - SI-5 Security Alerts, Advisories, and Directives
+  manifests:
+    - path: input-sensor/policy-advanced-managed-cluster-status.yaml
+  policySets:
+    - openshift-plus-hub
+    - openshift-plus-clusters
+  remediationAction: inform
 policySets:
   - description: The OpenShift Platform Plus policy set applies several policies
       that installs the OpenShift Platform Plus products using best practices


### PR DESCRIPTION
When a policy deploys an operator it is a best practices to have some
checks that the operator is able to successfully bring up the
needed resources.  This pr adds some checks to make sure
deployments are available which the operator should be starting.

Refs:
 - https://github.com/stolostron/backlog/issues/20097

Signed-off-by: Gus Parvin <gparvin@redhat.com>