### PR TITLE
OCP Plus needs to support the new version of quay

### DIFF
--- a/policygenerator/policy-sets/community/openshift-plus/input-quay/policy-config-quay.yaml
+++ b/policygenerator/policy-sets/community/openshift-plus/input-quay/policy-config-quay.yaml
@@ -22,7 +22,7 @@ metadata:
   name: quay-operator
   namespace: local-quay
 spec:
-  channel: stable-3.6
+  channel: stable-3.7
   installPlanApproval: Automatic
   name: quay-operator
   source: redhat-operators


### PR DESCRIPTION
Changed quay stable subscription from 3.6 to 3.7.
There were problems installing quay on OCP 4.10.x which moving to the
new channel fixes.

Signed-off-by: Gus Parvin <gparvin@redhat.com>