### PR TITLE
Change kyverno default probe settings to improve stability

### DIFF
--- a/community/CM-Configuration-Management/policy-install-kyverno.yaml
+++ b/community/CM-Configuration-Management/policy-install-kyverno.yaml
@@ -104,12 +104,21 @@ spec:
                       packageOverrides:
                       - path: spec
                         value:
+                            extraArgs:
+                              - '--clientRateLimitQPS=20'
+                              - '--clientRateLimitBurst=50'
                             resources:
                               limits:
                                 memory: 768Mi
                             initResources:
                               limits:
                                 memory: 512Mi
+                            livenessProbe:
+                              initialDelaySeconds: 45
+                              periodSeconds: 40
+                            readinessProbe:
+                              initialDelaySeconds: 35
+                              periodSeconds: 20
                   placement:
                     placementRef:
                       name: kyverno-placement-1


### PR DESCRIPTION
The kyverno policy successfully installs kyverno on OpenShift, but
I am seeing clusters get into a really bad state that I haven't been
able to debug.  These settings I think will reduce the likelihood
that kyverno restarts due to a probe timeout.  Some of the problems
seen are:
- nodes change to Not Ready
- oauth api server and many other pods go to Crash Loop Backoff
- can't view pod logs, difficult to diagnose the root cause

Refs:
 - https://github.com/stolostron/backlog/issues/20388

Signed-off-by: Gus Parvin <gparvin@redhat.com>