### PR TITLE
Namespace selector updates

### DIFF
--- a/community/AC-Access-Control/policy-roles-no-wildcards.yaml
+++ b/community/AC-Access-Control/policy-roles-no-wildcards.yaml
@@ -19,7 +19,6 @@ spec:
           remediationAction: inform # will be overridden by remediationAction in parent policy
           severity: high
           namespaceSelector:
-            exclude: ["kube-*"]
             include: ["default"]
           object-templates:
             - complianceType: mustnothave

--- a/community/CA-Security-Assessment-and-Authorization/policy-compliance-operator-install-upstream.yaml
+++ b/community/CA-Security-Assessment-and-Authorization/policy-compliance-operator-install-upstream.yaml
@@ -79,9 +79,6 @@ spec:
         spec:
           remediationAction: inform # will be overridden by remediationAction in parent policy
           severity: high
-          namespaceSelector:
-            exclude: ["kube-*"]
-            include: ["*"]
           object-templates:
             - complianceType: musthave
               objectDefinition:

--- a/community/CM-Configuration-Management/policy-ansible-awx-operator.yaml
+++ b/community/CM-Configuration-Management/policy-ansible-awx-operator.yaml
@@ -18,11 +18,6 @@ spec:
         spec:
           remediationAction: inform
           severity: low
-          namespaceSelector:
-            exclude:
-              - kube-*
-            include:
-              - default
           object-templates:
             - complianceType: musthave
               objectDefinition:

--- a/community/CM-Configuration-Management/policy-argocd-kubernetes.yaml
+++ b/community/CM-Configuration-Management/policy-argocd-kubernetes.yaml
@@ -18,11 +18,6 @@ spec:
         spec:
           remediationAction: inform
           severity: low
-          namespaceSelector:
-            exclude:
-              - kube-*
-            include:
-              - default
           object-templates:
             - complianceType: musthave
               objectDefinition:

--- a/community/CM-Configuration-Management/policy-autoscaler-templatized.yaml
+++ b/community/CM-Configuration-Management/policy-autoscaler-templatized.yaml
@@ -1,4 +1,4 @@
-#This demonstrates configuring ClusterAutoscaler  with values  customized to the target cluster using  HUB-templates
+# This demonstrates configuring ClusterAutoscaler  with values  customized to the target cluster using  HUB-templates
 # the below shows three policies 
 # 1.policy-autoscaler-templatized-config:  configures a ConfigMap on the HUB which contains the managedcluster specific values for  ClusterAutoscaler resource
 # 2.policy-autoscaler-templatized: configures  ClusterAutoScaler resources on target managedclusters with  cluster specific values retrieved from the above ConfigMap
@@ -8,10 +8,10 @@
 #                            This ensures that configmap  with cluster specific values data is created before the policy that retrieves the values from that configmap.
 
 
-#NOTE
-#The file has 3 related policies clubbed together, 
-#when deploying through GRC UI Editor pls copy paste each policy resource individually as the ui can handle only one policy at a time.
-#pls make sure to deploy all 3 policies in the same namespace and replace any placeholder <POLICIESNS> in this file with the policy namespace.
+# NOTE
+# The file has 3 related policies clubbed together, 
+# when deploying through GRC UI Editor pls copy paste each policy resource individually as the ui can handle only one policy at a time.
+# pls make sure to deploy all 3 policies in the same namespace and replace any placeholder <POLICIESNS> in this file with the policy namespace.
 
 
 apiVersion: policy.open-cluster-management.io/v1
@@ -34,11 +34,6 @@ spec:
         spec:
           remediationAction: inform
           severity: low
-          namespaceSelector:
-            exclude:
-              - kube-*
-            include:
-              - default
           object-templates:
             - complianceType: musthave
               objectDefinition:
@@ -90,11 +85,6 @@ spec:
         spec:
           remediationAction: inform
           severity: low
-          namespaceSelector:
-            exclude:
-              - kube-*
-            include:
-              - default
           object-templates:
             - complianceType: musthave
               objectDefinition:
@@ -138,11 +128,6 @@ spec:
         spec:
           remediationAction: inform
           severity: low
-          namespaceSelector:
-            exclude:
-              - kube-*
-            include:
-              - default
           object-templates:
             - complianceType: musthave
               objectDefinition:
@@ -152,7 +137,6 @@ spec:
                   name: policy-autoscaler-templatized
                   namespace: <POLICIESNS>
                 spec: # disable is set to true if policy status != complaint else it is set to false , 
-                  # TODO , specify the correct namespace of the policy resource, replace the "default" with the namespace of the policy
                   disabled: '{{ ne (lookup "policy.open-cluster-management.io/v1" "Policy" "<POLICIESNS>" "policy-autoscaler-templatized-config").status.compliant "Compliant" |  print | toBool }}'
 ---
 apiVersion: policy.open-cluster-management.io/v1

--- a/community/CM-Configuration-Management/policy-autoscaler.yaml
+++ b/community/CM-Configuration-Management/policy-autoscaler.yaml
@@ -18,11 +18,6 @@ spec:
         spec:
           remediationAction: inform
           severity: low
