### PR TITLE
Change kyverno install Placement to mustonlyhave

### DIFF
--- a/community/CM-Configuration-Management/policy-install-kyverno.yaml
+++ b/community/CM-Configuration-Management/policy-install-kyverno.yaml
@@ -124,7 +124,7 @@ spec:
                     placementRef:
                       name: kyverno-placement-1
                       kind: PlacementRule
-            - complianceType: musthave
+            - complianceType: mustonlyhave
               objectDefinition:
                 apiVersion: apps.open-cluster-management.io/v1
                 kind: PlacementRule


### PR DESCRIPTION
Previously, if this PlacementRule was modified inside this Policy, the
changes might not be enforced. Using mustonlyhave ensures that the
PlacementRule looks exactly like it is defined in the Policy.

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>