### PR TITLE
Remove commas from controls to prevent incorrect delimiting

### DIFF
--- a/community/SI-System-and-Information-Integrity/policy-falco-helm.yaml
+++ b/community/SI-System-and-Information-Integrity/policy-falco-helm.yaml
@@ -20,7 +20,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/standards: NIST SP 800-53
     policy.open-cluster-management.io/categories: SI System and Information Integrity
-    policy.open-cluster-management.io/controls: SI-5 Security Alerts, Advisories, and Directives
+    policy.open-cluster-management.io/controls: SI-5 Security Alerts Advisories and Directives
 spec:
   remediationAction: enforce
   disabled: false

--- a/community/SI-System-and-Information-Integrity/policy-falco.yaml
+++ b/community/SI-System-and-Information-Integrity/policy-falco.yaml
@@ -14,7 +14,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/standards: NIST SP 800-53
     policy.open-cluster-management.io/categories: SI System and Information Integrity
-    policy.open-cluster-management.io/controls: SI-5 Security Alerts, Advisories, and Directives
+    policy.open-cluster-management.io/controls: SI-5 Security Alerts Advisories and Directives
 spec:
   remediationAction: enforce
   disabled: false

--- a/community/SI-System-and-Information-Integrity/policy-sysdig.yaml
+++ b/community/SI-System-and-Information-Integrity/policy-sysdig.yaml
@@ -14,7 +14,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/standards: NIST SP 800-53
     policy.open-cluster-management.io/categories: SI System and Information Integrity
-    policy.open-cluster-management.io/controls: SI-5 Security Alerts, Advisories, and Directives
+    policy.open-cluster-management.io/controls: SI-5 Security Alerts Advisories and Directives
 spec:
   remediationAction: enforce
   disabled: false

--- a/policygenerator/policy-sets/community/openshift-plus/policyGenerator.yaml
+++ b/policygenerator/policy-sets/community/openshift-plus/policyGenerator.yaml
@@ -19,7 +19,7 @@ policyDefaults:
 policies:
 - name: policy-ocm-observability
   categories:
-    - CA Assessment, Authorization and Monitoring
+    - CA Assessment Authorization and Monitoring
   controls: 
     - CA-7 Continuous Monitoring
   manifests:
@@ -35,7 +35,7 @@ policies:
   categories:
     - SI System and Information Integrity
   controls:
-    - SI-5 Security Alerts, Advisories, and Directives
+    - SI-5 Security Alerts Advisories and Directives
   manifests:
     - path: input-acs-central/policy-acs-central-status.yaml
   remediationAction: inform
@@ -43,14 +43,14 @@ policies:
   categories:
     - SI System and Information Integrity
   controls: 
-    - SI-7 Software, Firmware, and Information Integrity
+    - SI-7 Software Firmware and Information Integrity
   manifests:
     - path: input-odf/policy-odf.yaml
 - name: policy-odf-status
   categories:
     - SI System and Information Integrity
   controls: 
-    - SI-7 Software, Firmware, and Information Integrity
+    - SI-7 Software Firmware and Information Integrity
   manifests:
     - path: input-odf/policy-odf-status.yaml
   remediationAction: inform
@@ -58,14 +58,14 @@ policies:
   categories:
     - SI System and Information Integrity
   controls: 
-    - SI-7 Software, Firmware, and Information Integrity
+    - SI-7 Software Firmware and Information Integrity
   manifests:
     - path: input-quay/policy-config-quay.yaml
 - name: policy-quay-status
   categories:
     - SI System and Information Integrity
   controls:
-    - SI-7 Software, Firmware, and Information Integrity
+    - SI-7 Software Firmware and Information Integrity
   manifests:
     - path: input-quay/policy-quay-status.yaml
   remediationAction: inform
@@ -73,14 +73,15 @@ policies:
   categories:
     - SI System and Information Integrity
   controls:
-    - SI-5 Security Alerts, Advisories, and Directives
+    - SI-5 Security Alerts Advisories and Directives
   manifests:
     - path: input-sensor/policy-acs-central-ca-bundle.yaml
 - name: policy-compliance-operator-install
   categories:
     - CA Security Assessment and Authorization
   controls:
-    - CA-2 Security Assessments, CA-7 Continuous Monitoring
+    - CA-2 Security Assessments
+    - CA-7 Continuous Monitoring
   manifests:
     - path: input-compliance/
   policySets:
@@ -90,7 +91,7 @@ policies:
   categories:
     - SI System and Information Integrity
   controls:
-    - SI-5 Security Alerts, Advisories, and Directives
+    - SI-5 Security Alerts Advisories and Directives
   manifests:
     - path: input-sensor/policy-advanced-managed-cluster-security.yaml
   policySets:
@@ -99,7 +100,7 @@ policies:
   categories:
     - SI System and Information Integrity
   controls:
-    - SI-5 Security Alerts, Advisories, and Directives
+    - SI-5 Security Alerts Advisories and Directives
   manifests:
     - path: input-sensor/policy-advanced-managed-cluster-status.yaml
   policySets:

--- a/policygenerator/policy-sets/stable/acm-hardening/policyGenerator.yaml
+++ b/policygenerator/policy-sets/stable/acm-hardening/policyGenerator.yaml
@@ -42,7 +42,7 @@ policies:
     - SI System and Information Integrity
   complianceType: "mustnothave"
   controls: 
-    - SI-5 Security Alerts, Advisories, and Directives
+    - SI-5 Security Alerts Advisories and Directives
   disabled: false
   manifests:
     - path: input-subscriptions/


### PR DESCRIPTION
We use comma as a delimiter `,` so it should not be part of the
control names.  See the screenshot in the related issue for results.

Refs:
 - https://github.com/stolostron/backlog/issues/21055

Signed-off-by: Gus Parvin <gparvin@redhat.com>