-          namespaceSelector:
-            exclude:
-              - kube-*
-            include:
-              - default
           object-templates:
             - complianceType: musthave
               objectDefinition:

--- a/community/CM-Configuration-Management/policy-cluster-dns-sample.yaml
+++ b/community/CM-Configuration-Management/policy-cluster-dns-sample.yaml
@@ -18,9 +18,6 @@ spec:
         spec:
           remediationAction: inform # will be overridden by remediationAction in parent policy
           severity: low
-          namespaceSelector:
-            exclude: ["kube-*"]
-            include: ["default"]
           object-templates:
             - complianceType: musthave
               objectDefinition:

--- a/community/CM-Configuration-Management/policy-cluster-logforwarder-templatized.yaml
+++ b/community/CM-Configuration-Management/policy-cluster-logforwarder-templatized.yaml
@@ -18,11 +18,6 @@ spec:
         spec:
           remediationAction: inform
           severity: low
-          namespaceSelector:
-            exclude:
-              - kube-*
-            include:
-              - default
           object-templates:
             - complianceType: musthave
               objectDefinition:

--- a/community/CM-Configuration-Management/policy-cluster-network-sample.yaml
+++ b/community/CM-Configuration-Management/policy-cluster-network-sample.yaml
@@ -18,9 +18,6 @@ spec:
         spec:
           remediationAction: inform # will be overridden by remediationAction in parent policy
           severity: low
-          namespaceSelector:
-            exclude: ["kube-*"]
-            include: ["default"]
           object-templates:
             - complianceType: musthave
               objectDefinition:

--- a/community/CM-Configuration-Management/policy-cluster-proxy-sample.yaml
+++ b/community/CM-Configuration-Management/policy-cluster-proxy-sample.yaml
@@ -18,9 +18,6 @@ spec:
         spec:
           remediationAction: inform # will be overridden by remediationAction in parent policy
           severity: low
-          namespaceSelector:
-            exclude: ["kube-*"]
-            include: ["default"]
           object-templates:
             - complianceType: musthave
               objectDefinition:
@@ -45,9 +42,6 @@ spec:
         spec:
           remediationAction: inform # will be overridden by remediationAction in parent policy
           severity: low
-          namespaceSelector:
-            exclude: ["kube-*"]
-            include: ["default"]
           object-templates:
             - complianceType: musthave
               objectDefinition: 

--- a/community/CM-Configuration-Management/policy-configure-logforwarding.yaml
+++ b/community/CM-Configuration-Management/policy-configure-logforwarding.yaml
@@ -18,11 +18,6 @@ spec:
         spec:
           remediationAction: inform
           severity: low
-          namespaceSelector:
-            exclude:
-              - kube-*
-            include:
-              - default
           object-templates:
             - complianceType: musthave
               objectDefinition:

--- a/community/CM-Configuration-Management/policy-custom-catalog.yaml
+++ b/community/CM-Configuration-Management/policy-custom-catalog.yaml
@@ -18,11 +18,6 @@ spec:
         spec:
           remediationAction: inform
           severity: medium
-          namespaceSelector:
-            exclude:
-              - kube-*
-            include:
-              - default
           object-templates:
             - complianceType: musthave
               objectDefinition:

--- a/community/CM-Configuration-Management/policy-egress-firewall-sample.yaml
+++ b/community/CM-Configuration-Management/policy-egress-firewall-sample.yaml
@@ -19,8 +19,6 @@ spec:
           remediationAction: inform
           severity: low
           namespaceSelector:
-            exclude:
-              - kube-*
             include:
               - default
           object-templates:

--- a/community/CM-Configuration-Management/policy-enable-if-etcd-encrypted-templatized.yaml
+++ b/community/CM-Configuration-Management/policy-enable-if-etcd-encrypted-templatized.yaml
@@ -1,12 +1,12 @@
-#This demonstrates enabling root policy based on status of a resource on the hub-cluster , using templates
+# This demonstrates enabling root policy based on status of a resource on the hub-cluster , using templates
 # Below shows two policies
 # 1 - policy-conditionalsecret : Enforces a Secret resource on the cluster, it is disabled by default.
 # 2 - policy-conditionalsecret-enabler : Checks if etcd encryption is set  and enables the above policy #1 that enforces a secure secret.
 
-#NOTE
-#The file has 2 related policies clubbed together, 
-#when deploying through GRC UI Editor pls copy paste each policy resource individually as the ui can handle only one policy at a time.
-#pls make sure to deploy both policies in the same namespace and replace any placeholder <POLICIESNS> in this file with the policy namespace.
+# NOTE
+# The file has 2 related policies clubbed together, 
+# when deploying through GRC UI Editor pls copy paste each policy resource individually as the ui can handle only one policy at a time.
+# pls make sure to deploy both policies in the same namespace and replace any placeholder <POLICIESNS> in this file with the policy namespace.
 
 
 apiVersion: policy.open-cluster-management.io/v1
@@ -29,11 +29,6 @@ spec:
         spec:
           remediationAction: inform
           severity: low
-          namespaceSelector:
-            exclude:
-              - kube-*
-            include:
-              - default
           object-templates:
             - complianceType: musthave
               objectDefinition:
