### PR TITLE
Organize the policies for openshit plus policyset

### DIFF
--- a/policygenerator/policy-sets/community/openshift-plus/README.md
+++ b/policygenerator/policy-sets/community/openshift-plus/README.md
@@ -14,3 +14,5 @@ Prior to applying the `PolicySet`, perform these steps:
 
 Apply the policies using the kustomize command or subscribing to a fork of the repository and pointing to this directory.  See 
 the details for using the Policy Generator for more information.  The command to run is `kustomize build --enable-alpha-plugins  | oc apply -f -`
+
+**Note**: For any components of OpenShift Plus that you do not wish to install, edit the `policyGenerator.yaml` file and remove or comment out the policies for those components.

--- a/policygenerator/policy-sets/community/openshift-plus/policyGenerator.yaml
+++ b/policygenerator/policy-sets/community/openshift-plus/policyGenerator.yaml
@@ -17,13 +17,7 @@ policyDefaults:
   standards:
     - NIST SP 800-53
 policies:
-- name: policy-ocm-observability
-  categories:
-    - CA Assessment Authorization and Monitoring
-  controls: 
-    - CA-7 Continuous Monitoring
-  manifests:
-    - path: input-acm-observability/
+# ACS Policies - start
 - name: policy-acs-operator-central
   categories:
     - SC System and Communications Protection
@@ -39,36 +33,6 @@ policies:
   manifests:
     - path: input-acs-central/policy-acs-central-status.yaml
   remediationAction: inform
-- name: policy-odf
-  categories:
-    - SI System and Information Integrity
-  controls: 
-    - SI-7 Software Firmware and Information Integrity
-  manifests:
-    - path: input-odf/policy-odf.yaml
-- name: policy-odf-status
-  categories:
-    - SI System and Information Integrity
-  controls: 
-    - SI-7 Software Firmware and Information Integrity
-  manifests:
-    - path: input-odf/policy-odf-status.yaml
-  remediationAction: inform
-- name: policy-config-quay
-  categories:
-    - SI System and Information Integrity
-  controls: 
-    - SI-7 Software Firmware and Information Integrity
-  manifests:
-    - path: input-quay/policy-config-quay.yaml
-- name: policy-quay-status
-  categories:
-    - SI System and Information Integrity
-  controls:
-    - SI-7 Software Firmware and Information Integrity
-  manifests:
-    - path: input-quay/policy-quay-status.yaml
-  remediationAction: inform
 - name: policy-acs-central-ca-bundle
   categories:
     - SI System and Information Integrity
@@ -76,17 +40,6 @@ policies:
     - SI-5 Security Alerts Advisories and Directives
   manifests:
     - path: input-sensor/policy-acs-central-ca-bundle.yaml
-- name: policy-compliance-operator-install
-  categories:
-    - CA Security Assessment and Authorization
-  controls:
-    - CA-2 Security Assessments
-    - CA-7 Continuous Monitoring
-  manifests:
-    - path: input-compliance/
-  policySets:
-    - openshift-plus-clusters
-    - openshift-plus-hub
 - name: policy-advanced-managed-cluster-security
   categories:
     - SI System and Information Integrity
@@ -107,6 +60,63 @@ policies:
     - openshift-plus-hub
     - openshift-plus-clusters
   remediationAction: inform
+# ACS Policies - end
+# Observability Policy - start
+- name: policy-ocm-observability
+  categories:
+    - CA Assessment Authorization and Monitoring
+  controls: 
+    - CA-7 Continuous Monitoring
+  manifests:
+    - path: input-acm-observability/
+# Observability Policy - end
+# ODF Policies - start
+- name: policy-odf
+  categories:
+    - SI System and Information Integrity
+  controls: 
+    - SI-7 Software Firmware and Information Integrity
+  manifests:
+    - path: input-odf/policy-odf.yaml
+- name: policy-odf-status
+  categories:
+    - SI System and Information Integrity
+  controls: 
+    - SI-7 Software Firmware and Information Integrity
+  manifests:
+    - path: input-odf/policy-odf-status.yaml
+  remediationAction: inform
+# ODF Policies - end
+# Quay Policies - start
+- name: policy-config-quay
+  categories:
+    - SI System and Information Integrity
+  controls: 
+    - SI-7 Software Firmware and Information Integrity
+  manifests:
+    - path: input-quay/policy-config-quay.yaml
+- name: policy-quay-status
+  categories:
+    - SI System and Information Integrity
+  controls:
+    - SI-7 Software Firmware and Information Integrity
+  manifests:
+    - path: input-quay/policy-quay-status.yaml
+  remediationAction: inform
+# Quay Policies - end
+# Compliance Operator Policies - start
+- name: policy-compliance-operator-install
+  categories:
+    - CA Security Assessment and Authorization
+  controls:
+    - CA-2 Security Assessments
+    - CA-7 Continuous Monitoring
+  manifests:
+    - path: input-compliance/
+  policySets:
+    - openshift-plus-clusters
+    - openshift-plus-hub
+# Compliance Operator Policies - end
 policySets:
   - description: The OpenShift Platform Plus policy set applies several policies
       that installs the OpenShift Platform Plus products using best practices

--- a/policygenerator/policy-sets/stable/acm-hardening/README.md
+++ b/policygenerator/policy-sets/stable/acm-hardening/README.md
@@ -1,0 +1,11 @@
+# PolicySets -- ACM Hardening
+
+See the [Policy Generator](https://github.com/stolostron/policy-generator-plugin) 
+Kustomize plugin for more information on using the policy generator.
+
+## PolicySet details
+
+The ACM Hardening `PolicySet` Applies best practices for how to harden your Advanced Cluster Management hub installation. 
+This `PolicySet` needs to be deployed only to the Advanced Cluster Management hub cluster. 
+
+**Note**: The `PolicySet` uses cluster `Placement` and not the `PlacementRule` placement mechanism.


### PR DESCRIPTION
Moved the policies around so the OpenShift plus products are grouped
together.  No changes other than that are being done at this time.

Signed-off-by: Gus Parvin <gparvin@redhat.com>