### PR TITLE
Add auditChunkSize setting to gatekeeper configs

### DIFF
--- a/community/CM-Configuration-Management/policy-gatekeeper-operator.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-operator.yaml
@@ -103,6 +103,7 @@ spec:
                 name: gatekeeper
               spec:
                 audit:
+                  auditChunkSize: 500
                   logLevel: INFO
                   replicas: 1
                 validatingWebhook: Enabled

--- a/stable/CM-Configuration-Management/policy-gatekeeper-operator-downstream.yaml
+++ b/stable/CM-Configuration-Management/policy-gatekeeper-operator-downstream.yaml
@@ -72,6 +72,7 @@ spec:
                 name: gatekeeper
               spec:
                 audit:
+                  auditChunkSize: 500
                   logLevel: INFO
                   replicas: 1
                 validatingWebhook: Enabled


### PR DESCRIPTION
In some versions of Gatekeeper, the audit pod may use too much memory
and get OOMKilled repeatedly, making it fail to function. More recent
versions have addressed this in multiple ways, but most notably the
--audit-chunk-size default was updated from 0 (infinite) to 500.

This commit specifies that setting in the gatekeeper config so it will
always use the new default. This may increase requests to the k8s API
server, but provides stability to the audit pod.

Refs:
 - https://github.com/stolostron/backlog/issues/23005

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>