### PR TITLE
[WIP] Create a policy set to quickly deploy project telescope

### DIFF
--- a/policygenerator/policy-sets/community/telescope/README.md
+++ b/policygenerator/policy-sets/community/telescope/README.md
@@ -1,0 +1,18 @@
+# PolicySets -- Red Hat Telescope
+
+Real-time Security Governance, Compliance, and Risk Automation for Enhanced DevSecOps
+
+## PolicySet details
+
+Policies install into the `open-cluster-management-global-set` namespace.
+Telescope installs into the `telescope` namespace and the placement deploys telescope only to the hub cluster.
+  - 10 GB PVC for the telescope database
+  - Postgresql helm chart
+  - Telescope backend helm chart
+  - Telescope frontend helm chart
+
+## Prerequisites
+
+ - ACM 2.6 for the `open-cluster-management-global-set` namespace.
+
+**Note**: The `PolicySet` uses cluster `Placement` and not the `PlacementRule` placement mechanism.

--- a/policygenerator/policy-sets/community/telescope/channels.yaml
+++ b/policygenerator/policy-sets/community/telescope/channels.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Channel
+metadata:
+  annotations:
+    apps.open-cluster-management.io/reconcile-rate: medium
+  name: telescope
+  namespace: telescope-channel
+spec:
+  pathname: https://rh-telescope.github.io/helm-charts
+  type: HelmRepo
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: Channel
+metadata:
+  annotations:
+    apps.open-cluster-management.io/reconcile-rate: medium
+  name: postgresql
+  namespace: telescopedb-channel
+spec:
+  pathname: https://charts.bitnami.com/bitnami
+  type: HelmRepo

--- a/policygenerator/policy-sets/community/telescope/dashboard-react-app.yaml
+++ b/policygenerator/policy-sets/community/telescope/dashboard-react-app.yaml
@@ -1,0 +1,54 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: dashboard-react-app
+  namespace: telescope
+  annotations:
+    apps.open-cluster-management.io/deployables: ''
+    apps.open-cluster-management.io/subscriptions: telescope/dashboard-react-app-subscription,telescope/dashboard-react-app-subscription-local
+spec:
+  componentKinds:
+    - group: apps.open-cluster-management.io
+      kind: Subscription
+  descriptor: {}
+  selector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values:
+          - dashboard-react-app
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  name: dashboard-react-app-subscription
+  namespace: telescope
+  labels:
+    app: dashboard-react-app
+    app.kubernetes.io/part-of: dashboard-react-app
+    apps.open-cluster-management.io/reconcile-rate: medium
+spec:
+  name: dashboard-react-app
+  channel: telescope-channel/telescope
+  packageOverrides:
+    - packageAlias: dashboard-react-app
+      packageName: dashboard-react-app
+  placement:
+    placementRef:
+      name: dashboard-react-app-placement
+      kind: PlacementRule
+posthooks: {}
+prehooks: {}
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: dashboard-react-app-placement
+  namespace: telescope
+  labels:
+    app: dashboard-react-app
+spec:
+  clusterSelector:
+    matchLabels:
+      local-cluster: 'true'
+

--- a/policygenerator/policy-sets/community/telescope/kustomization.yml
+++ b/policygenerator/policy-sets/community/telescope/kustomization.yml
@@ -1,0 +1,4 @@
+generators:
+- ./policyGenerator.yaml
+commonLabels:
+  open-cluster-management.io/policy-set: rh-telescope

--- a/policygenerator/policy-sets/community/telescope/managedclustersetbinding.yaml
+++ b/policygenerator/policy-sets/community/telescope/managedclustersetbinding.yaml
@@ -1,0 +1,7 @@
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: ManagedClusterSetBinding
+metadata:
+  namespace: telescope
+  name: default
+spec:
+  clusterSet: default

--- a/policygenerator/policy-sets/community/telescope/namespace.yaml
+++ b/policygenerator/policy-sets/community/telescope/namespace.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: telescope
+spec: {}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: telescope-channel
+spec: {}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: telescopedb-channel
+spec: {}

--- a/policygenerator/policy-sets/community/telescope/placement.yaml
+++ b/policygenerator/policy-sets/community/telescope/placement.yaml
@@ -1,0 +1,11 @@
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: placement-rh-telescope
+  namespace: open-cluster-management-global-set
+spec:
+  predicates:
+  - requiredClusterSelector:
+      labelSelector:
+        matchExpressions:
+          - {key: name, operator: In, values: ["local-cluster"]}

