### PR TITLE
Moving the secrets and securedcluster cr before job broke acs install

### DIFF
--- a/policygenerator/policy-sets/community/openshift-plus/input-sensor/policy-acs-central-ca-bundle.yaml
+++ b/policygenerator/policy-sets/community/openshift-plus/input-sensor/policy-acs-central-ca-bundle.yaml
@@ -63,62 +63,6 @@ subjects:
   name: create-cluster-init
   namespace: stackrox
 ---
-apiVersion: platform.stackrox.io/v1alpha1
-kind: SecuredCluster
-metadata:
-  name: stackrox-secured-cluster-services
-  namespace: stackrox
-spec:
-  clusterName: |
-    {{ fromSecret "open-cluster-management-agent" "hub-kubeconfig-secret" "cluster-name" | base64dec }}
-  auditLogs:
-    collection: Auto
-  centralEndpoint: |
-    {{ fromSecret "stackrox" "sensor-tls" "acs-host" | base64dec }}
-  admissionControl:
-    listenOnCreates: false
-    listenOnEvents: true
-    listenOnUpdates: false
-  perNode:
-    collector:
-      collection: KernelModule
-      imageFlavor: Regular
-    taintToleration: TolerateTaints
----
-apiVersion: v1
-data:
-  admission-control-cert.pem: '{{ fromSecret "stackrox" "admission-control-tls" "admission-control-cert.pem" }}'
-  admission-control-key.pem: '{{ fromSecret "stackrox" "admission-control-tls" "admission-control-key.pem" }}'
-  ca.pem: '{{ fromSecret "stackrox" "admission-control-tls" "ca.pem" }}'
-kind: Secret
-metadata:
-  name: admission-control-tls
-  namespace: policies
-type: Opaque
----
-apiVersion: v1
-data:
-  collector-cert.pem: '{{ fromSecret "stackrox" "collector-tls" "collector-cert.pem" }}'
-  collector-key.pem: '{{ fromSecret "stackrox" "collector-tls" "collector-key.pem" }}'
-  ca.pem: '{{ fromSecret "stackrox" "collector-tls" "ca.pem" }}'
-kind: Secret
-metadata:
-  name: collector-tls
-  namespace: policies
-type: Opaque
----
-apiVersion: v1
-data:
-  sensor-cert.pem: '{{ fromSecret "stackrox" "sensor-tls" "sensor-cert.pem" }}'
-  sensor-key.pem: '{{ fromSecret "stackrox" "sensor-tls" "sensor-key.pem" }}'
-  ca.pem: '{{ fromSecret "stackrox" "sensor-tls" "ca.pem" }}'
-  acs-host: '{{ fromSecret "stackrox" "sensor-tls" "acs-host" }}'
-kind: Secret
-metadata:
-  name: sensor-tls
-  namespace: policies
-type: Opaque
----
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -197,3 +141,59 @@ spec:
       serviceAccount: create-cluster-init
       serviceAccountName: create-cluster-init
       terminationGracePeriodSeconds: 30
+---
+apiVersion: platform.stackrox.io/v1alpha1
+kind: SecuredCluster
+metadata:
+  name: stackrox-secured-cluster-services
+  namespace: stackrox
+spec:
+  clusterName: |
+    {{ fromSecret "open-cluster-management-agent" "hub-kubeconfig-secret" "cluster-name" | base64dec }}
+  auditLogs:
+    collection: Auto
+  centralEndpoint: |
+    {{ fromSecret "stackrox" "sensor-tls" "acs-host" | base64dec }}
+  admissionControl:
+    listenOnCreates: false
+    listenOnEvents: true
+    listenOnUpdates: false
+  perNode:
+    collector:
+      collection: KernelModule
+      imageFlavor: Regular
+    taintToleration: TolerateTaints
+---
+apiVersion: v1
+data:
+  admission-control-cert.pem: '{{ fromSecret "stackrox" "admission-control-tls" "admission-control-cert.pem" }}'
+  admission-control-key.pem: '{{ fromSecret "stackrox" "admission-control-tls" "admission-control-key.pem" }}'
+  ca.pem: '{{ fromSecret "stackrox" "admission-control-tls" "ca.pem" }}'
+kind: Secret
+metadata:
+  name: admission-control-tls
+  namespace: policies
+type: Opaque
+---
+apiVersion: v1
+data:
+  collector-cert.pem: '{{ fromSecret "stackrox" "collector-tls" "collector-cert.pem" }}'
+  collector-key.pem: '{{ fromSecret "stackrox" "collector-tls" "collector-key.pem" }}'
+  ca.pem: '{{ fromSecret "stackrox" "collector-tls" "ca.pem" }}'
+kind: Secret
+metadata:
+  name: collector-tls
+  namespace: policies
+type: Opaque
+---
+apiVersion: v1
+data:
+  sensor-cert.pem: '{{ fromSecret "stackrox" "sensor-tls" "sensor-cert.pem" }}'
+  sensor-key.pem: '{{ fromSecret "stackrox" "sensor-tls" "sensor-key.pem" }}'
+  ca.pem: '{{ fromSecret "stackrox" "sensor-tls" "ca.pem" }}'
+  acs-host: '{{ fromSecret "stackrox" "sensor-tls" "acs-host" }}'
+kind: Secret
+metadata:
+  name: sensor-tls
+  namespace: policies
+type: Opaque

--- a/policygenerator/policy-sets/community/openshift-plus/policyGenerator.yaml
+++ b/policygenerator/policy-sets/community/openshift-plus/policyGenerator.yaml
@@ -36,6 +36,7 @@ policies:
 - name: policy-acs-central-ca-bundle
   categories:
     - SI System and Information Integrity
+  consolidateManifests: false
   controls:
     - SI-5 Security Alerts Advisories and Directives
   manifests:


### PR DESCRIPTION
The ACS job has to be defined before the secrets and secured cluster
CR since object processing does not continue once a failure is
encountered.  This could be something to think about enhancing in the
config policy controller -- but for now I'm just undoing the change to
this file.  The change to ODF is working and doesn't have this issue.

Signed-off-by: Gus Parvin <gparvin@redhat.com>