### PR TITLE
Added a second multitenancy policyset for hub only policies

### DIFF
--- a/policygenerator/policy-sets/community/kyverno/input/multitenancy/generateargocdpersmissions/generate-argocd-permissions-blueteam-spoke.yaml
+++ b/policygenerator/policy-sets/community/kyverno/input/multitenancy/generateargocdpersmissions/generate-argocd-permissions-blueteam-spoke.yaml
@@ -8,7 +8,7 @@ metadata:
     policies.kyverno.io/category: Multi-Tenancy
     policies.kyverno.io/subject: ClusterRoleBinding
     policies.kyverno.io/description: >-
-      When a user from Team1 creates a NS a ClusterRoleBinding gets created so
+      When a user from blue team creates a namespace, a ClusterRoleBinding gets created so
       it can access ArgoCD.
 spec:
   background: false

--- a/policygenerator/policy-sets/community/kyverno/input/multitenancy/generateargocdpersmissions/generate-argocd-permissions-redteam-spoke.yaml
+++ b/policygenerator/policy-sets/community/kyverno/input/multitenancy/generateargocdpersmissions/generate-argocd-permissions-redteam-spoke.yaml
@@ -6,7 +6,9 @@ metadata:
     policies.kyverno.io/title: Add ArgoCD Rolebinding
     policies.kyverno.io/category: Multi-Tenancy
     policies.kyverno.io/subject: ClusterRoleBinding
-    policies.kyverno.io/description: test
+    policies.kyverno.io/description: >-
+      When a user from red team creates a namespace, a ClusterRoleBinding gets created so
+      it can access ArgoCD.
 spec:
   background: false
   rules:
@@ -39,7 +41,4 @@ spec:
         - apiGroup: rbac.authorization.k8s.io
           kind: Group
           name: red-sre-group
-
-
-             
 

--- a/policygenerator/policy-sets/community/kyverno/multitenancy/README.md
+++ b/policygenerator/policy-sets/community/kyverno/multitenancy/README.md
@@ -1,18 +1,17 @@
-# governance-best-practises-for-apps
+# Kyverno Multitenancy Best Practices Sample
 
-repository showing best practices for apps
+Repository showing best practices sample for two tenants
+that can be separated using Kyverno policies.
 
-Based on the following links:
+## Kyverno multitenancy
 
-* https://cloud.redhat.com/blog/9-best-practices-for-deploying-highly-available-applications-to-openshift
-* https://cloud.redhat.com/blog/14-best-practices-for-developing-applications-on-openshift
-
-## Kyverno best prastices
-
-https://kyverno.io/policies/?policytypes=Best%2520Practices
+https://kyverno.io/policies/?policytypes=Multi-Tenancy
 
 
-we look to create a PolicySet based on RHACM-Policies and Kyverno Integration
+This is a sample that creates policy sets to provide multitenancy
+best practices.  There are two policy sets created by this solution:
+1. kyverno-multitenancy-hub-policyset - a set of policies deployed to the hub for multitenancy.  This placement should remain configured for hub deployment only.
+2. kyverno-multitenancy-policyset - a set of policies that should be deployed to the clusters running the application workloads from the 2 tenants. Update the placement for this policy set.  The default deploys placement is hub only.
 
 ## List of Policies 
 

--- a/policygenerator/policy-sets/community/kyverno/multitenancy/placement-hub.yaml
+++ b/policygenerator/policy-sets/community/kyverno/multitenancy/placement-hub.yaml
@@ -1,0 +1,11 @@
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: kyverno-tenancy-hub-placement
+  namespace: policies
+spec:
+  predicates:
+  - requiredClusterSelector:
+      labelSelector:
+        matchExpressions:
+          - {key: name, operator: In, values: ["local-cluster"]}

--- a/policygenerator/policy-sets/community/kyverno/multitenancy/policyGenerator.yaml
+++ b/policygenerator/policy-sets/community/kyverno/multitenancy/policyGenerator.yaml
@@ -18,42 +18,63 @@ policyDefaults:
   standards:
     - NIST SP 800-53
 policies:
-- name: add-labels-to-tenant
-  disabled: false
-  manifests:
-    - path: ../input/multitenancy/addlabelstotenant
+# hub policies
 - name: disallow-placementrules
   disabled: false
   manifests:
     - path: ../input/multitenancy/disallowplacementrules
-- name: generate-all
-  disabled: false
-  manifests:
-    - path: ../input/multitenancy/generateall
-- name: gen-argocdpersmissions
-  disabled: false
-  manifests:
-    - path: ../input/multitenancy/generateargocdpersmissions
+  policySets:
+    - kyverno-multitenancy-hub-policyset
 - name: gen-managed-clusterset-binding
   disabled: false
   manifests:
     - path: ../input/multitenancy/generateManagedClusterSetBinding
+  policySets:
+    - kyverno-multitenancy-hub-policyset
 - name: gen-placement-rules
   disabled: false
   manifests:
     - path: ../input/multitenancy/generatePlacementRules
-- name: add-job-ttl
+  policySets:
+    - kyverno-multitenancy-hub-policyset
+- name: generate-all
   disabled: false
   manifests:
-    - path: ../input/multitenancy/other
+    - path: ../input/multitenancy/generateall
+  policySets:
+    - kyverno-multitenancy-hub-policyset
+- name: validate-placement
+  disabled: false
+  manifests:
+    - path: ../input/multitenancy/validateplacement
+  policySets:
+    - kyverno-multitenancy-hub-policyset
 - name: preventupdatesappproject
   disabled: false
   manifests:
     - path: ../input/multitenancy/preventupdatesappproject
+  policySets:
+    - kyverno-multitenancy-hub-policyset
 - name: team-restrictions
   disabled: false
   manifests:
     - path: ../input/multitenancy/restrictions
+  policySets:
+    - kyverno-multitenancy-hub-policyset
+# end hub policies
+# managed cluster policies
+- name: add-labels-to-tenant
+  disabled: false
+  manifests:
+    - path: ../input/multitenancy/addlabelstotenant
+- name: gen-argocdpersmissions
+  disabled: false
+  manifests:
+    - path: ../input/multitenancy/generateargocdpersmissions
+- name: add-job-ttl
+  disabled: false
+  manifests:
+    - path: ../input/multitenancy/other
 - name: team-sharedresources
   disabled: false
   manifests:
@@ -62,11 +83,12 @@ policies:
   disabled: false
   manifests:
     - path: ../input/multitenancy/validatens
-- name: validate-placement
-  disabled: false
-  manifests:
-    - path: ../input/multitenancy/validateplacement
+# end managed cluster policies
 policySets:
+  - description: kyverno-multitenancy-hub-policyset to apply set of kyverno-policies on the open cluster management hub.
+    name: kyverno-multitenancy-hub-policyset
+    placement:
+      placementPath: placement-hub.yaml
   - description: kyverno-multitenancy-policyset to apply set of kyverno-policies.
     name: kyverno-multitenancy-policyset
     placement:


### PR DESCRIPTION
Some of the multitenancy policies are for the hub and some are for all managed clusters.  I tried to separate them. Be aware I did not modify the placement settings which currently have all policies deployed only to the hub, but this change will help anyone looking at this understand what they need to do.

Refs:
 - https://github.com/stolostron/backlog/issues/25956

Signed-off-by: Gus Parvin <gparvin@redhat.com>