@@ -67,11 +62,6 @@ spec:
         spec:
           remediationAction: inform
           severity: low
-          namespaceSelector:
-            exclude:
-              - kube-*
-            include:
-              - default
           object-templates:
             - complianceType: musthave
               objectDefinition:

--- a/community/CM-Configuration-Management/policy-enable-if-ns-exists-templatized.yaml
+++ b/community/CM-Configuration-Management/policy-enable-if-ns-exists-templatized.yaml
@@ -1,13 +1,13 @@
-#This demonstrates enabling root policy based on status of a resource on the hub-cluster , using templates
+# This demonstrates enabling root policy based on status of a resource on the hub-cluster , using templates
 # Below shows two policies
 # 1 - policy-conditionalconfigmap : Enforces a configmap resource in namespace "test", it is disabled by default.
 # 2 - policy-conditionalconfigmap-enabler : Checks if namespace "test" exists  and if it exists , 
 #                                           enables the above policy #1 (policy-conditionalconfigmap) that enforces a configmap .
 
-#NOTE
-#The file has 2 related policies clubbed together, 
-#when deploying through GRC UI Editor pls copy paste each policy resource individually as the ui can handle only one policy at a time.
-#pls make sure to deploy both policies in the same namespace and replace any placeholder <POLICIESNS> in this file with the policy namespace.
+# NOTE
+# The file has 2 related policies clubbed together, 
+# when deploying through GRC UI Editor pls copy paste each policy resource individually as the ui can handle only one policy at a time.
+# pls make sure to deploy both policies in the same namespace and replace any placeholder <POLICIESNS> in this file with the policy namespace.
 
 
 apiVersion: policy.open-cluster-management.io/v1
@@ -30,11 +30,6 @@ spec:
         spec:
           remediationAction: inform
           severity: low
-          namespaceSelector:
-            exclude:
-              - kube-*
-            include:
-              - default
           object-templates:
             - complianceType: musthave
               objectDefinition:
@@ -66,11 +61,6 @@ spec:
         spec:
           remediationAction: inform
           severity: low
-          namespaceSelector:
-            exclude:
-              - kube-*
-            include:
-              - default
           object-templates:
             - complianceType: musthave
               objectDefinition:

--- a/community/CM-Configuration-Management/policy-engineering-configmap.yaml
+++ b/community/CM-Configuration-Management/policy-engineering-configmap.yaml
@@ -19,8 +19,6 @@ spec:
           remediationAction: enforce
           severity: low
           namespaceSelector:
-            exclude:
-              - kube-*
             include:
               - default
           object-templates:

--- a/community/CM-Configuration-Management/policy-engineering-pod-disruption-budget.yaml
+++ b/community/CM-Configuration-Management/policy-engineering-pod-disruption-budget.yaml
@@ -19,7 +19,6 @@ spec:
           remediationAction: enforce # will be overridden by remediationAction in parent policy
           severity: low
           namespaceSelector:
-            exclude: ["kube-*"]
             include: ["default"]
           object-templates:
             - complianceType: musthave
@@ -42,7 +41,6 @@ spec:
           remediationAction: enforce # will be overridden by remediationAction in parent policy
           severity: low
           namespaceSelector:
-            exclude: ["kube-*"]
             include: ["default"]
           object-templates:
             - complianceType: musthave

--- a/community/CM-Configuration-Management/policy-etcd-backup.yaml
+++ b/community/CM-Configuration-Management/policy-etcd-backup.yaml
@@ -16,8 +16,6 @@ spec:
           name: policy-etcd-backup
         spec:
           namespaceSelector:
-            exclude:
-              - kube-*
             include:
               - default
           object-templates:

--- a/community/CM-Configuration-Management/policy-github-oauth-sample.yaml
+++ b/community/CM-Configuration-Management/policy-github-oauth-sample.yaml
@@ -18,11 +18,6 @@ spec:
         spec:
           remediationAction: inform
           severity: low
-          namespaceSelector:
-            exclude:
-              - kube-*
-            include:
-              - default
           object-templates:
             - complianceType: musthave
               objectDefinition:
@@ -49,11 +44,6 @@ spec:
         spec:
           remediationAction: inform
           severity: low
-          namespaceSelector:
-            exclude:
-              - kube-*
-            include:
-              - default
           object-templates:
             - complianceType: musthave
               objectDefinition:

--- a/community/CM-Configuration-Management/policy-image-policy-sample.yaml
+++ b/community/CM-Configuration-Management/policy-image-policy-sample.yaml
@@ -18,11 +18,6 @@ spec:
         spec:
           remediationAction: enforce
           severity: low
-          namespaceSelector:
-            exclude:
-              - kube-*
-            include:
-              - default
           object-templates:
             - complianceType: musthave
               objectDefinition:

--- a/community/CM-Configuration-Management/policy-ingress-controller.yaml
+++ b/community/CM-Configuration-Management/policy-ingress-controller.yaml
@@ -18,11 +18,6 @@ spec:
         spec:
           remediationAction: inform
           severity: low
-          namespaceSelector:
-            exclude:
-              - kube-*
-            include:
-              - default
           object-templates:
             - complianceType: musthave
               objectDefinition:

