### PR TITLE
Links and timing concerns for quay

### DIFF
--- a/policygenerator/policy-sets/community/openshift-plus/input-acm-observability/policy-ocm-console.yaml
+++ b/policygenerator/policy-sets/community/openshift-plus/input-acm-observability/policy-ocm-console.yaml
@@ -1,0 +1,11 @@
+apiVersion: console.openshift.io/v1
+kind: ConsoleLink
+metadata:
+  name: observability
+spec:
+  applicationMenu:
+    section: Red Hat applications
+    imageURL: 'https://upload.wikimedia.org/wikipedia/commons/3/3a/OpenShift-LogoType.svg'
+  href: https://{{ (lookup "route.openshift.io/v1" "Route" "open-cluster-management-observability" "grafana").spec.host }}
+  location: ApplicationMenu
+  text: 'Red Hat Advanced Cluster Management Observability'

--- a/policygenerator/policy-sets/community/openshift-plus/input-quay/policy-config-quay.yaml
+++ b/policygenerator/policy-sets/community/openshift-plus/input-quay/policy-config-quay.yaml
@@ -1,98 +1,22 @@
 apiVersion: v1
-kind: Namespace
+kind: ConfigMap
 metadata:
-  labels:
-    openshift.io/cluster-monitoring: "true"
-  name: local-quay
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: create-admin-user
-  namespace: local-quay
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: create-admin-user
-  namespace: local-quay
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - create
-  - patch
-  - update
-- apiGroups:
-  - route.openshift.io
-  resources:
-  - routes
-  verbs:
-  - get
-  - list
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: create-admin-user
-  namespace: local-quay
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: create-admin-user
-subjects:
-- kind: ServiceAccount
-  name: create-admin-user
-  namespace: local-quay
----
-apiVersion: operators.coreos.com/v1
-kind: OperatorGroup
-metadata:
-  name: local-quay
-  namespace: local-quay
-spec:
-  targetNamespaces:
-  - local-quay
----
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
-metadata:
-  labels:
-    operators.coreos.com/quay-operator.local-quay: ""
-  name: quay-operator
-  namespace: local-quay
-spec:
-  channel: stable-3.7
-  installPlanApproval: Automatic
-  name: quay-operator
-  source: redhat-operators
-  sourceNamespace: openshift-marketplace
----
-apiVersion: v1
+  name: quay-config
+  namespace: policies
 data:
-  config.yaml: RkVBVFVSRV9VU0VSX0lOSVRJQUxJWkU6IHRydWUKQlJPV1NFUl9BUElfQ0FMTFNfWEhSX09OTFk6IGZhbHNlClNVUEVSX1VTRVJTOgotIHF1YXlhZG1pbgpGRUFUVVJFX1VTRVJfQ1JFQVRJT046IGZhbHNlCg==
-kind: Secret
-metadata:
-  name: init-config-bundle-secret
-  namespace: local-quay
-type: Opaque
+  host: '{{ (lookup "route.openshift.io/v1" "Route" "local-quay" "registry-quay" ).spec.host }}'
 ---
-apiVersion: quay.redhat.com/v1
-kind: QuayRegistry
+apiVersion: console.openshift.io/v1
+kind: ConsoleLink
 metadata:
-  name: registry
-  namespace: local-quay
+  name: quay
 spec:
-  configBundleSecret: init-config-bundle-secret
-  components:
-    - kind: objectstorage
-      managed: true
-    - managed: true
-      kind: tls
+  applicationMenu:
+    section: Red Hat applications
+    imageURL: 'https://upload.wikimedia.org/wikipedia/commons/3/3a/OpenShift-LogoType.svg'
+  href: 'https://{{ (lookup "route.openshift.io/v1" "Route" "local-quay" "registry-quay" ).spec.host }}'
+  location: ApplicationMenu
+  text: 'Red Hat Quay Enterprise Registry'
 ---
 apiVersion: batch/v1
 kind: Job
@@ -155,6 +79,17 @@ spec:
             password: $(echo ${ADMINPASS} | base64)
           EOF
             echo "Quay password successfully set for user quayadmin and stored in secret local-quay/quayadmin."
+            TOKEN=$(echo "$RESULT" | tr ',' '\n' | grep access_token | awk -F: '{print $2}' | sed 's/"//g')
+            cat <<EOF | kubectl create -f -
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: quay-api-token
+          type: Opaque
+          data:
+            token: $(echo ${TOKEN} | base64)
+          EOF
+            echo "Quay token successfully obtained and stored in secret quay-api-token."
           fi
         image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
         imagePullPolicy: Always

