### PR TITLE
Remove subscriptions that ODF now manages on its own

### DIFF
--- a/policygenerator/policy-sets/community/openshift-plus/input-odf/policy-odf.yaml
+++ b/policygenerator/policy-sets/community/openshift-plus/input-odf/policy-odf.yaml
@@ -23,28 +23,6 @@ spec:
   source: redhat-operators
   sourceNamespace: openshift-marketplace
 ---
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
-metadata:
-  name: ocs-operator
-  namespace: openshift-storage
-spec:
-  installPlanApproval: Automatic
-  name: ocs-operator
-  source: redhat-operators
-  sourceNamespace: openshift-marketplace
----
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
-metadata:
-  name: mcg-operator
-  namespace: openshift-storage
-spec:
-  installPlanApproval: Automatic
-  name: mcg-operator
-  source: redhat-operators
-  sourceNamespace: openshift-marketplace
----
 apiVersion: odf.openshift.io/v1alpha1
 kind: StorageSystem
 metadata:


### PR DESCRIPTION
ODF should install correctly now without specifying the OCS or MCG
subscriptions.

Signed-off-by: Gus Parvin <gparvin@redhat.com>