--- a/community/CM-Configuration-Management/policy-install-kyverno.yaml
+++ b/community/CM-Configuration-Management/policy-install-kyverno.yaml
@@ -18,11 +18,6 @@ spec:
         spec:
           remediationAction: inform
           severity: low
-          namespaceSelector:
-            exclude:
-              - kube-*
-            include:
-              - default
           object-templates:
             - complianceType: musthave
               objectDefinition:
@@ -44,11 +39,6 @@ spec:
         spec:
           remediationAction: inform
           severity: low
-          namespaceSelector:
-            exclude:
-              - kube-*
-            include:
-              - default
           object-templates:
             - complianceType: musthave
               objectDefinition:

--- a/community/CM-Configuration-Management/policy-kernel-devel.yaml
+++ b/community/CM-Configuration-Management/policy-kernel-devel.yaml
@@ -30,9 +30,6 @@ spec:
         spec:
           remediationAction: enforce # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
           severity: low
-          namespaceSelector:
-            exclude: ["kube-*"]
-            include: ["*"]
           object-templates:
             - complianceType: musthave
               objectDefinition:

--- a/community/CM-Configuration-Management/policy-label-cluster.yaml
+++ b/community/CM-Configuration-Management/policy-label-cluster.yaml
@@ -18,11 +18,6 @@ spec:
         spec:
           remediationAction: inform
           severity: low
-          namespaceSelector:
-            exclude:
-              - kube-*
-            include:
-              - default
           object-templates:
             - complianceType: musthave
               objectDefinition:

--- a/community/CM-Configuration-Management/policy-machineconfig-chrony.yaml
+++ b/community/CM-Configuration-Management/policy-machineconfig-chrony.yaml
@@ -15,11 +15,6 @@ spec:
         metadata:
           name: add-chrony-worker
         spec:
-          namespaceSelector:
-            exclude:
-              - kube-*
-            include:
-              - default
           object-templates:
             - complianceType: musthave
               objectDefinition:

--- a/community/CM-Configuration-Management/policy-managedclusterinfo-templatized.yaml
+++ b/community/CM-Configuration-Management/policy-managedclusterinfo-templatized.yaml
@@ -1,11 +1,11 @@
-#This sample policy demonstrates building a configmap with managedcluster specific info using managed-cluster templates
+# This sample policy demonstrates building a configmap with managedcluster specific info using managed-cluster templates
 # such  configmap can later be referenced in other policies to configure target cluster specific values.
 
-#NOTES
-#All cluster labels are available on the managed cluster env  as clusterclaim resources. 
-#fromClusterClaim() can be used to retrive the values of  DEFAULT LABELS like id.openshift.io, version.openshift.io etc are available on all managed clusters.
+# NOTES
+# All cluster labels are available on the managed cluster env  as clusterclaim resources. 
+# fromClusterClaim() can be used to retrive the values of  DEFAULT LABELS like id.openshift.io, version.openshift.io etc are available on all managed clusters.
 
-#In the below policy, 
+# In the below policy, 
 # a configmap is created with the cluster specific info like id, version retrieved through fromClusterClaim func
 
 apiVersion: policy.open-cluster-management.io/v1

--- a/community/CM-Configuration-Management/policy-network-policy-samples.yaml
+++ b/community/CM-Configuration-Management/policy-network-policy-samples.yaml
@@ -16,8 +16,6 @@ spec:
           name: allow-http-and-https
         spec:
           namespaceSelector:
-            exclude:
-              - kube-*
             include:
               - default
           object-templates:
@@ -46,8 +44,6 @@ spec:
           name: deny-all
         spec:
           namespaceSelector:
-            exclude:
-              - kube-*
             include:
               - default
           object-templates:
@@ -69,8 +65,6 @@ spec:
           name: allow-same-namespace
         spec:
           namespaceSelector:
-            exclude:
-              - kube-*
             include:
               - default
           object-templates:
@@ -94,8 +88,6 @@ spec:
           name: allow-pod-and-namespace-both
         spec:
           namespaceSelector:
-            exclude:
-              - kube-*
             include:
               - default
           object-templates:

--- a/community/CM-Configuration-Management/policy-nginx-deployment-templatized.yaml
+++ b/community/CM-Configuration-Management/policy-nginx-deployment-templatized.yaml
@@ -25,8 +25,6 @@ spec:
           remediationAction: inform
           severity: low
           namespaceSelector:
-            exclude:
-              - kube-*
             include:
               - default
           object-templates:

--- a/community/CM-Configuration-Management/policy-nginx-deployment.yaml
+++ b/community/CM-Configuration-Management/policy-nginx-deployment.yaml
@@ -19,8 +19,6 @@ spec:
           remediationAction: inform
           severity: low
           namespaceSelector:
-            exclude:
-              - kube-*
             include:
               - default
           object-templates:

--- a/community/CM-Configuration-Management/policy-oauth-config.yaml
+++ b/community/CM-Configuration-Management/policy-oauth-config.yaml
@@ -21,11 +21,6 @@ spec:
         spec:
           remediationAction: inform
           severity: low
-          namespaceSelector:
-            exclude:
-              - kube-*
-            include:
-              - default
           object-templates:
             - complianceType: musthave
               objectDefinition:

