### PR TITLE
`spec:` line and subs are wrong

### DIFF
--- a/community/CM-Configuration-Management/policy-ingress-controller.yaml
+++ b/community/CM-Configuration-Management/policy-ingress-controller.yaml
@@ -26,11 +26,11 @@ spec:
                 metadata:
                   name: default
                   namespace: openshift-ingress-operator
-                  spec:
-                    nodePlacement:
-                      nodeSelector:
-                        matchLabels:
-                          node-role.kubernetes.io/infra: ""
+                spec:
+                  nodePlacement:
+                    nodeSelector:
+                      matchLabels:
+                        node-role.kubernetes.io/infra: ""
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding


### PR DESCRIPTION
The `spec:` line and subheadings should be even with `metadata:` as they are an item of their own.

Without this change, the policy doesn't actually apply anything which is not the intended effect.

Signed-off-by: chuckersjp <cdouglas@redhat.com>