### PR TITLE
Increase the timing for the quay config job

### DIFF
--- a/policygenerator/policy-sets/openshift-plus/input-quay/policy-config-quay.yaml
+++ b/policygenerator/policy-sets/openshift-plus/input-quay/policy-config-quay.yaml
@@ -111,7 +111,7 @@ spec:
 
           # Wait for quay to be ready
           attempt_counter=0
-          max_attempts=20
+          max_attempts=80
           echo "Waiting for quay to be available..."
           until $(curl --output /dev/null --silent --head --fail http://registry-quay-app); do
               if [ ${attempt_counter} -eq ${max_attempts} ];then
@@ -122,7 +122,7 @@ spec:
               printf '.'
               attempt_counter=$(($attempt_counter+1))
               echo "Made attempt $attempt_counter, waiting..."
-              sleep 5
+              sleep 30
           done
 
           QUAYHOST=$(oc get route -n local-quay registry-quay -o jsonpath='{.spec.host}')


### PR DESCRIPTION
The goal of the PR is to fix cases where it takes a while for quay
to initialize when all of OCP Plus is being installed.  The install
appears to take around 20 minutes so I am aiming for about double
that amount of time for the timeout.

Refs:
 - https://github.com/stolostron/backlog/issues/20363

Signed-off-by: Gus Parvin <gparvin@redhat.com>