### PR TITLE
fix #299 - properly select namespaces

### DIFF
--- a/community/SC-System-and-Communications-Protection/policy-remove-kubeadmin.yaml
+++ b/community/SC-System-and-Communications-Protection/policy-remove-kubeadmin.yaml
@@ -18,15 +18,11 @@ spec:
         spec:
           remediationAction: inform
           severity: low
-          namespaceSelector:
-            exclude:
-              - kube-*
-            include:
-              - default
           object-templates:
             - complianceType: mustnothave
               objectDefinition:
                 kind: Secret
+                apiVersion: v1
                 metadata:
                   name: kubeadmin
                   namespace: kube-system


### PR DESCRIPTION
The present namespace selector does not make sense, since it
excludes `kube-*` while the Secret in question is in `kube-system`

Also the objectDefinition requires the `apiVersion` to be present
otherwise we do not lookup the proper kind.