### PR TITLE
Implement `--dry-run` and `--deploy-app` flags for `deploy.sh`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+deploy/manifests.yaml

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -8,8 +8,8 @@ You must meet the following prerequisites before you deploy policies with the sc
 
 - Your `oc` or `kubectl` CLI must be configured and able to access the cluster to which you want to
   deploy.
-- You must have an existing cluster namespace on the cluster to which you select to deploy.
-- starting in 2.4 you need to be Subscription-Admin. One option is to execute: `community/CM-Configuration-Management/policy-configure-subscription-admin-hub` 
+- Starting in 2.4 you need to be Subscription-Admin. One option is to execute:
+  [`community/CM-Configuration-Management/policy-configure-subscription-admin-hub`](../community/CM-Configuration-Management/policy-configure-subscription-admin-hub.yaml)
   from the command-line and set it to enforce.
 
 View the following guidance on how to use the script (all parameters are optional--any parameters
@@ -17,7 +17,8 @@ not provided will use the defaults specified):
 
 ```
 Usage:
-  ./deploy.sh [-u <url>] [-b <branch>] [-p <path/to/dir>] [-n <namespace>] [-a|--name <resource-name>] [-s|--sync <rate>]
+  ./deploy.sh [-u <url>] [-b <branch>] [-p <path/to/dir>] [-n <namespace>]
+              [-a|--name <resource-name>] [--deploy-app] [--dry-run]
 
   -h|--help                   Display this menu
   -u|--url <url>              URL to the Git repository
@@ -30,8 +31,10 @@ Usage:
                                 (Default namespace: "policies")
   -a|--name <resource-name>   Prefix for the Channel and Subscription resources
                                 (Default name: "demo-stable-policies")
-  -s|--sync <rate>            How frequently the github resources are compared to the hub resources"
+  -s|--sync <rate>            How frequently the github resources are compared to the hub resources
                                 (Default rate: "medium") Rates: "high", "medium", "low", "off"
+  --deploy-app                Create an Application manifest for additional visibility in the UI
+  --dry-run                   Print the YAML to stdout without applying them to the cluster
 ```
 
 For more details on the `sync` parameter values, see the git subscription chapter
@@ -39,8 +42,11 @@ For more details on the `sync` parameter values, see the git subscription chapte
 
 ## Remove resources
 
-Find and remove resources that are created with the `deploy.sh` script from Red Hat Advanced Cluster
-Management. You must meet the following prerequisites before you remove resources with the
+You can either use `remove.sh` to search for and remove resources from Open Cluster Management that
+are created with the `deploy.sh` script, or you can use `kubectl delete -f manifests.yaml` if
+`deploy.sh` has not been run since the manifests were generated and deployed to the cluster.
+
+To use `remove.sh`, you must meet the following prerequisites before you remove resources with the
 `remove.sh` script:
 
 - Your `oc` or `kubectl` CLI must be configured and able to access to the resources that you want to

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -33,7 +33,8 @@ Usage:
                                 (Default name: "demo-stable-policies")
   -s|--sync <rate>            How frequently the github resources are compared to the hub resources
                                 (Default rate: "medium") Rates: "high", "medium", "low", "off"
