### PR TITLE
Address problem downloading the cli image in the OPP policyset

### DIFF
--- a/policygenerator/policy-sets/community/openshift-plus/input-quay/policy-config-quay.yaml
+++ b/policygenerator/policy-sets/community/openshift-plus/input-quay/policy-config-quay.yaml
@@ -5,6 +5,50 @@ metadata:
     openshift.io/cluster-monitoring: "true"
   name: local-quay
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: create-admin-user
+  namespace: local-quay
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: create-admin-user
+  namespace: local-quay
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - create
+  - patch
+  - update
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: create-admin-user
+  namespace: local-quay
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: create-admin-user
+subjects:
+- kind: ServiceAccount
+  name: create-admin-user
+  namespace: local-quay
+---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -49,50 +93,6 @@ spec:
       managed: true
     - managed: true
       kind: tls
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: create-admin-user
-  namespace: local-quay
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: create-admin-user
-  namespace: local-quay
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - create
-  - patch
-  - update
-- apiGroups:
-  - route.openshift.io
-  resources:
-  - routes
-  verbs:
-  - get
-  - list
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: create-admin-user
-  namespace: local-quay
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: create-admin-user
-subjects:
-- kind: ServiceAccount
-  name: create-admin-user
-  namespace: local-quay
 ---
 apiVersion: batch/v1
 kind: Job

--- a/policygenerator/policy-sets/community/openshift-plus/input-sensor/policy-acs-central-ca-bundle.yaml
+++ b/policygenerator/policy-sets/community/openshift-plus/input-sensor/policy-acs-central-ca-bundle.yaml
@@ -63,6 +63,62 @@ subjects:
   name: create-cluster-init
   namespace: stackrox
 ---
+apiVersion: platform.stackrox.io/v1alpha1
+kind: SecuredCluster
+metadata:
+  name: stackrox-secured-cluster-services
+  namespace: stackrox
+spec:
+  clusterName: |
+    {{ fromSecret "open-cluster-management-agent" "hub-kubeconfig-secret" "cluster-name" | base64dec }}
+  auditLogs:
+    collection: Auto
+  centralEndpoint: |
+    {{ fromSecret "stackrox" "sensor-tls" "acs-host" | base64dec }}
+  admissionControl:
+    listenOnCreates: false
+    listenOnEvents: true
+    listenOnUpdates: false
+  perNode:
+    collector:
+      collection: KernelModule
+      imageFlavor: Regular
+    taintToleration: TolerateTaints
+---
+apiVersion: v1
+data:
+  admission-control-cert.pem: '{{ fromSecret "stackrox" "admission-control-tls" "admission-control-cert.pem" }}'
+  admission-control-key.pem: '{{ fromSecret "stackrox" "admission-control-tls" "admission-control-key.pem" }}'
+  ca.pem: '{{ fromSecret "stackrox" "admission-control-tls" "ca.pem" }}'
+kind: Secret
+metadata:
+  name: admission-control-tls
+  namespace: policies
+type: Opaque
+---
+apiVersion: v1
+data:
+  collector-cert.pem: '{{ fromSecret "stackrox" "collector-tls" "collector-cert.pem" }}'
+  collector-key.pem: '{{ fromSecret "stackrox" "collector-tls" "collector-key.pem" }}'
+  ca.pem: '{{ fromSecret "stackrox" "collector-tls" "ca.pem" }}'
+kind: Secret
+metadata:
+  name: collector-tls
+  namespace: policies
+type: Opaque
+---
+apiVersion: v1
+data:
+  sensor-cert.pem: '{{ fromSecret "stackrox" "sensor-tls" "sensor-cert.pem" }}'
+  sensor-key.pem: '{{ fromSecret "stackrox" "sensor-tls" "sensor-key.pem" }}'
+  ca.pem: '{{ fromSecret "stackrox" "sensor-tls" "ca.pem" }}'
+  acs-host: '{{ fromSecret "stackrox" "sensor-tls" "acs-host" }}'
+kind: Secret
+metadata:
+  name: sensor-tls
+  namespace: policies
+type: Opaque
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -141,59 +197,3 @@ spec:
       serviceAccount: create-cluster-init
       serviceAccountName: create-cluster-init
       terminationGracePeriodSeconds: 30
----
-apiVersion: platform.stackrox.io/v1alpha1
-kind: SecuredCluster
-metadata:
-  name: stackrox-secured-cluster-services
-  namespace: stackrox
-spec:
-  clusterName: |
-    {{ fromSecret "open-cluster-management-agent" "hub-kubeconfig-secret" "cluster-name" | base64dec }}
-  auditLogs:
-    collection: Auto
-  centralEndpoint: |
-    {{ fromSecret "stackrox" "sensor-tls" "acs-host" | base64dec }}
-  admissionControl:
-    listenOnCreates: false
-    listenOnEvents: true
-    listenOnUpdates: false
-  perNode:
-    collector:
-      collection: KernelModule
-      imageFlavor: Regular
-    taintToleration: TolerateTaints
----
-apiVersion: v1
-data:
-  admission-control-cert.pem: '{{ fromSecret "stackrox" "admission-control-tls" "admission-control-cert.pem" }}'
-  admission-control-key.pem: '{{ fromSecret "stackrox" "admission-control-tls" "admission-control-key.pem" }}'
-  ca.pem: '{{ fromSecret "stackrox" "admission-control-tls" "ca.pem" }}'
-kind: Secret
-metadata:
-  name: admission-control-tls
-  namespace: policies
-type: Opaque
----
-apiVersion: v1
-data:
-  collector-cert.pem: '{{ fromSecret "stackrox" "collector-tls" "collector-cert.pem" }}'
-  collector-key.pem: '{{ fromSecret "stackrox" "collector-tls" "collector-key.pem" }}'
-  ca.pem: '{{ fromSecret "stackrox" "collector-tls" "ca.pem" }}'
-kind: Secret
-metadata:
-  name: collector-tls
-  namespace: policies
-type: Opaque
----
-apiVersion: v1
-data:
-  sensor-cert.pem: '{{ fromSecret "stackrox" "sensor-tls" "sensor-cert.pem" }}'
-  sensor-key.pem: '{{ fromSecret "stackrox" "sensor-tls" "sensor-key.pem" }}'
-  ca.pem: '{{ fromSecret "stackrox" "sensor-tls" "ca.pem" }}'
-  acs-host: '{{ fromSecret "stackrox" "sensor-tls" "acs-host" }}'
-kind: Secret
-metadata:
-  name: sensor-tls
-  namespace: policies
-type: Opaque


### PR DESCRIPTION
The openshift CLI image sometimes can't be downloaded.  In one scenario
I recreated the issue and noticed one pod successfully downloaded the
image and another pod didn't.  Both pods were on the same node so I
deleted the pod that failed to download and when the pod restarted it
worked find.  My guess is there may be a permissions or timing issue
that caused the problem so I have re-ordered some resources to change
the timing.

Currently this is a guess so it may turn into some job configuration.

Signed-off-by: Gus Parvin <gparvin@redhat.com>