### PR TITLE
Kyverno version 1.7.0 is available but doesn't install with our policy

### DIFF
--- a/community/CM-Configuration-Management/policy-install-kyverno.yaml
+++ b/community/CM-Configuration-Management/policy-install-kyverno.yaml
@@ -119,6 +119,7 @@ spec:
                             readinessProbe:
                               initialDelaySeconds: 35
                               periodSeconds: 20
+                            securityContext: null
                   placement:
                     placementRef:
                       name: kyverno-placement-1


### PR DESCRIPTION
Small update to the policy so the kyverno helm chart installs
successfully on OpenShift.

Signed-off-by: Gus Parvin <gparvin@redhat.com>