### PR TITLE
Need separated config policies when using acm 2.6 with stackrox

### DIFF
--- a/policygenerator/policy-sets/community/openshift-plus/policyGenerator.yaml
+++ b/policygenerator/policy-sets/community/openshift-plus/policyGenerator.yaml
@@ -44,6 +44,7 @@ policies:
 - name: policy-advanced-managed-cluster-security
   categories:
     - SI System and Information Integrity
+  consolidateManifests: false
   controls:
     - SI-5 Security Alerts Advisories and Directives
   manifests:


### PR DESCRIPTION
Changes in ACM 2.6 prevent object definitions from loading properly.
This is similar to a recent case where the problem happened with
stackrox on the hub.  This is the managed cluster case which only
happens when you have a managed cluster separate from the hub.

Signed-off-by: Gus Parvin <gparvin@redhat.com>