--- a/community/CM-Configuration-Management/policy-oc-client-cronjob.yaml
+++ b/community/CM-Configuration-Management/policy-oc-client-cronjob.yaml
@@ -16,11 +16,6 @@ spec:
       metadata:
         name: policy-oc-client
       spec:
-        namespaceSelector:
-          exclude:
-            - kube-*
-          include:
-            - default
         object-templates:
           - complianceType: musthave
             objectDefinition:

--- a/community/CM-Configuration-Management/policy-opa-sample.yaml
+++ b/community/CM-Configuration-Management/policy-opa-sample.yaml
@@ -19,7 +19,6 @@ spec:
           remediationAction: enforce
           severity: high
           namespaceSelector:
-            exclude: ["kube-*"]
             include: ["default"]
           object-templates:
             - complianceType: musthave

--- a/community/CM-Configuration-Management/policy-openshift-gitops.yaml
+++ b/community/CM-Configuration-Management/policy-openshift-gitops.yaml
@@ -18,11 +18,6 @@ spec:
         spec:
           remediationAction: enforce
           severity: medium
-          namespaceSelector:
-            exclude:
-              - kube-*
-            include:
-              - default
           object-templates:
             - complianceType: musthave
               objectDefinition:

--- a/community/CM-Configuration-Management/policy-pao-operator.yaml
+++ b/community/CM-Configuration-Management/policy-pao-operator.yaml
@@ -18,14 +18,11 @@ spec:
         spec:
           remediationAction: enforce # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
           severity: low
-          namespaceSelector:
-            exclude: ["kube-*"]
-            include: ["*"]
           object-templates:
             - complianceType: musthave
               objectDefinition:
                 apiVersion: v1
-                kind: Namespace # must have openshift-pao
+                kind: Namespace # must have namespace openshift-performance-addon
                 metadata:
                   name: openshift-performance-addon
                 spec: {}
@@ -37,9 +34,6 @@ spec:
         spec:
           remediationAction: enforce # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
           severity: low
-          namespaceSelector:
-            exclude: ["kube-*"]
-            include: ["*"]
           object-templates:
             - complianceType: musthave
               objectDefinition:
@@ -60,9 +54,6 @@ spec:
         spec:
           remediationAction: enforce # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
           severity: low
-          namespaceSelector:
-            exclude: ["kube-*"]
-            include: ["*"]
           object-templates:
             - complianceType: musthave
               objectDefinition:

--- a/community/CM-Configuration-Management/policy-pod-disruption-budget-templatized.yaml
+++ b/community/CM-Configuration-Management/policy-pod-disruption-budget-templatized.yaml
@@ -1,14 +1,14 @@
-#This sample policy demonstrate configuring pod disruption budget "customized" to managedcluster using managedcluster-templates
-#It customizes the values in  PodDisruptionBudget resource based on whether the managedcluster has the custom label environment=prod
+# This sample policy demonstrate configuring pod disruption budget "customized" to managedcluster using managedcluster-templates
+# It customizes the values in  PodDisruptionBudget resource based on whether the managedcluster has the custom label environment=prod
 
-#NOTES
-#All cluster labels are available on the managed cluster env  as clusterclaim resources. 
+# NOTES
+# All cluster labels are available on the managed cluster env  as clusterclaim resources. 
 
-#fromClusterClaim() should be used for default labels\clusterclaims like id.openshift.io, version.openshift.io etc are available on all managed clusters
-#using it on custom labels that may not be avaliable on all clusters may cause a policy violation on the clusters where it doesnt exist.
+# fromClusterClaim() should be used for default labels\clusterclaims like id.openshift.io, version.openshift.io etc are available on all managed clusters
+# using it on custom labels that may not be avaliable on all clusters may cause a policy violation on the clusters where it doesnt exist.
 
-#for CUSTOM LABELS, instead consider using the lookup function to first check  the existence of clusterclaim resource and then get retrieve the value as needed.
-#As shown in the policy below.
+# for CUSTOM LABELS, instead consider using the lookup function to first check  the existence of clusterclaim resource and then get retrieve the value as needed.
+# As shown in the policy below.
 
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
@@ -31,7 +31,6 @@ spec:
           remediationAction: enforce # will be overridden by remediationAction in parent policy
           severity: low
           namespaceSelector:
-            exclude: ["kube-*"]
             include: ["default"]
           object-templates:
             - complianceType: musthave

--- a/community/CM-Configuration-Management/policy-ptp-operator.yaml
+++ b/community/CM-Configuration-Management/policy-ptp-operator.yaml
@@ -18,9 +18,6 @@ spec:
         spec:
           remediationAction: enforce # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
           severity: low
-          namespaceSelector:
-            exclude: ["kube-*"]
-            include: ["*"]
           object-templates:
             - complianceType: musthave
               objectDefinition:
@@ -40,9 +37,6 @@ spec:
         spec:
           remediationAction: enforce # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
           severity: low
-          namespaceSelector:
-            exclude: ["kube-*"]
-            include: ["*"]
           object-templates:
             - complianceType: musthave
               objectDefinition:
