### PR TITLE
spec: and its subheadings in the Policy is wrong

### DIFF
--- a/community/CM-Configuration-Management/policy-ingress-controller.yaml
+++ b/community/CM-Configuration-Management/policy-ingress-controller.yaml
@@ -26,11 +26,11 @@ spec:
                 metadata:
                   name: default
                   namespace: openshift-ingress-operator
-                  spec:
-                    nodePlacement:
-                      nodeSelector:
-                        matchLabels:
-                          node-role.kubernetes.io/infra: ""
+                spec:
+                  nodePlacement:
+                    nodeSelector:
+                      matchLabels:
+                        node-role.kubernetes.io/infra: ""
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding


### PR DESCRIPTION
The `spec:` heading and it sub items are not part of `metadata:` item so this policy doesn't perform as expected.

The `spec:` section of the Policy should be shifted left 2 spaces to line up under `metadata:`