--- a/policygenerator/policy-sets/community/openshift-plus/input-quay/policy-install-quay.yaml
+++ b/policygenerator/policy-sets/community/openshift-plus/input-quay/policy-install-quay.yaml
@@ -1,0 +1,95 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  name: local-quay
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: create-admin-user
+  namespace: local-quay
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: create-admin-user
+  namespace: local-quay
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - create
+  - patch
+  - update
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: create-admin-user
+  namespace: local-quay
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: create-admin-user
+subjects:
+- kind: ServiceAccount
+  name: create-admin-user
+  namespace: local-quay
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: local-quay
+  namespace: local-quay
+spec:
+  targetNamespaces:
+  - local-quay
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/quay-operator.local-quay: ""
+  name: quay-operator
+  namespace: local-quay
+spec:
+  channel: stable-3.7
+  installPlanApproval: Automatic
+  name: quay-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+---
+apiVersion: v1
+data:
+  config.yaml: RkVBVFVSRV9VU0VSX0lOSVRJQUxJWkU6IHRydWUKQlJPV1NFUl9BUElfQ0FMTFNfWEhSX09OTFk6IGZhbHNlClNVUEVSX1VTRVJTOgotIHF1YXlhZG1pbgpGRUFUVVJFX1VTRVJfQ1JFQVRJT046IGZhbHNlCg==
+kind: Secret
+metadata:
+  name: init-config-bundle-secret
+  namespace: local-quay
+type: Opaque
+---
+apiVersion: quay.redhat.com/v1
+kind: QuayRegistry
+metadata:
+  name: registry
+  namespace: local-quay
+spec:
+  configBundleSecret: init-config-bundle-secret
+  components:
+    - kind: objectstorage
+      managed: true
+    - managed: true
+      kind: tls

--- a/policygenerator/policy-sets/community/openshift-plus/input-sensor/policy-acs-central-ca-bundle.yaml
+++ b/policygenerator/policy-sets/community/openshift-plus/input-sensor/policy-acs-central-ca-bundle.yaml
@@ -109,7 +109,6 @@ spec:
             curl -k -o /tmp/bundle.json -X POST -u "admin:$PASSWORD" -H "Content-Type: application/json" --data $DATA https://central/v1/cluster-init/init-bundles
 
             echo "Bundle received"
-            cat /tmp/bundle.json
 
             if [[ "$OSTYPE" == "linux-gnu"* ]]; then
                 BASE='base64 -w 0'
@@ -141,59 +140,3 @@ spec:
       serviceAccount: create-cluster-init
       serviceAccountName: create-cluster-init
       terminationGracePeriodSeconds: 30
----
-apiVersion: platform.stackrox.io/v1alpha1
-kind: SecuredCluster
-metadata:
-  name: stackrox-secured-cluster-services
-  namespace: stackrox
-spec:
-  clusterName: |
-    {{ fromSecret "open-cluster-management-agent" "hub-kubeconfig-secret" "cluster-name" | base64dec }}
-  auditLogs:
-    collection: Auto
-  centralEndpoint: |
-    {{ fromSecret "stackrox" "sensor-tls" "acs-host" | base64dec }}
-  admissionControl:
-    listenOnCreates: false
-    listenOnEvents: true
-    listenOnUpdates: false
-  perNode:
-    collector:
-      collection: KernelModule
-      imageFlavor: Regular
-    taintToleration: TolerateTaints
----
-apiVersion: v1
-data:
-  admission-control-cert.pem: '{{ fromSecret "stackrox" "admission-control-tls" "admission-control-cert.pem" }}'
-  admission-control-key.pem: '{{ fromSecret "stackrox" "admission-control-tls" "admission-control-key.pem" }}'
-  ca.pem: '{{ fromSecret "stackrox" "admission-control-tls" "ca.pem" }}'
-kind: Secret
-metadata:
-  name: admission-control-tls
-  namespace: policies
-type: Opaque
----
-apiVersion: v1
-data:
-  collector-cert.pem: '{{ fromSecret "stackrox" "collector-tls" "collector-cert.pem" }}'
-  collector-key.pem: '{{ fromSecret "stackrox" "collector-tls" "collector-key.pem" }}'
-  ca.pem: '{{ fromSecret "stackrox" "collector-tls" "ca.pem" }}'
-kind: Secret
-metadata:
-  name: collector-tls
-  namespace: policies
-type: Opaque
----
-apiVersion: v1
-data:
-  sensor-cert.pem: '{{ fromSecret "stackrox" "sensor-tls" "sensor-cert.pem" }}'
-  sensor-key.pem: '{{ fromSecret "stackrox" "sensor-tls" "sensor-key.pem" }}'
-  ca.pem: '{{ fromSecret "stackrox" "sensor-tls" "ca.pem" }}'
-  acs-host: '{{ fromSecret "stackrox" "sensor-tls" "acs-host" }}'
-kind: Secret
-metadata:
-  name: sensor-tls
-  namespace: policies
-type: Opaque