@@ -62,9 +56,6 @@ spec:
         spec:
           remediationAction: enforce # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
           severity: low
-          namespaceSelector:
-            exclude: ["kube-*"]
-            include: ["*"]
           object-templates:
             - complianceType: musthave
               objectDefinition:
@@ -87,9 +78,6 @@ spec:
         spec:
           remediationAction: enforce # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
           severity: low
-          namespaceSelector:
-            exclude: ["kube-*"]
-            include: ["*"]
           object-templates:
             - complianceType: musthave
               objectDefinition:
@@ -109,9 +97,6 @@ spec:
         spec:
           remediationAction: enforce # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
           severity: low
-          namespaceSelector:
-            exclude: ["kube-*"]
-            include: ["*"]
           object-templates:
             - complianceType: musthave
               objectDefinition:

--- a/community/CM-Configuration-Management/policy-resiliency-image-pruner.yaml
+++ b/community/CM-Configuration-Management/policy-resiliency-image-pruner.yaml
@@ -18,11 +18,6 @@ spec:
         spec:
           remediationAction: inform
           severity: low
-          namespaceSelector:
-            exclude:
-              - kube-*
-            include:
-              - default
           object-templates:
             - complianceType: musthave
               objectDefinition:

--- a/community/CM-Configuration-Management/policy-rhsso-operator.yaml
+++ b/community/CM-Configuration-Management/policy-rhsso-operator.yaml
@@ -18,9 +18,6 @@ spec:
         spec:
           remediationAction: enforce # will be overridden by remediationAction in parent policy
           severity: high
-          namespaceSelector:
-            exclude: ["kube-*"]
-            include: ["*"]
           object-templates:
             - complianceType: musthave
               objectDefinition:
@@ -37,9 +34,6 @@ spec:
         spec:
           remediationAction: enforce # will be overridden by remediationAction in parent policy
           severity: high
-          namespaceSelector:
-            exclude: ["kube-*", "openshift-*"]
-            include: ["keycloak"]
           object-templates:
             - complianceType: musthave
               objectDefinition:
@@ -72,9 +66,6 @@ spec:
         spec:
           remediationAction: enforce # will be overridden by remediationAction in parent policy
           severity: high
-          namespaceSelector:
-            exclude: ["kube-*", "openshift-*"]
-            include: ["keycloak"]
           object-templates:
             - complianceType: musthave
               objectDefinition:

--- a/community/CM-Configuration-Management/policy-scheduler.yaml
+++ b/community/CM-Configuration-Management/policy-scheduler.yaml
@@ -18,11 +18,6 @@ spec:
         spec:
           remediationAction: inform
           severity: low
-          namespaceSelector:
-            exclude:
-              - kube-*
-            include:
-              - default
           object-templates:
             - complianceType: musthave
               objectDefinition:

--- a/community/CM-Configuration-Management/policy-sriov-operator.yaml
+++ b/community/CM-Configuration-Management/policy-sriov-operator.yaml
@@ -18,9 +18,6 @@ spec:
         spec:
           remediationAction: enforce # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
           severity: low
-          namespaceSelector:
-            exclude: ["kube-*"]
-            include: ["*"]
           object-templates:
             - complianceType: musthave
               objectDefinition:
@@ -36,9 +33,6 @@ spec:
         spec:
           remediationAction: enforce # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
           severity: low
-          namespaceSelector:
-            exclude: ["kube-*"]
-            include: ["*"]
           object-templates:
             - complianceType: musthave
               objectDefinition:
@@ -58,9 +52,6 @@ spec:
         spec:
           remediationAction: enforce # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
           severity: low
-          namespaceSelector:
-            exclude: ["kube-*"]
-            include: ["*"]
           object-templates:
             - complianceType: musthave
               objectDefinition:
@@ -83,9 +74,6 @@ spec:
         spec:
           remediationAction: enforce # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
           severity: low
-          namespaceSelector:
-            exclude: ["kube-*"]
-            include: ["*"]
           object-templates:
             - complianceType: musthave
               objectDefinition:
@@ -107,9 +95,6 @@ spec:
         spec:
           remediationAction: inform # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
           severity: low
-          namespaceSelector:
-            exclude: ["kube-*"]
-            include: ["*"]
           object-templates:
             - complianceType: musthave
               objectDefinition:
@@ -135,9 +120,6 @@ spec:
         spec:
           remediationAction: enforce # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
           severity: low
-          namespaceSelector:
-            exclude: ["kube-*"]
-            include: ["*"]
           object-templates:
             - complianceType: musthave
               objectDefinition:

--- a/community/CM-Configuration-Management/policy-sriovnetwork-templatized.yaml
+++ b/community/CM-Configuration-Management/policy-sriovnetwork-templatized.yaml
@@ -24,11 +24,6 @@ spec:
             spec:
                 remediationAction: inform
                 severity: low
-                namespaceselector:
-                    exclude:
-                        - kube-*
-                    include:
-                        - '*'
                 object-templates:
                     - complianceType: musthave
                       objectDefinition:
@@ -90,11 +85,6 @@ spec:
         spec:
           remediationAction: inform
           severity: low
-          namespaceSelector:
-            exclude:
-              - kube-*
-            include:
-              - default
           object-templates:
             - complianceType: musthave
               objectDefinition:

