### PR TITLE
Remove the volsync content and sync with the backup policy

### DIFF
--- a/policygenerator/policy-sets/stable/acm-hardening/input-backup/policy-backup.yaml
+++ b/policygenerator/policy-sets/stable/acm-hardening/input-backup/policy-backup.yaml
@@ -3,5 +3,61 @@ kind: BackupSchedule
 status:
   phase: Enabled
 ---
-apiVersion: volsync.backube/v1alpha1
-kind: ReplicationSource
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: cluster-backup-chart
+  namespace: open-cluster-management-backup
+status:
+  phase: Running
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    repository: https://github.com/openshift/oadp-operator
+  namespace: open-cluster-management-backup
+status:
+  phase: Running
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app.kubernetes.io/name: velero
+  namespace: open-cluster-management-backup
+status:
+  phase: Running
+---
+apiVersion: velero.io/v1
+kind: BackupStorageLocation
+metadata:
+  namespace: open-cluster-management-backup
+status:
+  phase: Available
+---
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  labels:
+    velero.io/schedule-name: acm-validation-policy-schedule
+  namespace: open-cluster-management-backup
+---
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  labels:
+    velero.io/schedule-name: acm-managed-clusters-schedule
+  namespace: open-cluster-management-backup
+status:
+  phase: Completed
+---
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  labels:
+    velero.io/schedule-name: acm-resources-schedule
+  namespace: open-cluster-management-backup
+status:
+  phase: Completed


### PR DESCRIPTION
Now the backup policy in our policy set will match the musthave
content.  Could add the mustnothave entries, but to fix this issue I'm
mainly getting rid of the incorrect volsync entry.

Refs:
 - https://github.com/stolostron/backlog/issues/21818

Signed-off-by: Gus Parvin <gparvin@redhat.com>