### PR TITLE
Changing TVK version from latest to 2.10.6

### DIFF
--- a/community/CM-Configuration-Management/policy-install-triliovault-for-kubernetes.yaml
+++ b/community/CM-Configuration-Management/policy-install-triliovault-for-kubernetes.yaml
@@ -54,6 +54,7 @@ spec:
                   installPlanApproval: Automatic
                   source: certified-operators
                   sourceNamespace: openshift-marketplace
+                  startingCSV: k8s-triliovault-stable.2.10.6
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy


### PR DESCRIPTION
Changing the TVK version from latest to 2.10.6. For next TVK release 3.0.0, operator install procedure is changed. A subsequent change in ACM policy for TVK 3.0.0 will be done post the TVK release.

Signed-off-by: Sachin Kulkarni <sachin.kulkarni@trilio.io>