### PR TITLE
Observability instructions indicate the pull secret must be copied

### DIFF
--- a/policygenerator/policy-sets/community/openshift-plus/input-acm-observability/policy-ocm-pull-secret.yaml
+++ b/policygenerator/policy-sets/community/openshift-plus/input-acm-observability/policy-ocm-pull-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  .dockerconfigjson: '{{- if eq (lookup "v1" "Secret" "open-cluster-management" "multiclusterhub-operator-pull-secret").kind "Secret" -}} {{- fromSecret "open-cluster-management" "multiclusterhub-operator-pull-secret" ".dockerconfigjson" -}} {{- else -}} {{- fromSecret "openshift-config" "pull-secret" ".dockerconfigjson" -}} {{- end -}}'
+kind: Secret
+metadata:
+  name: multiclusterhub-operator-pull-secret
+  namespace: open-cluster-management-observability
+type: kubernetes.io/dockerconfigjson


### PR DESCRIPTION
Observability is working for me without copying the pull secret to the
namespace, but the instructions indicate it must be done.  This PR
will comply with the instructions because in many scenarios I expect
this is needed.

Refs:
 - https://github.com/stolostron/policy-collection/issues/297

Signed-off-by: Gus Parvin <gparvin@redhat.com>