-  --deploy-app                Create an Application manifest for additional visibility in the UI
+  --deploy-app                Create an Application and Placement manifest for additional visibility 
+                                in the UI (Search should also be enabled in the Hub cluster)
   --dry-run                   Print the YAML to stdout without applying them to the cluster
 ```
 

--- a/deploy/application.yaml
+++ b/deploy/application.yaml
@@ -1,0 +1,16 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: demo-stable-policies-app
+  namespace: policies
+spec:
+  componentKinds:
+    - group: apps.open-cluster-management.io
+      kind: Subscription
+  descriptor: {}
+  selector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values:
+          - demo-stable-policies

--- a/deploy/application_template.json
+++ b/deploy/application_template.json
@@ -1,0 +1,12 @@
+[
+    {
+        "op": "replace",
+        "path": "/metadata/name",
+        "value": "##NAME##-app"
+    },
+    {
+        "op": "replace",
+        "path": "/spec/selector/matchExpressions/0/values/0",
+        "value": "##NAME##"
+    }
+]

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -9,10 +9,10 @@ help () {
   echo ""
   echo "Prerequisites:"
   echo " - oc or kubectl CLI must be pointing to the cluster to which to deploy policies"
-  echo " - The desired cluster namespace should already exist"
   echo ""
   echo "Usage:"
-  echo "  ./deploy.sh [-u <url>] [-b <branch>] [-p <path/to/dir>] [-n <namespace>] [-a|--name <resource-name>]"
+  echo "  ./deploy.sh [-u <url>] [-b <branch>] [-p <path/to/dir>] [-n <namespace>]"
+  echo "              [-a|--name <resource-name>] [--deploy-app] [--dry-run]"
   echo ""
   echo "  -h|--help                   Display this menu"
   echo "  -u|--url <url>              URL to the Git repository"
@@ -27,6 +27,8 @@ help () {
   echo '                                (Default name: "demo-stable-policies")'
   echo "  -s|--sync <rate>            How frequently the github resources are compared to the hub resources"
   echo '                                (Default rate: "medium") Rates: "high", "medium", "low", "off"'
+  echo "  --deploy-app                Create an Application manifest for additional visibility in the UI"
+  echo "  --dry-run                   Print the YAML to stdout without applying them to the cluster"
   echo ""
 }
 
@@ -68,6 +70,14 @@ while [[ $# -gt 0 ]]; do
             RATE=${1}
             shift
             ;;
+            --deploy-app)
+            shift
+            DEPLOY_APP="true"
+            ;;
+            --dry-run)
+            shift
+            DRY_RUN="true"
+            ;;
             *)    # default
             echo "Invalid input: ${1}"
             exit 1
@@ -87,6 +97,8 @@ echo "Git URL:            ${GH_URL:=https://github.com/stolostron/policy-collect
 echo "Git Branch:         ${GH_BRANCH:=main}"
 echo "Git Path:           ${GH_PATH:=stable}"
 echo "Sync Rate:          ${RATE:=medium}"
+echo "Create Application: ${DEPLOY_APP:=false}"
+echo "Dry run:            ${DRY_RUN:=false}"
 echo "====================================================="
 
 while read -r -p "Would you like to proceed (y/n)? " response; do
@@ -97,6 +109,22 @@ while read -r -p "Would you like to proceed (y/n)? " response; do
                   ;;
   esac
 done
+
+if [ "$DRY_RUN" != "true" ]; then
+  # Check for the namespace
+  echo "* Checking for namespace ${NAMESPACE}"
+  if ! kubectl get ns ${NAMESPACE} &>/dev/null; then
+    while read -r -p "Namespace '${NAMESPACE}' not found. Would you like to create it (y/n)? " response; do
+      case "$response" in
+        Y|y|Yes|yes ) kubectl create ns "${NAMESPACE}"
+                      break
+                      ;;
+        N|n|No|no )   exit 1
+                      ;;
+      esac
+    done
+  fi
+fi
 
 # Populate the Channel template
 CHAN_CFG=$(cat "channel_template.json" |
@@ -113,18 +141,33 @@ SUBSCRIPTION_CFG=$(cat "subscription_template.json" |
   sed "s/##NAMESPACE##/${NAMESPACE}/g")
 echo "$SUBSCRIPTION_CFG" > subscription_patch.json
 
+# Populate the Application template
+APPLICATION_CFG=$(cat "application_template.json" |
+  sed "s/##NAME##/${NAME}/g")
+echo "$APPLICATION_CFG" > application_patch.json
+
 # Populate the Kustomize template
 KUST_CFG=$(cat "kustomization_template.yaml" |
   sed "s/##NAME##/${NAME}/g" |
   sed "s/##NAMESPACE##/${NAMESPACE}/g")
+if [ "${DEPLOY_APP}" = "true" ]; then
+  KUST_CFG=$(echo "$KUST_CFG" | sed "s/##//g")
+fi
 echo "$KUST_CFG" > kustomization.yaml
 
 # Deploy the resources to the cluster
-kubectl kustomize . > resources.yaml
-kubectl apply -f resources.yaml
+kubectl kustomize . > manifests.yaml
+echo "* Subscription manifests saved to 'manifests.yaml'"
+if [ "$DRY_RUN" = "true" ]; then
+  echo "* Dry-run is enabled. Not creating resources on cluster."
+  echo "* Displaying manifests from manifests.yaml:"
+  echo "---"
+  cat manifests.yaml
+else
+  printf ""
+  kubectl apply -f manifests.yaml
+fi
 
 # Remove artifacts
-rm channel_patch.json
-rm subscription_patch.json
+rm *_patch.json
 rm kustomization.yaml
-rm resources.yaml

--- a/deploy/kustomization_template.yaml
+++ b/deploy/kustomization_template.yaml
@@ -15,6 +15,7 @@ resources:
   - channel.yaml
   - subscription.yaml
 ##  - application.yaml
+##  - placement.yaml
 
 patchesJson6902:
 ##- path: application_patch.json
@@ -23,6 +24,18 @@ patchesJson6902:
 ##    version: v1
 ##    kind: Application
 ##    name: demo-stable-policies-app
+##- path: placement_patch.json
+##  target:
+##    group: apps.open-cluster-management.io
+##    version: v1
+##    kind: PlacementRule
+##    name: demo-stable-policies-placement
+##- path: subscription_placement_patch.json
+##  target:
+##    group: apps.open-cluster-management.io
+##    version: v1
+##    kind: Subscription
+##    name: demo-stable-policies-sub
 - path: subscription_patch.json
   target:
     group: apps.open-cluster-management.io

--- a/deploy/kustomization_template.yaml
+++ b/deploy/kustomization_template.yaml
@@ -4,6 +4,8 @@ kind: Kustomization
 
 # namespace to deploy all Resources to
 namespace: ##NAMESPACE##
+commonLabels:
+  app: ##NAME##
 
 generatorOptions:
   disableNameSuffixHash: true
@@ -12,8 +14,15 @@ generatorOptions:
 resources:
   - channel.yaml
   - subscription.yaml
+##  - application.yaml
 
 patchesJson6902:
+##- path: application_patch.json
+##  target:
+##    group: app.k8s.io
+##    version: v1
+##    kind: Application
+##    name: demo-stable-policies-app
 - path: subscription_patch.json
   target:
     group: apps.open-cluster-management.io

--- a/deploy/placement.yaml
+++ b/deploy/placement.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: demo-stable-policies-placement
+spec:
+  clusterConditions:
+    - status: "True"
+      type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      - key: local-cluster
+        operator: In
+        values:
+          - "true"

--- a/deploy/placement_template.json
+++ b/deploy/placement_template.json
@@ -1,0 +1,7 @@
+[
+  {
+      "op": "replace",
+      "path": "/metadata/name",
+      "value": "##NAME##-placement"
+  }
+]

--- a/deploy/remove.sh
+++ b/deploy/remove.sh
@@ -145,17 +145,27 @@ if [[ "${RESOURCE}-chan" != "${CHANREF}" ]]; then
   exit 1
 fi
 
+# Check for Application resource
+APP_FOUND=$(kubectl get app -n ${NAMESPACE} ${PREFIX}-app &>/dev/null && echo "true")
+
 # Delete Subscription and Channel resources
 echo "This will delete these resources as well as resources they have deployed:"
+if [ "${APP_FOUND}" = "true" ]; then
+  echo "- Application:  ${RESOURCE}-app"
+fi
 echo "- Channel:      ${RESOURCE}-chan"
 echo "- Subscription: ${RESOURCE}-sub"
 while read -r -p "Would you like to proceed (y/n)? " response; do
   case "$response" in
-    Y|y|Yes|yes ) kubectl delete appsub -n ${NAMESPACE} ${PREFIX}-sub
-                  kubectl delete channels -n ${NAMESPACE} ${PREFIX}-chan
-                  break
+    Y|y|Yes|yes ) break
                   ;;
     N|n|No|no )   exit 1
                   ;;
   esac
 done
+
+if [ "${APP_FOUND}" = "true" ]; then
+  kubectl delete app -n ${NAMESPACE} ${PREFIX}-app
+fi
+kubectl delete appsub -n ${NAMESPACE} ${PREFIX}-sub
+kubectl delete channels -n ${NAMESPACE} ${PREFIX}-chan

--- a/deploy/remove.sh
+++ b/deploy/remove.sh
@@ -145,13 +145,17 @@ if [[ "${RESOURCE}-chan" != "${CHANREF}" ]]; then
   exit 1
 fi
 
-# Check for Application resource
-APP_FOUND=$(kubectl get app -n ${NAMESPACE} ${PREFIX}-app &>/dev/null && echo "true")
+# Check for Application and Placement resources
+APP_FOUND=$(kubectl get app -n ${NAMESPACE} ${PREFIX}-app &>/dev/null || echo "false")
+PLACEMENT_FOUND=$(kubectl get placementrule -n ${NAMESPACE} ${PREFIX}-placement &>/dev/null || echo "false")
 
 # Delete Subscription and Channel resources
 echo "This will delete these resources as well as resources they have deployed:"
-if [ "${APP_FOUND}" = "true" ]; then
+if [ "${APP_FOUND}" != "false" ]; then
   echo "- Application:  ${RESOURCE}-app"
+fi
+if [ "${PLACEMENT_FOUND}" != "false" ]; then
+  echo "- Placement:  ${RESOURCE}-placement"
 fi
 echo "- Channel:      ${RESOURCE}-chan"
 echo "- Subscription: ${RESOURCE}-sub"
@@ -164,8 +168,11 @@ while read -r -p "Would you like to proceed (y/n)? " response; do
   esac
 done
 
-if [ "${APP_FOUND}" = "true" ]; then
+if [ "${APP_FOUND}" != "false" ]; then
   kubectl delete app -n ${NAMESPACE} ${PREFIX}-app
+fi
+if [ "${PLACEMENT_FOUND}" != "false" ]; then
+  kubectl delete placementrule -n ${NAMESPACE} ${PREFIX}-placement
 fi
 kubectl delete appsub -n ${NAMESPACE} ${PREFIX}-sub
 kubectl delete channels -n ${NAMESPACE} ${PREFIX}-chan

--- a/deploy/subscription_placement_template.json
+++ b/deploy/subscription_placement_template.json
@@ -1,0 +1,12 @@
+[
+  {
+    "op": "replace",
+    "path": "/spec/placement",
+    "value": {
+      "placementRef": {
+        "kind": "PlacementRule",
+        "name": "##NAME##-placement"
+      }
+    }
+  }
+]

--- a/policygenerator/README.md
+++ b/policygenerator/README.md
@@ -15,6 +15,7 @@ through GitOps in Open Cluster Management.
 - [Policy Generator product documentation](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.4/html/governance/governance#policy-generator)
 - [Policy Generator source repository documentation](https://github.com/stolostron/policy-generator-plugin/blob/main/README.md)
 - [Policy Generator reference YAML](https://github.com/stolostron/policy-generator-plugin/blob/main/docs/policygenerator-reference.yaml)
+- [Kustomize documentation](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/)
 
 ## About the Policy Generator
 
@@ -34,7 +35,7 @@ For more information about contributing to the policy engine expanders, see the
 In this `policygenerator/` folder you will find:
 
 - [`subscription.yaml`](subscription.yaml) - Manifest to deploy the Subscription/Channel resource
-  objects for GitOps for this folder
+  objects for GitOps for the `kustomize/` folder
 - `kustomize/`
   - [`kustomization.yaml`](kustomize/kustomization.yaml) - Kustomize manifest pointing to the
     PolicyGenerator manifest
@@ -46,11 +47,13 @@ In this `policygenerator/` folder you will find:
     policy (assumes Gatekeeper is installed)
   - [`policy3_kyverno/`](kustomize/policy3_kyverno) - Kyverno policy manifests to wrap in a policy
     (assumes Kyverno is installed)
-  - [`policy-sets/`](policy-sets) - A directory of generator manifests that are each
-    using the `PolicySet` mechanism for organizing related policies.  Requires Advanced Cluster
-    Management 2.5 and newer for the `PolicySet` support.
+- `policy-sets/` - A directory of generator manifests that are each using the `PolicySet` mechanism
+  for organizing related policies. Requires Advanced Cluster Management 2.5 and newer for the
+  `PolicySet` support.
+  - [`stable/`](policy-sets/stable) - tested and supported PolicySets
+  - [`community/`](policy-sets/community) - PolicySets that have been contributed by the community
 
-To deploy the examples in this folder via GitOps:
+To deploy the policy generator examples in the `kustomize/` folder via GitOps:
 
 - Clone this repository.
 - Create the [`subscription.yaml`](subscription.yaml) on an Open Cluster Management hub. This file
@@ -60,8 +63,13 @@ To deploy the examples in this folder via GitOps:
   ```shell
   oc create -f subscription.yaml
   ```
-  **NOTE**: You must be a Subscription Admin to successfully deploy this manifest. See the
-  [Subscription Administrator](../README.md#subscription-administrator) topic.
+  **NOTES**:
+  - You must be a Subscription Admin to successfully deploy this manifest. See the
+    [Subscription Administrator](../README.md#subscription-administrator) topic.
+  - Use [deploy.sh](../deploy) to create customized Subscription/Channel manifests or update the
+    `apps.open-cluster-management.io/git-path` annotation in the Subscription of
+    [`subscription.yaml`](subscription.yaml) to deploy a different folder of the `policy-collection`
+    repository)
 - Navigate to the Governance tab of your hub to view the deployed policies!
 
   **NOTE**: The deployment could take a few minutes. Check the status of the Subscription if the
@@ -101,9 +109,9 @@ To generate the policy manifests locally:
 
 ## Adding additional manifests
 
-To add your own manifests, add your YAML files to the [`policygenerator/kustomize`](kustomize)
-directory (or to a new or existing subdirectory there). Then, update the `policies` array in
-[`policyGenerator.yaml`](kustomize/policyGenerator.yaml) with:
+To add your own manifests to be generated, add your YAML files to the
+[`policygenerator/kustomize`](kustomize) directory (or to a new or existing subdirectory there).
+Then, update the `policies` array in [`policyGenerator.yaml`](kustomize/policyGenerator.yaml) with:
 
 1. The name of the policy you want to generate.
 2. Paths to the manifests from which to generate policies (specifying a directory will place all
@@ -113,5 +121,8 @@ If the manifests point to a Kyverno or Gatekeeper API version, they will automat
 upon generation with additional Open Cluster Management policies to show whether the respective
 policy engine has detected a violation.
 
-See [Additional information](#additional-information) for more about additional configuration
-options and the policy expanders.
+See [Additional information](#additional-information) for resources about additional generator
+configuration options and the policy expanders.
+
+Full Policy YAML can also be deployed and customized by leveraging Kustomize directly in the
+`kustomization.yaml` by adding a `resources:` key and listing the files or directories underneath.

--- a/policygenerator/policy-sets/README.md
+++ b/policygenerator/policy-sets/README.md
@@ -1,19 +1,19 @@
 # What are `PolicySets`
 
-A `PolicySet` is a collection of policies that can be placed together instead of 
-having to manage their placement individually. The intent of the `PolicySet` can 
-be specified in the `description` field and the `status` of the `PolicySet` reflects 
-the status of the policies that it contains. 
+A `PolicySet` is a collection of policies that can be placed together instead of having to manage
+their placement individually. The intent of a particular `PolicySet` can be specified in the
+`description` field and the `status` of the `PolicySet` reflects the status of the policies that it
+contains.
 
 # Stable `PolicySets`
 
-A stable `PolicySet` is a `PolicySet` that is tested and supported by Red Hat. These `PolicySets` work with little or no modifications.
+A stable `PolicySet` is a `PolicySet` that is tested and supported by Red Hat. These `PolicySets`
+work with little or no modifications.
 
 # Community `PolicySets`
 
-A community `PolicySet` is a `PolicySet` that has been contributed by the 
-community. Community donations provide value, but that value might be 
-specific to certain environments, or it may need changes to apply the solution 
-to your environment. Some community `PolicySets` can provide samples showing 
-how a problem can be solved for one user of the policy framework, which may 
-or may not apply to other users.
+A community `PolicySet` is a `PolicySet` that has been contributed by the community. Community
+contributions provide value but could be specific to certain environments and may need modifications
+to apply the solution to your environment. Some community `PolicySets` provide samples showing how a
+problem can be solved for one user of the policy framework, which may or may not apply to other
+users.


### PR DESCRIPTION
- `deploy.sh` outputs the resulting Subscription manifests to a file every time, regardless of whether in dry-run mode or not
- `--dry-run` - Output the result to `stdout` but don't apply it to the cluster (also saves the result to `manifests.yaml`)
- `--deploy-app` - Deploy an Application manifest for additional visibility in the UI (also updates the Subscription to use Placement since the UI doesn't support the full topology otherwise)
- Updates to the various `README.md` for these changes as well as clarifications around the generator and PolicySets