### PR TITLE
Update to help anyone that wants to use the quay bridge operator

### DIFF
--- a/policygenerator/policy-sets/community/openshift-plus/input-quay/policy-hub-quay-bridge.yaml
+++ b/policygenerator/policy-sets/community/openshift-plus/input-quay/policy-hub-quay-bridge.yaml
@@ -1,0 +1,35 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/quay-bridge-operator.openshift-operators: ""
+  name: quay-bridge-operator
+  namespace: openshift-operators
+spec:
+  installPlanApproval: Automatic
+  name: quay-bridge-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+---
+apiVersion: quay.redhat.com/v1
+kind: QuayIntegration
+metadata:
+ name: quay
+ annotations:
+   argocd.argoproj.io/sync-wave: "8"
+spec:
+ clusterID: openshift
+ credentialsSecret:
+   name: quay-integration
+   namespace: policies
+ insecureRegistry: false
+ quayHostname: https://{{ fromConfigMap "policies" "quay-config" "host" }}
+---
+kind: Secret
+type: Opaque
+metadata:
+  name: quay-integration
+  namespace: policies
+apiVersion: v1
+data:
+  token: '{{ fromSecret "openshift-operators" "quay-integration" "token" }}'

--- a/policygenerator/policy-sets/community/openshift-plus/input-quay/policy-quay-bridge.yaml
+++ b/policygenerator/policy-sets/community/openshift-plus/input-quay/policy-quay-bridge.yaml
@@ -1,0 +1,35 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/quay-bridge-operator.openshift-operators: ""
+  name: quay-bridge-operator
+  namespace: openshift-operators
+spec:
+  installPlanApproval: Automatic
+  name: quay-bridge-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+---
+apiVersion: quay.redhat.com/v1
+kind: QuayIntegration
+metadata:
+ name: quay
+ annotations:
+   argocd.argoproj.io/sync-wave: "8"
+spec:
+ clusterID: openshift
+ credentialsSecret:
+   name: quay-integration
+   namespace: openshift-operators
+ insecureRegistry: false
+ quayHostname: https://{{hub fromConfigMap "" "quay-config" "host" hub}}
+---
+kind: Secret
+type: Opaque
+metadata:
+  name: quay-integration
+  namespace: openshift-operators
+apiVersion: v1
+data:
+  token: '{{hub fromSecret "" "quay-integration" "token" hub}}'

--- a/policygenerator/policy-sets/community/openshift-plus/policyGenerator.yaml
+++ b/policygenerator/policy-sets/community/openshift-plus/policyGenerator.yaml
@@ -120,6 +120,27 @@ policies:
   manifests:
     - path: input-quay/policy-quay-status.yaml
   remediationAction: inform
+# Quay Bridge requires a token that needs to be populated in a secret. Uncomment the following 
+# 2 policies if you need to use the quay bridge.  After quay is running, see the instructions:
+# https://hybrid-cloud-patterns.io/devsecops/getting-started/#completing-the-quay-bridge-with-a-bearer-token
+# The command below is needed to place the secret where the policies expect to find it.
+# oc create secret -n openshift-operators generic quay-integration --from-literal=token=<access_token>
+#- name: policy-hub-quay-bridge
+#  categories:
+#    - SI System and Information Integrity
+#  controls:
+#    - SI-7 Software Firmware and Information Integrity
+#  manifests:
+#    - path: input-quay/policy-hub-quay-bridge.yaml
+#- name: policy-quay-bridge
+#  categories:
+#    - SI System and Information Integrity
+#  controls:
+#    - SI-7 Software Firmware and Information Integrity
+#  manifests:
+#    - path: input-quay/policy-quay-bridge.yaml
+#  policySets:
+#    - openshift-plus-clusters
 # Quay Policies - end
 # Compliance Operator Policies - start
 - name: policy-compliance-operator-install


### PR DESCRIPTION
This is a mostly untested template of how the quay bridge operator could be deployed.  I'm not sure if it needs to be on the hub cluster but it's currently commented out with some instructions due to a manual procedure needed for creating a token.

Refs:
 - https://github.com/stolostron/backlog/issues/25954

Signed-off-by: Gus Parvin <gparvin@redhat.com>