### PR TITLE
The new ACS operator wants to be installed in the rhacs-operator ns

### DIFF
--- a/community/CM-Configuration-Management/policy-acs-operator-central.yaml
+++ b/community/CM-Configuration-Management/policy-acs-operator-central.yaml
@@ -27,6 +27,20 @@ spec:
               kind: Namespace
               metadata:
                 name: stackrox
+          - complianceType: musthave
+            objectDefinition:
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: rhacs-operator
+          - complianceType: musthave
+            objectDefinition:
+              apiVersion: operators.coreos.com/v1
+              kind: OperatorGroup
+              metadata:
+                name: rhacs-operator-group
+                namespace: rhacs-operator
+              spec: {}
   - objectDefinition:
       apiVersion: policy.open-cluster-management.io/v1
       kind: ConfigurationPolicy
@@ -42,7 +56,7 @@ spec:
               kind: Subscription
               metadata:
                 name: rhacs-operator
-                namespace: openshift-operators
+                namespace: rhacs-operator
               spec:
                 channel: latest
                 installPlanApproval: Automatic

--- a/community/CM-Configuration-Management/policy-acs-operator-secured-clusters.yaml
+++ b/community/CM-Configuration-Management/policy-acs-operator-secured-clusters.yaml
@@ -35,6 +35,20 @@ spec:
               kind: Namespace
               metadata:
                 name: stackrox
+          - complianceType: musthave
+            objectDefinition:
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: rhacs-operator
+          - complianceType: musthave
+            objectDefinition:
+              apiVersion: operators.coreos.com/v1
+              kind: OperatorGroup
+              metadata:
+                name: rhacs-operator-group
+                namespace: rhacs-operator
+              spec: {}
   - objectDefinition:
       apiVersion: policy.open-cluster-management.io/v1
       kind: ConfigurationPolicy
@@ -50,7 +64,7 @@ spec:
               kind: Subscription
               metadata:
                 name: rhacs-operator
-                namespace: openshift-operators
+                namespace: rhacs-operator
               spec:
                 channel: latest
                 installPlanApproval: Automatic

--- a/policygenerator/policy-sets/community/openshift-plus/input-acs-central/policy-acs-operator-central.yaml
+++ b/policygenerator/policy-sets/community/openshift-plus/input-acs-central/policy-acs-operator-central.yaml
@@ -3,11 +3,23 @@ kind: Namespace
 metadata:
   name: stackrox
 ---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rhacs-operator
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: rhacs-operator-group
+  namespace: rhacs-operator
+spec: {}
+---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: rhacs-operator
-  namespace: openshift-operators
+  namespace: rhacs-operator
 spec:
   channel: latest
   installPlanApproval: Automatic

--- a/policygenerator/policy-sets/community/openshift-plus/input-sensor/policy-advanced-managed-cluster-security.yaml
+++ b/policygenerator/policy-sets/community/openshift-plus/input-sensor/policy-advanced-managed-cluster-security.yaml
@@ -3,11 +3,23 @@ kind: Namespace
 metadata:
   name: stackrox
 ---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rhacs-operator
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: rhacs-operator-group
+  namespace: rhacs-operator
+spec: {}
+---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: rhacs-operator
-  namespace: openshift-operators
+  namespace: rhacs-operator
 spec:
   channel: latest
   installPlanApproval: Automatic


### PR DESCRIPTION
Adjust the policy so the ACS operator is installed in the namespace
that it wants to be installed in now: `rhacs-operator`.  This creates
the new namespace and the operator group.

Refs:
 - https://github.com/stolostron/policy-collection/issues/260

Signed-off-by: Gus Parvin <gparvin@redhat.com>