### PR TITLE
Container security operator display name changed

### DIFF
--- a/stable/SI-System-and-Information-Integrity/policy-imagemanifestvuln.yaml
+++ b/stable/SI-System-and-Information-Integrity/policy-imagemanifestvuln.yaml
@@ -48,7 +48,7 @@ spec:
                 metadata:
                   namespace: openshift-operators
                 spec:
-                  displayName: Quay Container Security
+                  displayName: Red Hat Quay Container Security Operator
                 status:
                   phase: Succeeded   # check the csv status to determine if operator is running or not
     - objectDefinition:


### PR DESCRIPTION
The container security operator now has a new display name.
This is causing problems with the CSV check in the automation.

Signed-off-by: Gus Parvin <gparvin@redhat.com>