### PR TITLE
test-IAM-policy-in-policy-generator

### DIFF
--- a/policygenerator/policy-sets/openshift-hardening/input-admin/policy-limitclusteradmin.yaml
+++ b/policygenerator/policy-sets/openshift-hardening/input-admin/policy-limitclusteradmin.yaml
@@ -1,24 +1,11 @@
 apiVersion: policy.open-cluster-management.io/v1
-kind: Policy
+kind: IamPolicy # limit clusteradminrole and report violation
 metadata:
-  name: policy-limitclusteradmin
-  annotations:
-    policy.open-cluster-management.io/standards: NIST SP 800-53
-    policy.open-cluster-management.io/categories: AC Access Control
-    policy.open-cluster-management.io/controls: AC-3 Access Enforcement
+  name: policy-limitclusteradmin-example
 spec:
-  remediationAction: inform
-  disabled: false
-  policy-templates:
-    - objectDefinition:
-        apiVersion: policy.open-cluster-management.io/v1
-        kind: IamPolicy # limit clusteradminrole and report violation
-        metadata:
-          name: policy-limitclusteradmin-example
-        spec:
-          severity: medium
-          namespaceSelector:
-            include: ["*"]
-            exclude: ["kube-*", "openshift-*"]
-          remediationAction: inform # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
-          maxClusterRoleBindingUsers: 5
+  severity: medium
+  namespaceSelector:
+    include: ["*"]
+    exclude: ["kube-*", "openshift-*"]
+  remediationAction: inform # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
+  maxClusterRoleBindingUsers: 5

--- a/policygenerator/policy-sets/openshift-hardening/policyGenerator.yaml
+++ b/policygenerator/policy-sets/openshift-hardening/policyGenerator.yaml
@@ -17,9 +17,16 @@ policyDefaults:
   standards:
     - NIST SP 800-53
 policies:
-#- name: policy-limitclusteradmin # iam policy not supported by the generator
-#  manifests:
-#    - path: input-admin/policy-limitclusteradmin.yaml
+- name: policy-limitclusteradmin # iam policy not supported by the generator
+  standards: 
+    - NIST SP 800-53
+  categories: 
+    - AC Access Control
+  controls: 
+    - AC-3 Access Enforcement
+  remediationAction: inform
+  manifests:
+    - path: input-admin/policy-limitclusteradmin.yaml
 - name: policy-remove-kubeadmin
   categories:
     - SC System and Communications Protection


### PR DESCRIPTION
Signed-off-by: Chunxi Luo <chuluo@redhat.com>

@gparvin 

1) So as this PR, if we just put `objectDefinition` section in the policy manifest `policy-limitclusteradmin.yaml` and move the rest higher-level info into `policyGenerator.yaml`, then we got the below result in the output:

```
apiVersion: policy.open-cluster-management.io/v1
kind: Policy
metadata:
  annotations:
    policy.open-cluster-management.io/categories: AC Access Control
    policy.open-cluster-management.io/controls: AC-3 Access Enforcement
    policy.open-cluster-management.io/standards: NIST SP 800-53
  labels:
    open-cluster-management.io/policy-set: openshift-hardening
  name: policy-limitclusteradmin
  namespace: policies
spec:
  disabled: false
  policy-templates:
  - objectDefinition:
      apiVersion: policy.open-cluster-management.io/v1
      kind: ConfigurationPolicy
      metadata:
        name: policy-limitclusteradmin
      spec:
        object-templates:
        - complianceType: musthave
          objectDefinition:
            apiVersion: policy.open-cluster-management.io/v1
            kind: IamPolicy
            metadata:
              name: policy-limitclusteradmin-example
            spec:
              maxClusterRoleBindingUsers: 5
              namespaceSelector:
                exclude:
                - kube-*
                - openshift-*
                include:
                - '*'
              remediationAction: inform
              severity: medium
        remediationAction: inform
        severity: medium
```
2) Current policy-generator + policy-collection will get the below result in the output, we can find policy-generator just treat the policy manifest `policy-limitclusteradmin.yaml`  as an `objectDefinition` section, that is the reason of nested `policy-templates`. If we need to keep the policy manifest `policy-limitclusteradmin.yaml`  as current format, then we should add an additional boolean flag in the policy section of `policyGenerator.yaml` to let policy-generator subtract `objectDefinition` part from the policy manifest, rather than read the whole manifest as an `objectDefinition` section.

Feel free to let me know which direction we should go.


```
apiVersion: policy.open-cluster-management.io/v1
kind: Policy
metadata:
  annotations:
    policy.open-cluster-management.io/categories: CM Configuration Management
    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
    policy.open-cluster-management.io/standards: NIST SP 800-53
  labels:
    open-cluster-management.io/policy-set: openshift-hardening
  name: policy-limitclusteradmin
  namespace: policies
spec:
  disabled: false
  policy-templates:
  - objectDefinition:
      apiVersion: policy.open-cluster-management.io/v1
      kind: ConfigurationPolicy
      metadata:
        name: policy-limitclusteradmin
      spec:
        object-templates:
        - complianceType: musthave
          objectDefinition:
            apiVersion: policy.open-cluster-management.io/v1
            kind: Policy
            metadata:
              annotations:
                policy.open-cluster-management.io/categories: AC Access Control
                policy.open-cluster-management.io/controls: AC-3 Access Enforcement
                policy.open-cluster-management.io/standards: NIST SP 800-53
              name: policy-limitclusteradmin
            spec:
              disabled: false
              policy-templates:
              - objectDefinition:
                  apiVersion: policy.open-cluster-management.io/v1
                  kind: IamPolicy
                  metadata:
                    name: policy-limitclusteradmin-example
                  spec:
                    maxClusterRoleBindingUsers: 5
                    namespaceSelector:
                      exclude:
                      - kube-*
                      - openshift-*
                      include:
                      - '*'
                    remediationAction: inform
                    severity: medium
              remediationAction: inform
        remediationAction: enforce
        severity: medium
```