--- a/community/CM-Configuration-Management/policy-trusted-container.yaml
+++ b/community/CM-Configuration-Management/policy-trusted-container.yaml
@@ -19,7 +19,6 @@ spec:
           severity: low
           namespaceSelector:
             include: ["default"]
-            exclude: ["kube-system"]
           remediationAction: inform
           imageRegistry: quay.io
 ---

--- a/community/CM-Configuration-Management/policy-update-service-openshift-cluster.yaml
+++ b/community/CM-Configuration-Management/policy-update-service-openshift-cluster.yaml
@@ -18,11 +18,6 @@ spec:
       spec:
         remediationAction: enforce
         severity: medium
-        namespaceSelector:
-          exclude:
-            - kube-*
-          include:
-            - default
         object-templates:
           - complianceType: musthave
             objectDefinition:
@@ -47,11 +42,6 @@ spec:
       spec:
         remediationAction: enforce
         severity: medium
-        namespaceSelector:
-          exclude:
-            - kube-*
-          include:
-            - default
         object-templates:
           - complianceType: musthave
             objectDefinition:

--- a/community/CM-Configuration-Management/policy-upgrade-openshift-cluster.yaml
+++ b/community/CM-Configuration-Management/policy-upgrade-openshift-cluster.yaml
@@ -17,11 +17,6 @@ spec:
         spec:
           remediationAction: inform
           severity: low
-          namespaceSelector:
-            exclude:
-              - kube-*
-            include:
-              - default          
           object-templates:
             - complianceType: musthave
               objectDefinition:
@@ -42,11 +37,6 @@ spec:
         spec:
           remediationAction: inform
           severity: low
-          namespaceSelector:
-            exclude:
-              - kube-*
-            include:
-              - default
           object-templates:
             - complianceType: mustnothave
               objectDefinition:
@@ -64,11 +54,6 @@ spec:
         spec:
           remediationAction: inform
           severity: low
-          namespaceSelector:
-            exclude:
-              - kube-*
-            include:
-              - default
           object-templates:
             - complianceType: mustnothave
               objectDefinition:

--- a/community/CM-Configuration-Management/policy-zts-cmc-deployment.yaml
+++ b/community/CM-Configuration-Management/policy-zts-cmc-deployment.yaml
@@ -19,8 +19,6 @@ spec:
           remediationAction: inform
           severity: low
           namespaceSelector:
-            exclude:
-              - kube-*
             include:
               - default
           object-templates:
@@ -55,8 +53,6 @@ spec:
           remediationAction: inform
           severity: low
           namespaceSelector:
-            exclude:
-              - kube-*
             include:
               - default
           object-templates:
@@ -83,8 +79,6 @@ spec:
           remediationAction: inform
           severity: low
           namespaceSelector:
-            exclude:
-              - kube-*
             include:
               - default 
           object-templates:

--- a/community/SC-System-and-Communications-Protection/policy-checkclusteroperator.yaml
+++ b/community/SC-System-and-Communications-Protection/policy-checkclusteroperator.yaml
@@ -19,8 +19,6 @@ spec:
           remediationAction: inform
           severity: low
           namespaceSelector:
-            exclude:
-              - kube-*
             include:
               - default
           object-templates:
@@ -41,8 +39,6 @@ spec:
           remediationAction: inform
           severity: low
           namespaceSelector:
-            exclude:
-              - kube-*
             include:
               - default
           object-templates:

--- a/community/SI-System-and-Information-Integrity/policy-falco-auditing.yaml
+++ b/community/SI-System-and-Information-Integrity/policy-falco-auditing.yaml
@@ -38,9 +38,6 @@ spec:
         spec:
           remediationAction: inform # will be overridden by remediationAction in parent policy
           severity: low
-          namespaceSelector:
-            include:
-              - "falco"
           object-templates:
             - complianceType: musthave
               objectDefinition:

--- a/community/SI-System-and-Information-Integrity/policy-sysdig.yaml
+++ b/community/SI-System-and-Information-Integrity/policy-sysdig.yaml
@@ -27,9 +27,6 @@ spec:
         spec:
           remediationAction: enforce # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
           severity: low
-          namespaceSelector:
-            exclude: ["kube-*"]
-            include: ["*"]
           object-templates:
             - complianceType: musthave
               objectDefinition:
@@ -46,9 +43,6 @@ spec:
         spec:
           remediationAction: enforce # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
           severity: low
-          namespaceSelector:
-            exclude: ["kube-*"]
-            include: ["sysdig-operator"]
           object-templates:
             - complianceType: musthave
               objectDefinition:
@@ -68,9 +62,6 @@ spec:
         spec:
           remediationAction: enforce # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
           severity: low
-          namespaceSelector:
-            exclude: ["kube-*"]
-            include: ["sysdig-operator"]
           object-templates:
             - complianceType: musthave
               objectDefinition:
@@ -93,9 +84,6 @@ spec:
         spec:
           remediationAction: enforce # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
           severity: low
-          namespaceSelector:
-            exclude: ["kube-*"]
-            include: ["sysdig-operator"]
           object-templates:
             - complianceType: musthave
               objectDefinition:

