### PR TITLE
Pin the version of the community gatekeeper

### DIFF
--- a/community/CM-Configuration-Management/policy-gatekeeper-operator.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-operator.yaml
@@ -45,7 +45,7 @@ spec:
                 displayName: Gatekeeper Operator Upstream
                 publisher: github.com/font/gatekeeper-operator
                 sourceType: grpc
-                image: 'quay.io/gatekeeper/gatekeeper-operator-bundle-index:latest'
+                image: 'quay.io/gatekeeper/gatekeeper-operator-bundle-index:v0.2.1'
                 updateStrategy:
                   registryPoll:
                     interval: 45m


### PR DESCRIPTION
The latest tag is sometimes updated to versions that may not work. This
pins the version to a currently working tag.

Refs:
 - https://github.com/stolostron/backlog/issues/23005

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>