### PR TITLE
Add disable self-provisioner policy

### DIFF
--- a/community/README.md
+++ b/community/README.md
@@ -230,6 +230,7 @@ Policy  | Description | Prerequisites
 [OpenShift Certificate Expiration Policy](./SC-System-and-Communications-Protection/policy-ocp4-certs.yaml) | Monitor the OpenShift 4.x namespaces to validate that certificates managed by the infrastructure are rotated as expected. | OpenShift 4.x is required.
 [OpenShift Cluster Operator state policy](./SC-System-and-Communications-Protection/policy-checkclusteroperator.yaml) | This policy alerts when an OpenShift `ClusterOperator` becomes unhealthy. See [ClusterOperator config](https://docs.openshift.com/container-platform/latest/rest_api/config_apis/clusteroperator-config-openshift-io-v1.html) for additional details. | OpenShift 4.x only.
 [Check namespaces in Terminating status](./SC-System-and-Communications-Protection/policy-checknamespaces-terminating.yaml)| check for namespaces in terminating status | check e.g. this [link](https://www.redhat.com/sysadmin/troubleshooting-terminating-namespaces) how to fix this.
+[Disable self-provisioner](./SC-System-and-Communications-Protection/policy-disable-self-provisioner.yaml)| Disable ability to for users to create their own projects | OpenShift 4.x only.
 
 
 ### System and Information Integrity

--- a/community/SC-System-and-Communications-Protection/policy-disable-self-provisioner.yaml
+++ b/community/SC-System-and-Communications-Protection/policy-disable-self-provisioner.yaml
@@ -1,0 +1,59 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: policy-remove-self-provisioner
+  annotations:
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+    policy.open-cluster-management.io/categories: SC System and Communications Protection
+    policy.open-cluster-management.io/controls: SC-1 SYSTEM AND COMMUNICATIONS PROTECTION POLICY AND PROCEDURES
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-remove-self-provisioner
+        spec:
+          remediationAction: inform
+          severity: low
+          object-templates:
+            - complianceType: mustonlyhave
+              objectDefinition:
+                kind: ClusterRoleBinding
+                apiVersion: rbac.authorization.k8s.io/v1
+                metadata:
+                  name: self-provisioners
+                  annotations:
+                    rbac.authorization.kubernetes.io/autoupdate: 'false'
+                subjects: []
+                roleRef:
+                  apiGroup: rbac.authorization.k8s.io
+                  kind: ClusterRole
+                  name: self-provisioner
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: binding-remove-self-provisioner
+placementRef:
+  name: placement-remove-self-provisioner
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+- name: policy-remove-self-provisioner
+  kind: Policy
+  apiGroup: policy.open-cluster-management.io
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: placement-remove-self-provisioner
+spec:
+  clusterConditions:
+  - status: "True"
+    type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      - {key: environment, operator: In, values: ["dev"]}


### PR DESCRIPTION
Signed-off-by: chuckersjp <cdouglas@redhat.com>

This change adds a policy that will disable the project self-provisioner ability from a cluster.

It is currently set to `inform` rather than `enforce` as a default.