--- a/policygenerator/policy-sets/community/telescope/policyGenerator.yaml
+++ b/policygenerator/policy-sets/community/telescope/policyGenerator.yaml
@@ -1,0 +1,41 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: policy-rh-telescope
+placementBindingDefaults:
+  name: binding-policy-rh-telescope
+policyDefaults:
+  categories:
+    - CM Configuration Management
+  controls: 
+    - CM-2 Baseline Configuration
+  disabled: false
+  namespace: open-cluster-management-global-set
+  policySets:
+    - rh-telescope
+  remediationAction: enforce
+  severity: medium
+  standards:
+    - NIST SP 800-53
+policies:
+- name: policy-telescope-prereqs
+  manifests:
+    - path: namespace.yaml
+    - path: managedclustersetbinding.yaml
+    - path: channels.yaml
+    - path: storage.yaml
+    - path: rolebinding.yaml
+- name: policy-telescope-db
+  manifests:
+    - path: postgresql.yaml
+- name: policy-telescope-ui
+  manifests:
+    - path: dashboard-react-app.yaml
+- name: policy-telescope-backend
+  manifests:
+    - path: telescope-backend.yaml
+policySets:
+  - name: rh-telescope
+    description: Real-time Security Governance, Compliance, and Risk Automation for Enhanced DevSecOps
+    placement:
+      placementPath: placement.yaml

--- a/policygenerator/policy-sets/community/telescope/postgresql.yaml
+++ b/policygenerator/policy-sets/community/telescope/postgresql.yaml
@@ -1,0 +1,70 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: psql-telescope
+  namespace: telescope
+  annotations:
+    apps.open-cluster-management.io/deployables: ''
+    apps.open-cluster-management.io/subscriptions: telescope/psql-telescope-subscription,telescope/psql-telescope-subscription-local
+spec:
+  componentKinds:
+    - group: apps.open-cluster-management.io
+      kind: Subscription
+  descriptor: {}
+  selector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values:
+          - psql-telescope
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  name: psql-telescope-subscription
+  namespace: telescope
+  labels:
+    app: psql-telescope
+    app.kubernetes.io/part-of: psql-telescope
+    apps.open-cluster-management.io/reconcile-rate: medium
+spec:
+  name: postgresql
+  channel: telescopedb-channel/postgresql
+  packageOverrides:
+    - packageAlias: postgresql
+      packageName: postgresql
+      packageOverrides:
+        - path: spec
+          value:
+            global:
+              postgresql:
+                auth:
+                  postgresqlPassword: scope123
+                  username: telescope-db
+                  password: scope123
+                  database: telescope
+            primary:
+              persistence:
+                enabled: true
+                existingClaim: telescopedb-pv-claim
+            volumePermissions:
+              enabled: true
+  placement:
+    placementRef:
+      name: postgresql-placement
+      kind: PlacementRule
+posthooks: {}
+prehooks: {}
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: postgresql-placement
+  namespace: telescope
+  labels:
+    app: psql-telescope
+spec:
+  clusterSelector:
+    matchLabels:
+      local-cluster: 'true'
+

--- a/policygenerator/policy-sets/community/telescope/rolebinding.yaml
+++ b/policygenerator/policy-sets/community/telescope/rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:openshift:scc:anyuid
+  namespace: telescope
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:anyuid
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: telescope

--- a/policygenerator/policy-sets/community/telescope/storage.yaml
+++ b/policygenerator/policy-sets/community/telescope/storage.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: telescopedb-pv
+  labels:
+    type: local
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/mnt/data"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: telescopedb-pv-claim
+  namespace: telescope
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/policygenerator/policy-sets/community/telescope/telescope-backend.yaml
+++ b/policygenerator/policy-sets/community/telescope/telescope-backend.yaml
@@ -1,0 +1,58 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: telescope-backend
+  namespace: telescope
+  annotations:
+    apps.open-cluster-management.io/deployables: ''
+    apps.open-cluster-management.io/subscriptions: telescope/telescope-backend-subscription,telescope/telescope-backend-subscription-local
+spec:
+  componentKinds:
+    - group: apps.open-cluster-management.io
+      kind: Subscription
+  descriptor: {}
+  selector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values:
+          - telescope-backend
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  name: telescope-backend-subscription
+  namespace: telescope
+  labels:
+    app: telescope-backend
+    app.kubernetes.io/part-of: telescope-backend
+    apps.open-cluster-management.io/reconcile-rate: medium
+spec:
+  name: telescope-backend
+  channel: telescope-channel/telescope
+  packageOverrides:
+    - packageAlias: telescope-backend
+      packageName: telescope-backend
+      packageOverrides:
+        - path: spec
+          value:
+            image: quay.io/gparvin/telescope-backend:latest
+  placement:
+    placementRef:
+      name: telescope-placement
+      kind: PlacementRule
+posthooks: {}
+prehooks: {}
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: telescope-placement
+  namespace: telescope
+  labels:
+    app: telescope-backend
+spec:
+  clusterSelector:
+    matchLabels:
+      local-cluster: 'true'
+


### PR DESCRIPTION
Policy set that deploys all of the components of project telescope to a cluster.  This currently deploys it to the ACM hub with an initial goal of using project telescope for Secure Engineering analysis.

Signed-off-by: Gus Parvin <gparvin@redhat.com>