### PR TITLE
Add tolerations to allow pods to start

### DIFF
--- a/community/CM-Configuration-Management/policy-ingress-controller.yaml
+++ b/community/CM-Configuration-Management/policy-ingress-controller.yaml
@@ -31,6 +31,11 @@ spec:
                     nodeSelector:
                       matchLabels:
                         node-role.kubernetes.io/infra: ""
+                    tolerations:
+                      - effect: NoSchedule
+                        operator: Exists
+                      - effect: NoExecute
+                        operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding


### PR DESCRIPTION
This change adds tolerations to the policy to allow the router pods to spin up on infra labelled nodes.

Signed-off-by: chuckersjp <cdouglas@redhat.com>