### PR TITLE
Fix trilio validation error and update aap policy

### DIFF
--- a/community/CM-Configuration-Management/policy-automation-operator.yaml
+++ b/community/CM-Configuration-Management/policy-automation-operator.yaml
@@ -45,7 +45,6 @@ spec:
                   name: ansible-automation-operator
                   namespace: ansible-automation-platform
                 spec:
-                  channel: stable-2.1-cluster-scoped
                   installPlanApproval: Automatic
                   name: ansible-automation-platform-operator
                   source: redhat-operators

--- a/community/CM-Configuration-Management/policy-continuous-restore-triliovault-for-kubernetes.yaml
+++ b/community/CM-Configuration-Management/policy-continuous-restore-triliovault-for-kubernetes.yaml
@@ -83,7 +83,7 @@ spec:
                   source:
                     type: ConsistentSet
                     consistentSet:
-                      name: {{ (index (lookup "triliovault.trilio.io/v1" "ConsistentSet" "" "").items (len (slice (index (lookup "triliovault.trilio.io/v1" "ConsistentSet" "" "").items) 1))).metadata.name }}
+                      name: '{{ (index (lookup "triliovault.trilio.io/v1" "ConsistentSet" "" "").items (len (slice (index (lookup "triliovault.trilio.io/v1" "ConsistentSet" "" "").items) 1))).metadata.name }}'
                   restoreNamespace: '{{hub fromConfigMap "" "tvk-cr-restore-configmap" "restoreNS" hub}}'
                   skipIfAlreadyExists: true
                 status:


### PR DESCRIPTION
The validation script is failing on a new policy that didn't run the validation because the PR was created before validation was added.  I also removed the channel in the AAP policy so the latest will be used.

Signed-off-by: Gus Parvin <gparvin@redhat.com>