### PR TITLE
The subscription applies only to the hub where the subscription exists

### DIFF
--- a/policygenerator/policy-sets/community/openshift-plus/input-sensor/policy-acs-central-ca-bundle.yaml
+++ b/policygenerator/policy-sets/community/openshift-plus/input-sensor/policy-acs-central-ca-bundle.yaml
@@ -142,18 +142,6 @@ spec:
       serviceAccountName: create-cluster-init
       terminationGracePeriodSeconds: 30
 ---
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
-metadata:
-  name: rhacs-operator
-  namespace: openshift-operators
-spec:
-  channel: latest
-  installPlanApproval: Automatic
-  name: rhacs-operator
-  source: redhat-operators
-  sourceNamespace: openshift-marketplace
----
 apiVersion: platform.stackrox.io/v1alpha1
 kind: SecuredCluster
 metadata:


### PR DESCRIPTION
Remove duplicate subscription definition.  The namespace was also
wrong in the subscription.

Signed-off-by: Gus Parvin <gparvin@redhat.com>