### PR TITLE
Duplication cleanup

### DIFF
--- a/community/CM-Configuration-Management/policy-aws-machine-sets.yaml
+++ b/community/CM-Configuration-Management/policy-aws-machine-sets.yaml
@@ -15,6 +15,7 @@ metadata:
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
 spec:
+  remediationAction: inform
   disabled: false
   policy-templates:
     - objectDefinition:
@@ -23,6 +24,7 @@ spec:
         metadata:
           name: machineset-ocs-worker1
         spec:
+          severity: high
           object-templates:
           - complianceType: musthave
             objectDefinition:
@@ -231,8 +233,6 @@ spec:
                           name: worker-user-data
                     versions:
                       kubelet: ""
-  severity: high
-  remediationAction: inform
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/community/CM-Configuration-Management/policy-cluster-logforwarder-templatized.yaml
+++ b/community/CM-Configuration-Management/policy-cluster-logforwarder-templatized.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
-  name: policy-enableclusterlogforwarder
+  name: policy-enableclusterlogforwarder-templated
   annotations:
     policy.open-cluster-management.io/standards: NIST SP 800-53
     policy.open-cluster-management.io/categories: CM Configuration Management
@@ -14,7 +14,7 @@ spec:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
         metadata:
-          name: policy-enableclusterlogforwarder
+          name: policy-enableclusterlogforwarder-templated
         spec:
           remediationAction: inform
           severity: low
@@ -42,20 +42,20 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-  name: binding-policy-enableclusterlogforwarder
+  name: binding-policy-enableclusterlogforwarder-templated
 placementRef:
-  name: placement-policy-enableclusterlogforwarder
+  name: placement-policy-enableclusterlogforwarder-templated
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-  - name: policy-enableclusterlogforwarder
+  - name: policy-enableclusterlogforwarder-templated
     kind: Policy
     apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
-  name: placement-policy-enableclusterlogforwarder
+  name: placement-policy-enableclusterlogforwarder-templated
 spec:
   clusterConditions:
     - status: 'True'

--- a/community/CM-Configuration-Management/policy-gatekeeper-container-tgps.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-container-tgps.yaml
@@ -43,9 +43,9 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-  name: binding-policy-gatekeeper-annotation-owner
+  name: binding-policy-gatekeeper-container-tgps
 placementRef:
-  name: placement-policy-gatekeeper-annotation-owner
+  name: placement-policy-gatekeeper-container-tgps
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
@@ -56,7 +56,7 @@ subjects:
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
-  name: placement-policy-gatekeeper-annotation-owner
+  name: placement-policy-gatekeeper-container-tgps
 spec:
   clusterConditions:
     - status: "True"


### PR DESCRIPTION
A few files were re-using names, and one policy had the `severity` set at the wrong level, sometimes causing an error.