### PR TITLE
Add additional status checks for odf

### DIFF
--- a/policygenerator/policy-sets/community/openshift-plus/input-odf/policy-odf-status.yaml
+++ b/policygenerator/policy-sets/community/openshift-plus/input-odf/policy-odf-status.yaml
@@ -27,3 +27,43 @@ status:
   conditions:
     - status: "True"
       type: Available
+---
+apiVersion: ocs.openshift.io/v1
+kind: StorageCluster
+metadata:
+  name: ocs-storagecluster
+  namespace: openshift-storage
+status:
+  phase: Ready
+---
+apiVersion: noobaa.io/v1alpha1
+kind: NooBaa
+metadata:
+  name: noobaa
+  namespace: openshift-storage
+status:
+  phase: Ready
+---
+apiVersion: noobaa.io/v1alpha1
+kind: BackingStore
+metadata:
+  name: noobaa-default-backing-store
+  namespace: openshift-storage
+status:
+  phase: Ready
+---
+apiVersion: noobaa.io/v1alpha1
+kind: BucketClass
+metadata:
+  name: noobaa-default-bucket-class
+  namespace: openshift-storage
+status:
+  phase: Ready
+---
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: obc-observability
+  namespace: openshift-storage
+status:
+  phase: Bound


### PR DESCRIPTION
The status for odf was only checking on some deployments.  I have added
additional checks that look at the storage components too.

Refs:
 - https://github.com/stolostron/policy-collection/issues/295

Signed-off-by: Gus Parvin <gparvin@redhat.com>