### PR TITLE
The refresh of the blog added a digit to the end

### DIFF
--- a/blogs/README.md
+++ b/blogs/README.md
@@ -46,4 +46,4 @@ Read our blogs for more information and best practices for Red Hat Advanced Clus
 
 * [Latest Integrity Shield protects Red Hat Advanced Cluster Management for Kubernetes policies](https://cloud.redhat.com/blog/latest-integrity-shield-protects-red-hat-advanced-cluster-management-for-kubernetes-policies)
 
-* [Deploying Red Hat Advanced Cluster Security with Red Hat Advanced Cluster Management](https://cloud.redhat.com/blog/deploying-red-hat-advanced-cluster-security-with-red-hat-advanced-cluster-management)
+* [Deploying Red Hat Advanced Cluster Security with Red Hat Advanced Cluster Management](https://cloud.redhat.com/blog/deploying-red-hat-advanced-cluster-security-with-red-hat-advanced-cluster-management-2)


### PR DESCRIPTION
Updating the link since the blog refresh with new content now is at
a slightly different link.  The link ends with a `-2`
Full link: https://cloud.redhat.com/blog/deploying-red-hat-advanced-cluster-security-with-red-hat-advanced-cluster-management-2

Signed-off-by: Gus Parvin <gparvin@redhat.com>