### PR TITLE
Remove channel for odf and fix bucket for observability

### DIFF
--- a/policygenerator/policy-sets/community/openshift-plus/input-acm-observability/policy-ocm-observability.yaml
+++ b/policygenerator/policy-sets/community/openshift-plus/input-acm-observability/policy-ocm-observability.yaml
@@ -8,8 +8,8 @@ stringData:
   thanos.yaml: |
     type: s3
     config:
-      bucket: {{ (lookup "objectbucket.io/v1alpha1" "ObjectBucket" "" "obc-local-quay-registry-quay-datastore").spec.endpoint.bucketName }}
-      endpoint: {{ (lookup "objectbucket.io/v1alpha1" "ObjectBucket" "" "obc-local-quay-registry-quay-datastore").spec.endpoint.bucketHost }}
+      bucket: {{ (lookup "objectbucket.io/v1alpha1" "ObjectBucket" "" "obc-openshift-storage-obc-observability").spec.endpoint.bucketName }}
+      endpoint: {{ (lookup "objectbucket.io/v1alpha1" "ObjectBucket" "" "obc-openshift-storage-obc-observability").spec.endpoint.bucketHost }}
       insecure: true
       access_key: {{ fromSecret "openshift-storage" "noobaa-admin" "AWS_ACCESS_KEY_ID" | base64dec }}
       secret_key: {{ fromSecret "openshift-storage" "noobaa-admin" "AWS_SECRET_ACCESS_KEY" | base64dec }}

--- a/policygenerator/policy-sets/community/openshift-plus/input-odf/policy-odf.yaml
+++ b/policygenerator/policy-sets/community/openshift-plus/input-odf/policy-odf.yaml
@@ -18,7 +18,6 @@ metadata:
   name: odf-operator
   namespace: openshift-storage
 spec:
-  channel: stable-4.9
   installPlanApproval: Automatic
   name: odf-operator
   source: redhat-operators
@@ -30,7 +29,6 @@ metadata:
   name: ocs-operator
   namespace: openshift-storage
 spec:
-  channel: stable-4.9
   installPlanApproval: Automatic
   name: ocs-operator
   source: redhat-operators
@@ -42,7 +40,6 @@ metadata:
   name: mcg-operator
   namespace: openshift-storage
 spec:
-  channel: stable-4.9
   installPlanApproval: Automatic
   name: mcg-operator
   source: redhat-operators
@@ -100,4 +97,20 @@ spec:
     preparePlacement: {}
     replica: 3
     resources: {}
-  version: 4.9.0
+---
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: obc-observability
+  namespace: openshift-storage
+spec:
+  generateBucketName: obc-observability-bucket
+  storageClassName: openshift-storage.noobaa.io
+---
+apiVersion: operator.openshift.io/v1
+kind: Console
+metadata:
+  name: cluster
+spec:
+  plugins:
+  - odf-console


### PR DESCRIPTION
This adds back the missing odf storage bucket for observability.
It also enables the console plugin and removes the channel for odf so
the latest version is used.

Refs:
 - https://github.com/stolostron/backlog/issues/24242

Signed-off-by: Gus Parvin <gparvin@redhat.com>