--- a/policygenerator/policy-sets/community/openshift-plus/input-sensor/policy-acs-sync-resources.yaml
+++ b/policygenerator/policy-sets/community/openshift-plus/input-sensor/policy-acs-sync-resources.yaml
@@ -1,0 +1,67 @@
+apiVersion: platform.stackrox.io/v1alpha1
+kind: SecuredCluster
+metadata:
+  name: stackrox-secured-cluster-services
+  namespace: stackrox
+spec:
+  clusterName: |
+    {{ fromSecret "open-cluster-management-agent" "hub-kubeconfig-secret" "cluster-name" | base64dec }}
+  auditLogs:
+    collection: Auto
+  centralEndpoint: |
+    {{ fromSecret "stackrox" "sensor-tls" "acs-host" | base64dec }}
+  admissionControl:
+    listenOnCreates: false
+    listenOnEvents: true
+    listenOnUpdates: false
+  perNode:
+    collector:
+      collection: KernelModule
+      imageFlavor: Regular
+    taintToleration: TolerateTaints
+---
+apiVersion: v1
+data:
+  admission-control-cert.pem: '{{ fromSecret "stackrox" "admission-control-tls" "admission-control-cert.pem" }}'
+  admission-control-key.pem: '{{ fromSecret "stackrox" "admission-control-tls" "admission-control-key.pem" }}'
+  ca.pem: '{{ fromSecret "stackrox" "admission-control-tls" "ca.pem" }}'
+kind: Secret
+metadata:
+  name: admission-control-tls
+  namespace: policies
+type: Opaque
+---
+apiVersion: v1
+data:
+  collector-cert.pem: '{{ fromSecret "stackrox" "collector-tls" "collector-cert.pem" }}'
+  collector-key.pem: '{{ fromSecret "stackrox" "collector-tls" "collector-key.pem" }}'
+  ca.pem: '{{ fromSecret "stackrox" "collector-tls" "ca.pem" }}'
+kind: Secret
+metadata:
+  name: collector-tls
+  namespace: policies
+type: Opaque
+---
+apiVersion: v1
+data:
+  sensor-cert.pem: '{{ fromSecret "stackrox" "sensor-tls" "sensor-cert.pem" }}'
+  sensor-key.pem: '{{ fromSecret "stackrox" "sensor-tls" "sensor-key.pem" }}'
+  ca.pem: '{{ fromSecret "stackrox" "sensor-tls" "ca.pem" }}'
+  acs-host: '{{ fromSecret "stackrox" "sensor-tls" "acs-host" }}'
+kind: Secret
+metadata:
+  name: sensor-tls
+  namespace: policies
+type: Opaque
+---
+apiVersion: console.openshift.io/v1
+kind: ConsoleLink
+metadata:
+  name: acs
+spec:
+  applicationMenu:
+    section: Red Hat applications
+    imageURL: 'https://upload.wikimedia.org/wikipedia/commons/3/3a/OpenShift-LogoType.svg'
+  href: https://{{ (lookup "route.openshift.io/v1" "Route" "stackrox" "central").spec.host }}
+  location: ApplicationMenu
+  text: 'Red Hat Advanced Cluster Security for Kubernetes'

--- a/policygenerator/policy-sets/community/openshift-plus/policyGenerator.yaml
+++ b/policygenerator/policy-sets/community/openshift-plus/policyGenerator.yaml
@@ -36,11 +36,18 @@ policies:
 - name: policy-acs-central-ca-bundle
   categories:
     - SI System and Information Integrity
-  consolidateManifests: false
   controls:
     - SI-5 Security Alerts Advisories and Directives
   manifests:
     - path: input-sensor/policy-acs-central-ca-bundle.yaml
+- name: policy-acs-sync-resources
+  categories:
+    - SI System and Information Integrity
+  consolidateManifests: false
+  controls:
+    - SI-5 Security Alerts Advisories and Directives
+  manifests:
+    - path: input-sensor/policy-acs-sync-resources.yaml
 - name: policy-advanced-managed-cluster-security
   categories:
     - SI System and Information Integrity
@@ -65,6 +72,7 @@ policies:
 # ACS Policies - end
 # Observability Policy - start
 - name: policy-ocm-observability
+  consolidateManifests: false
   categories:
     - CA Assessment Authorization and Monitoring
   controls: 
@@ -90,6 +98,13 @@ policies:
   remediationAction: inform
 # ODF Policies - end
 # Quay Policies - start
+- name: policy-install-quay
+  categories:
+    - SI System and Information Integrity
+  controls:
+    - SI-7 Software Firmware and Information Integrity
+  manifests:
+    - path: input-quay/policy-install-quay.yaml
 - name: policy-config-quay
   categories:
     - SI System and Information Integrity


### PR DESCRIPTION
This commit adds the links for:
- acm observability grafana
- ACS
- quay

This commit re-arranges the quay and ACS resources.  The ACS resources that contain templates are now separated into a sync resources policy which will need to always have `consolidateManifests` set to false. The quay hub install now has an install and a config policy.  The config policy has some templates in the first 2 resources and the `consolidateManifests` is not set (so it's true) and this should solve the quay timing issue with the pull secret if using ACM 2.6 or newer.

Refs:
 - https://github.com/stolostron/backlog/issues/25659
 - https://github.com/stolostron/backlog/issues/25923

Signed-off-by: Gus Parvin <gparvin@redhat.com>