### PR TITLE
OpenShift 4.11 has changes to the restricted scc

### DIFF
--- a/stable/SC-System-and-Communications-Protection/policy-scc.yaml
+++ b/stable/SC-System-and-Communications-Protection/policy-scc.yaml
@@ -27,8 +27,6 @@ spec:
                 apiVersion: security.openshift.io/v1
                 kind: SecurityContextConstraints # restricted scc
                 metadata:
-                  annotations:
-                    kubernetes.io/description: restricted denies access to all host features and requires pods to be run with a UID, and SELinux context that are allocated to the namespace.  This is the most restrictive SCC and it is used by default for authenticated users.
                   name: restricted
                 allowHostDirVolumePlugin: false
                 allowHostIPC: false
@@ -39,8 +37,6 @@ spec:
                 allowPrivilegedContainer: false
                 fsGroup:
                   type: MustRunAs
-                groups:
-                - system:authenticated
                 readOnlyRootFilesystem: false
                 requiredDropCapabilities:
                 - KILL


### PR DESCRIPTION
Our test automation isn't working with the updated `restricted` scc in
OCP 4.11.  The description annotation changed and the group field
also is different.  I'm removing these values from the policy so this
policy will be accurate for OCP 4.11 and older releases.

Refs:
 - https://github.com/stolostron/backlog/issues/24410

Signed-off-by: Gus Parvin <gparvin@redhat.com>