--- a/policygenerator/policy-sets/community/openshift-hardening/input-admin/policy-limitclusteradmin.yaml
+++ b/policygenerator/policy-sets/community/openshift-hardening/input-admin/policy-limitclusteradmin.yaml
@@ -17,8 +17,5 @@ spec:
           name: policy-limitclusteradmin-example
         spec:
           severity: medium
-          namespaceSelector:
-            include: ["*"]
-            exclude: ["kube-*", "openshift-*"]
           remediationAction: inform # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
           maxClusterRoleBindingUsers: 5

--- a/stable/AC-Access-Control/policy-limitclusteradmin.yaml
+++ b/stable/AC-Access-Control/policy-limitclusteradmin.yaml
@@ -17,9 +17,6 @@ spec:
           name: policy-limitclusteradmin-example
         spec:
           severity: medium
-          namespaceSelector:
-            include: ["*"]
-            exclude: ["kube-*", "openshift-*"]
           remediationAction: inform # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
           maxClusterRoleBindingUsers: 5
 ---

--- a/stable/AC-Access-Control/policy-role.yaml
+++ b/stable/AC-Access-Control/policy-role.yaml
@@ -19,7 +19,6 @@ spec:
           remediationAction: inform # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
           severity: high
           namespaceSelector:
-            exclude: ["kube-*"]
             include: ["default"]
           object-templates:
             - complianceType: mustonlyhave # role definition should exact match

--- a/stable/AC-Access-Control/policy-rolebinding.yaml
+++ b/stable/AC-Access-Control/policy-rolebinding.yaml
@@ -19,7 +19,6 @@ spec:
           remediationAction: inform # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
           severity: high
           namespaceSelector:
-            exclude: ["kube-*"]
             include: ["default"]
           object-templates:
             - complianceType: musthave

--- a/stable/CM-Configuration-Management/policy-namespace.yaml
+++ b/stable/CM-Configuration-Management/policy-namespace.yaml
@@ -18,9 +18,6 @@ spec:
         spec:
           remediationAction: inform # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
           severity: low
-          namespaceSelector:
-            exclude: ["kube-*"]
-            include: ["default"]
           object-templates:
             - complianceType: musthave
               objectDefinition:

--- a/stable/CM-Configuration-Management/policy-pod.yaml
+++ b/stable/CM-Configuration-Management/policy-pod.yaml
@@ -19,7 +19,6 @@ spec:
           remediationAction: inform # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
           severity: low
           namespaceSelector:
-            exclude: ["kube-*"]
             include: ["default"]
           object-templates:
             - complianceType: musthave

--- a/stable/CM-Configuration-Management/policy-zts-cmc.yaml
+++ b/stable/CM-Configuration-Management/policy-zts-cmc.yaml
@@ -1,6 +1,6 @@
-#This policy uses the Config Map reloader to restart the deployment
-#when the Configmap changes.  
-#https://github.com/stakater/Reloader/blob/master/LICENSE
+# This policy uses the Config Map reloader to restart the deployment
+# when the Configmap changes.  
+# https://github.com/stakater/Reloader/blob/master/LICENSE
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
@@ -22,8 +22,6 @@ spec:
           remediationAction: inform
           severity: low
           namespaceSelector:
-            exclude:
-              - kube-*
             include:
               - default
           object-templates:
@@ -58,8 +56,6 @@ spec:
           remediationAction: inform 
           severity: low
           namespaceSelector:
-            exclude:
-              - kube-*
             include:
               - default 
           object-templates:

--- a/stable/SC-System-and-Communications-Protection/policy-certificate.yaml
+++ b/stable/SC-System-and-Communications-Protection/policy-certificate.yaml
@@ -18,7 +18,6 @@ spec:
         spec:
           namespaceSelector:
             include: ["default"]
-            exclude: ["kube-*"]
           remediationAction: inform # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
           severity: low
           minimumDuration: 300h

--- a/stable/SC-System-and-Communications-Protection/policy-limitmemory.yaml
+++ b/stable/SC-System-and-Communications-Protection/policy-limitmemory.yaml
@@ -19,7 +19,6 @@ spec:
           remediationAction: inform # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
           severity: medium
           namespaceSelector:
-            exclude: ["kube-*"]
             include: ["default"]
           object-templates:
             - complianceType: mustonlyhave

--- a/stable/SC-System-and-Communications-Protection/policy-psp.yaml
+++ b/stable/SC-System-and-Communications-Protection/policy-psp.yaml
@@ -19,7 +19,6 @@ spec:
           remediationAction: inform # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
           severity: high
           namespaceSelector:
-            exclude: ["kube-*"]
             include: ["default"]
           object-templates:
             - complianceType: musthave
@@ -31,7 +30,7 @@ spec:
                   annotations:
                     seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
                 spec:
-                  privileged: false # no priviliedged pods
+                  privileged: false # no privileged pods
                   allowPrivilegeEscalation: false
                   allowedCapabilities:
                   - '*'


### PR DESCRIPTION
- For clusterwide objects, remove it entirely
- For objects with namespace specified, remove it entirely
- For selectors that have a definitive `include`, remove `exclude`
