### PR TITLE
[WIP] Adding PolicySets used to backup and restore stateful application data on managed clusters

### DIFF
--- a/policygenerator/policy-sets/community/acm-app-backup/README.md
+++ b/policygenerator/policy-sets/community/acm-app-backup/README.md
@@ -1,0 +1,123 @@
+## PolicySets used to backup and restore stateful application data on managed clusters
+
+This Policysets cover:
+
+- Persistent application backup 
+- Persistent application restore
+
+## Scenario
+
+The Policies available here provide backup and restore support for stateful applications running on  managed clusters or hub. Velero is used to backup and restore applications data. The product is installed using the OADP operator, which the [oadp-hdr-app-install](./policies/oadp-hdr-app-install.yaml) policy installs and configure on each target cluster.
+
+You can use these policies to backup stateful applications (policies under [oadp-hdr-app-backup-set](./policy-sets/acm-app-backup-policy-set.yaml) PolicySet) or to restore applications backups (policies under [oadp-hdr-app-restore-set](./policy-sets/acm-app-restore-policy-set.yaml) PolicySet).
+
+The PolicySet is used to place the backup or restore policies on managed clusters.
+
+The policies should be installed on the hub managing clusters where you want to create stateful applications backups, or the hub managing clusters where you plan to restore the application backups. 
+
+Both backup and restore policies can be installed on the same hub, if this hub manages clusters where applications need to be backed up or restored. 
+
+A managed cluster can be a backup target if the PlacementRule for the [oadp-hdr-app-backup-set](./policy-sets/acm-app-backup-policy-set.yaml) PolicySet includes this managed cluster.
+
+A managed cluster can be a restore target if the PlacementRule for the [oadp-hdr-app-restore-set](./policy-sets/acm-app-restore-policy-set.yaml) PolicySet includes this managed cluster. 
+
+A managed cluster can be both a backup and restore target, if the PlacementRule from the backup and restore PolicySets matches this cluster.
+
+## List of PolicySets 
+
+PolicySet                                     | Description 
+-------------------------------------------| ----------- 
+acm-app-backup                             | This PolicySet is used to place the [oadp-hdr-app-install](./policies/oadp-hdr-app-install.yaml) and [oadp-hdr-app-backup](./policies/oadp-hdr-app-backup.yaml) policies on managed clusters using the [acm-app-backup-placement](./policy-sets/acm-app-backup-policy-set.yaml) rule, which is all managed clusters with a label "acm-pv-dr=backup". Update the placement rule if you want to customize the target cluster list.
+acm-app-restore                            | This PolicySet is used to place the [oadp-hdr-app-install](./policies/oadp-hdr-app-install.yaml) and [oadp-hdr-app-restore](./policies/oadp-hdr-app-restore.yaml) policies on managed clusters using the [acm-app-restore-placement](./policy-sets/acm-app-restore-policy-set.yaml) rule, which is all managed clusters with a label "acm-pv-dr=restore". Update the placement rule if you want to customize the target cluster list.
+
+
+## List of Policies 
+
+Policy                                     | Description 
+-------------------------------------------| ----------- 
+oadp-hdr-app-install                       | Deploys velero using the OADP operator to all managed clusters matching the acm-app-backup-placement or acm-app-restore-placement rules. Installs the OADP Operator using the hdr-app-configmap channel and subscriptionName properties. Creates the cloud credentials secret used by the DataProtectionApplication to connect with the backup storage. The cloud credentials secret is set using the [hdr-app-configmap](./input/restic/hdr-app-configmap.yaml) `dpa.aws.backup.cloud.credentials` property. Creates the DataProtectionApplication resource used to configure Velero. Uses hdr-app-configmap `dpaName` for the DataProtectionApplication name and hdr-app-configmap `dpa.spec` for the resource spec settings. Informs on Velero pod not running, or DataProtectionApplication not properly configured.
+oadp-hdr-app-backup                         | Creates a velero backup schedule on managed clusters matching the [acm-app-backup-placement](./policy-sets/acm-app-backup-policy-set.yaml) rules. The schedule is used to backup applications resources and PVs.
+oadp-hdr-app-restore                        | Creates a velero restore resource on managed clusters matching the [acm-app-restore-placement](./policy-sets/acm-app-restore-policy-set.yaml) rules. The restore resource is used to restore applications resources and PVs from a selected backup. The restore uses the `restore.nsToRestore` [hdr-app-configmap](./input/restic/hdr-app-configmap.yaml) property to specify the namespaces for the applications to restore.
+
+
+## Policies input data using hdr-app-configmap 
+
+Before you install the backup and restore Policies and PolicySets on the hub, you have to update the `hdr-app-configmap` available [here](./input/). 
+
+You create the configmap on the hub, the same hub where the policies will be installed.
+
+The configmap sets configuration options for the backup storage location, for the backup schedule backing up applications, and for the restore resource used to restore applications backups.
+
+Make sure you <b>update all settings with valid values</b> before applying the `hdr-app-configmap` resource on the hub.
+
+<b>Note</b>:
+
+- The `dpa.spec` property defines the storage location properties. The default value shows the `dpa.spec` format for using an S3 bucket. Update this to match the type of storage location you want to use.
+- You can still upate the `hdr-app-configmap` properties after the `ConfigMap` was applied to the hub. When you do that, the backup settings on the managed clusters where the PolicySet has been applied will be automatically updated with the new values for the `hdr-app-configmap`.  For example, to restore a new backup, update the `restore.backupName` property on the `hdr-app-configmap` on the hub; the change is pushed to the deployed policies on the managed cluster and a restore resource matching the new properties will be created there.
+
+All values specified with brackets <> should be updated before applying the `hrd-app-configmap`.
+
+hrd-app-configmap input data               | Description 
+-------------------------------------------| ----------- 
+backupNS                                   | Used by the [oadp-hdr-app-install](./policies/oadp-hdr-app-install.yaml) policy. Namespace name where velero/oadp is installed on the target cluster. If you want to place the application backup or restore policy on the hub, then first enable the backup and restore option on the MCH resource and use the `open-cluster-management-backup` value for the backupNS. If you don't enable the backup option on the MCH resource and use the `open-cluster-management-backup` value for the backupNS, the MCH will  delete this namespace on reconcile. 
+channel                                    | Used by the [oadp-hdr-app-install](./policies/oadp-hdr-app-install.yaml) policy. OADP operator install channel; set to stable-1.1 by default
+dpa.aws.backup.cloud.credentials           | Used by the [oadp-hdr-app-install](./policies/oadp-hdr-app-install.yaml) policy. Defines cloud-credential used to connect to the storage location, base64 encoded string. You must update this property with a valid value.
+dpaName                                    | Used by the [oadp-hdr-app-install](./policies/oadp-hdr-app-install.yaml) policy. DataProtectionApplication resource name
+dpa.spec                                   | Used by the [oadp-hdr-app-install](./policies/oadp-hdr-app-install.yaml) policy. DataProtectionApplication spec values. The config file contains a spec configuration for an aws storage. Update this with the DataProtectionApplication spec format for the type of storage you are using. 
+backup.prefix                              | Used by the [oadp-hdr-app-backup](./policies/oadp-hdr-app-backup.yaml) policy. by the The name prefix for to backup resource. It is defaulted to `acm-app`. You can optionally change it if you want to match the name of the application you are backing up, for example to `pacman-app` if you are backing up the pacman application.
+backup.snapshotVolumes                     | Used by the [oadp-hdr-app-backup](./policies/oadp-hdr-app-backup.yaml) policy. Set to `true` if you want to create backup snapshots. This is the value used by the [pv snapshot config](./input/pv-snap/hdr-app-configmap.yaml). It is set to `false` by the [restic config](./input/restic/hdr-app-configmap.yaml).
+backup.defaultVolumesToRestic               | Used by the [oadp-hdr-app-backup](./policies/oadp-hdr-app-backup.yaml) policy. Set to `false` if you want to create backup snapshots. This is the value used by the [pv snapshot config](./input/pv-snap/hdr-app-configmap.yaml). It is set to `true` by the [restic config](./input/restic/hdr-app-configmap.yaml).
+backup.schedule                             | Used by the [oadp-hdr-app-backup](./policies/oadp-hdr-app-backup.yaml) policy. Defines the cron schedule to use when creating backups.
+backup.ttl                                  | Used by the [oadp-hdr-app-backup](./policies/oadp-hdr-app-backup.yaml) policy. Defines the expiration time for the backups.
+backup.nsToBackup                           | Used by the [oadp-hdr-app-backup](./policies/oadp-hdr-app-backup.yaml) policy. Defines the list of namespaces to backup. Backing up all resources from these namespaces, including the PV and PVC used by the applications running in these namespaces.
+restore.restorePVs                          | Used by the [oadp-hdr-app-restore](./policies/oadp-hdr-app-restore.yaml) policy. Set to `true` if the bacup to restore has used `backup.snapshotVolumes:true`, should be set to `false` otherwise.
+restore.backupName                          | Used by the [oadp-hdr-app-restore](./policies/oadp-hdr-app-restore.yaml) policy. Sets the name of the backup to restore from, for example `acm-pv-schedule-vb-managed-cls-1-20230208150010`.
+restore.nsToRestore                         | Used by the [oadp-hdr-app-restore](./policies/oadp-hdr-app-restore.yaml) policy. Defines the list of namespaces to restore from the backup file.
+restore.storage.config.name                 | Used by the [oadp-hdr-app-restore](./policies/oadp-hdr-app-restore.yaml) policy. Restore storage config map resource name [class mapping](https://velero.io/docs/main/restore-reference/#changing-pvpvc-storage-classes), used when the source cluster has a different storage class than the restore cluster. You can optionally change the default value `storage-class-acm-app`. 
+restore.mappings                            | Used by the [oadp-hdr-app-restore](./policies/oadp-hdr-app-restore.yaml) policy and in conjunction with the  `restore.storage.config.name`. Defines the data for the storage config map resource name.        
+
+## Notes on Kustomization
+
+Apply the PolicySets by running the [kustomization.yaml](./kustomization.yaml)
+
+`oc apply -k ./acm-app-backup`
+
+Update all settings with valid values before applying the `hdr-app-configmap` resource on the hub.
+The `kustomization.yaml` uses the [resric config](./input/pv-snap/hdr-app-configmap.yaml), you can change it to use the [pv config](./input/pv-snap/hdr-app-configmap.yaml) if you want to use Restic instead of Persitent Volume Snapshot.
+
+Use Restic if: 
+- the PV snapshot is not supported 
+- or your backup and restore clusters are running on different platforms 
+- or they are in different regions and can't share PV snapshots, 
+See restic limitations here https://velero.io/docs/v1.9/restic/#limitations 
+
+PV Snapshot usage limitations:
+- PVStorage for the backup resource must match the location of the PVs to be backed up. 
+- You cannot backup PVs from different regions/locations in the same backup, since a backup points to only one PVStorage
+-  You cannot restore a PV unless the restore resource points to the same PVStorage as the backup; so the restore cluster must have access to the PV snapshot storage location.
+- PV backup is storage/platform specific; you need the same storage class usage on both source ( where you backup the PV and take the snapshots) and on target cluster ( where you restore the PV snapshot )
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/policygenerator/policy-sets/community/acm-app-backup/input/pv-snap/hdr-app-configmap.yaml
+++ b/policygenerator/policy-sets/community/acm-app-backup/input/pv-snap/hdr-app-configmap.yaml
@@ -1,0 +1,155 @@
+#
+# This configmap is used by the oadp-hdr-app-install and oadp-hdr-app-backup policies 
+# and specifies the configuration required to install velero and create backups 
+#
+# This config is set to use snapshotVolumes for backing up PVs; this option works only if 
+# your backup and restore clusters use the same StorageClass 
+# and the restore cluster can access the region/location where the volume snapshot are stored
+# 
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hdr-app-configmap
+data:
+  # backupNS is the ns where velero/oadp is installed on the cluster
+  backupNS: open-cluster-management-backup 
+  channel: stable-1.1
+  subscriptionName: redhat-oadp-operator
+
+# define cloud-credential used to connect to the storage location, base64 encoded string
+# for example, for an aws storage location, the credential is in this format
+#
+# [default]
+# aws_access_key_id=<id>
+# aws_secret_access_key=<key>
+#
+  dpa.aws.backup.cloud.credentials: W2RlZmF1bHRdCmF3c19hY2Nlc3Nfa2V5X2lkPTxpZD4KYXdzX3NlY3JldF9hY2Nlc3Nfa2V5PTxrZXk+
+
+
+## DPA resource configuration
+#
+  #DPA resource name; use the same name for all hubs, the PV cannot be restored if 
+  # the BackupStorageLocation resource doesn't have the same name
+  # on both backup and restore cluster 
+  dpaName: dpa
+  dpa.backup.cloud.credentials.name: cloud-credentials
+#######
+# DPA spec
+# below is the spec format for an aws storage
+# update this with the DPA format for the type of storage you are using
+# values specified with brackets <> should be updated before applying this configmap
+  dpa.spec: "{
+  \"backupLocations\": [
+    {
+      \"velero\": {
+        \"config\": {
+          \"profile\": \"default\",
+          \"region\": \"<us-east-1>\"
+        },
+        \"credential\": {
+          \"key\": \"cloud\",
+          \"name\": \"<dpa.backup.cloud.credentials.name>\"
+        },
+        \"default\": true,
+        \"objectStorage\": {
+          \"bucket\": \"<bucket-name>\",
+          \"prefix\": \"<in-bucket-folder-name>\"
+        },
+        \"provider\": \"<aws>\"
+      }
+    }
+  ],
+  \"configuration\": {
+    \"restic\": {
+      \"enable\": false
+    },
+    \"velero\": {
+      \"defaultPlugins\": [
+        \"openshift\",
+        \"aws\"
+      ],
+      \"podConfig\": {
+        \"resourceAllocations\": {
+          \"limits\": {
+            \"cpu\": \"2\",
+            \"memory\": \"1Gi\"
+          },
+          \"requests\": {
+            \"cpu\": \"500m\",
+            \"memory\": \"256Mi\"
+          }
+        }
+      }
+    }
+  },
+  \"snapshotLocations\": [
+    {
+      \"velero\": {
+        \"config\": {
+          \"profile\": \"default\",
+          \"region\": \"<use here ClusterClaim region.open-cluster-management.io value>\"
+        },
+        \"provider\": \"<aws>\"
+      }
+    },
+    {
+      \"velero\": {
+        \"config\": {
+          \"profile\": \"<east1>\",
+          \"region\": \"<us-east-1>\"
+        },
+        \"provider\": \"<aws>\"
+      }
+    },
+  ]
+}"
+## END DPA ##
+
+   # the name prefix for the resource to backup
+  backup.prefix: acm-app
+
+###### backup schedule resource ###
+####################################
+  backup.snapshotVolumes: "true"
+  backup.defaultVolumesToRestic: "false"
+######################################
+###### end backup schedule resource ###
+
+###### restore resource ###
+####################################
+  restore.restorePVs: "true"
+######################################
+###### end backup schedule resource ###
+
+
+###### backup schedule resource ###
+####################################
+  backup.schedule: 0 */1 * * *
+  backup.ttl: 240h0m0s
+
+  # list here all applications namespaces you want to backup
+  # for example backup.nsToBackup: "[\"pacman-ns\", \"helloworld-pv-ns\"]"
+  backup.nsToBackup: "[\"app1-ns\", \"app2-ns\", \"app3-ns\"]" 
+######################################
+###### end backup schedule resource ###
+
+## restore storage class mapping ##
+  restore.storage.config.name: storage-class-acm-app
+  restore.mappings: "{
+      \"data\": {
+          \"managed-csi\": \"thin\",
+      },
+    }"
+##################################
+
+###### restore resource ###
+####################################
+  # the name of the backup to restore from
+  # for example backupName: acm-pv-schedule-vb-managed-cls-1-20230208150010
+  restore.backupName: <backup-name>
+  # list here all apps ns you want to restore from the specified backup
+  # for example backup.nsToBackup: "[\"pacman-ns\"]"
+  restore.nsToRestore: "[\"app1-ns\", \"app2-ns\"]"
+######################################
+###### end backup schedule resource ###
+

--- a/policygenerator/policy-sets/community/acm-app-backup/input/restic/hdr-app-configmap.yaml
+++ b/policygenerator/policy-sets/community/acm-app-backup/input/restic/hdr-app-configmap.yaml
@@ -1,0 +1,139 @@
+#
+# This configmap is used by the oadp-hdr-app-install and oadp-hdr-app-backup policies 
+# and specifies the configuration required to install velero and create backups 
+#
+# This config is set to use restic for backing up PVs 
+# https://velero.io/docs/v1.9/restic/
+# see restic limitations here https://velero.io/docs/v1.9/restic/#limitations
+# use this option if the PV snapshot is not supported your backup and restore clusters are running on different platforms
+# or they are in different regions and can't share PV snapshots - otherwise use the configmap from the  pv-snap folder
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hdr-app-configmap
+data:
+  # backupNS is the ns where velero/oadp is installed on the cluster
+  backupNS: open-cluster-management-backup 
+  channel: stable-1.1
+  subscriptionName: redhat-oadp-operator
+
+# define cloud-credential used to connect to the storage location, base64 encoded string
+# for example, for an aws storage location, the credential is in this format
+#
+# [default]
+# aws_access_key_id=<id>
+# aws_secret_access_key=<key>
+#
+  dpa.aws.backup.cloud.credentials: W2RlZmF1bHRdCmF3c19hY2Nlc3Nfa2V5X2lkPTxpZD4KYXdzX3NlY3JldF9hY2Nlc3Nfa2V5PTxrZXk+
+
+
+## DPA resource configuration
+#
+  #DPA resource name; use the same name for all hubs, the PV cannot be restored if 
+  # the BackupStorageLocation resource doesn't have the same name
+  # on both backup and restore cluster 
+  dpaName: dpa
+  dpa.backup.cloud.credentials.name: cloud-credentials
+#######
+# DPA spec
+# below is the spec format for an aws storage
+# update this with the DPA format for the type of storage you are using
+# values specified with brackets <> should be updated before appliying this configmap
+  dpa.spec: "{
+  \"backupLocations\": [
+    {
+      \"velero\": {
+        \"config\": {
+          \"profile\": \"default\",
+          \"region\": \"<us-east-1>\"
+        },
+        \"credential\": {
+          \"key\": \"cloud\",
+          \"name\": \"<dpa.backup.cloud.credentials.name>\"
+        },
+        \"default\": true,
+        \"objectStorage\": {
+          \"bucket\": \"<bucket-name>\",
+          \"prefix\": \"<in-bucket-folder-name>\"
+        },
+        \"provider\": \"<aws>\"
+      }
+    }
+  ],
+  \"configuration\": {
+    \"restic\": {
+      \"enable\": true
+    },
+    \"velero\": {
+      \"defaultPlugins\": [
+        \"openshift\",
+        \"aws\"
+      ],
+      \"podConfig\": {
+        \"resourceAllocations\": {
+          \"limits\": {
+            \"cpu\": \"2\",
+            \"memory\": \"1Gi\"
+          },
+          \"requests\": {
+            \"cpu\": \"500m\",
+            \"memory\": \"256Mi\"
+          }
+        }
+      }
+    }
+  }
+}"
+## END DPA ##
+
+   # the name prefix for the resource to backup
+  backup.prefix: acm-restic
+
+
+###### backup schedule resource ###
+####################################
+  backup.snapshotVolumes: "false"
+  backup.defaultVolumesToRestic: "true"
+######################################
+###### end backup schedule resource ###
+
+###### restore resource ###
+####################################
+  restore.restorePVs: "false"
+######################################
+###### end backup schedule resource ###
+
+###### backup schedule resource ###
+####################################
+  backup.schedule: 0 */1 * * *
+  backup.ttl: 240h0m0s
+
+  # list here all applications namespaces you want to backup
+  # for example backup.nsToBackup: "[\"pacman-ns\", \"helloworld-pv-ns\"]"
+  backup.nsToBackup: "[\"app1-ns\", \"app2-ns\", \"app3-ns\"]" 
+######################################
+###### end backup schedule resource ###
+
+## restore storage class mapping ##
+  restore.storage.config.name: storage-class-acm-app
+  restore.mappings: "{
+      \"data\": {
+          \"managed-csi\": \"thin\",
+      },
+    }"
+##################################
+
+###### restore resource ###
+####################################
+  # the name of the backup to restore from
+  # for example backupName: acm-pv-schedule-vb-managed-cls-1-20230208150010
+  restore.backupName: <backup-name>
+  # list here all apps ns you want to restore from the specified backup
+  # for example backup.nsToBackup: "[\"pacman-ns\"]"
+  restore.nsToRestore: "[\"app1-ns\", \"app2-ns\"]"
+######################################
+###### end backup schedule resource ###
+
+
+

--- a/policygenerator/policy-sets/community/acm-app-backup/kustomization.yaml
+++ b/policygenerator/policy-sets/community/acm-app-backup/kustomization.yaml
@@ -1,0 +1,12 @@
+# The configmap sets configuration options for the backup storage location, for the backup schedule 
+# backing up applications, and for the restore resource used to restore applications backups.
+# Update all settings with valid values before applying the `hdr-app-configmap` resource on the hub.
+# use ./input/pv-snap/hdr-app-configmap.yaml if you want to use volume snapshots instead of restic
+- ./input/restic/hdr-app-configmap.yaml 
+- ./policies/oadp-hdr-app-install.yaml
+# install the backup or restore policyset, or both ( comment out the policyset not used on this hub ) 
+- ./policy-sets/acm-app-backup-policy-set.yaml
+- ./policy-sets/acm-app-restore-policy-set.yaml
+# install the backup or restore policy, or both ( comment out the policy not used on this hub ) 
+- ./policies/oadp-hdr-app-backup.yaml
+- ./policies/oadp-hdr-app-restore.yaml

--- a/policygenerator/policy-sets/community/acm-app-backup/policies/oadp-hdr-app-backup.yaml
+++ b/policygenerator/policy-sets/community/acm-app-backup/policies/oadp-hdr-app-backup.yaml
@@ -1,0 +1,189 @@
+#
+# This policy creates a velero backup schedule on managed clusters matching the acm-app-backup-placement rule
+# defined with the ../policy-sets/acm-app-restore-policy-set.yaml. 
+# The schedule is used to backup applications resources and PVs.
+# The schedule uses the `backup.nsToBackup` hdr-app-configmap property to specify the namespaces for the applications to backup. 
+# 
+# This policy is contained by the acm-app-backup policy set. 
+# Create this policy on the hub managing clusters where you want to create stateful applications backups.
+#
+# Both policies, oadp-hdr-app-backup and oadp-hdr-app-restore can be installed on the same hub,
+# if this hub manages clusters where applications need to be backed up or restored. 
+#
+# If the managed cluster (or hub) matches the acm-app-backup-placement then the oadp-hdr-app-backup policy 
+# is propagated to this cluster for an application backup schedule. This cluster produces applications backups.
+# Make sure the hdr-app-configmap's backup schedule resource settings are properly set before applying this policy.
+#
+# Note that it is set to enforce by default.
+#
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: oadp-hdr-app-backup
+  annotations:
+    policy.open-cluster-management.io/categories: CA Security Assessment and Authorization
+    policy.open-cluster-management.io/controls: CA-2 Security Assessments, CA-7 Continuous Monitoring
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+spec:
+  dependencies:
+  - apiVersion: policy.open-cluster-management.io/v1
+    compliance: Compliant
+    kind: Policy
+    name: oadp-hdr-app-install
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: check-schedule-resource
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: velero.io/v1
+                kind: Schedule
+                metadata:
+                  name: '{{hub fromConfigMap "" "hdr-app-configmap" "backup.prefix" hub}}-{{hub fromConfigMap "" "hdr-app-configmap" "backup.volumeSnapshotLocation" hub}}-{{ fromClusterClaim "name" }}'
+                  namespace: '{{hub fromConfigMap "" "hdr-app-configmap" "backupNS" hub}}'
+                  labels:
+                    cluster-id: '{{ fromClusterClaim "id.openshift.io" }}'
+                    cluster-name: '{{ fromClusterClaim "name" }}'
+                spec:
+                  schedule: '{{hub fromConfigMap "" "hdr-app-configmap" "backup.schedule" hub}}' 
+                  template:
+                    volumeSnapshotLocations:
+                      - '{{hub fromConfigMap "" "hdr-app-configmap" "backup.volumeSnapshotLocation" hub}}' 
+                    snapshotVolumes: '{{hub fromConfigMap "" "hdr-app-configmap" "backup.snapshotVolumes" | toBool hub}}'
+                    defaultVolumesToRestic: '{{hub fromConfigMap "" "hdr-app-configmap" "backup.defaultVolumesToRestic" | toBool hub}}'
+                    includedNamespaces: '{{hub fromConfigMap "" "hdr-app-configmap" "backup.nsToBackup" | toLiteral hub}}' 
+                    ttl: '{{hub fromConfigMap "" "hdr-app-configmap" "backup.ttl" hub}}'  
+          pruneObjectBehavior: DeleteIfCreated             
+          remediationAction: enforce
+          severity: high
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: check-backup-completed
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: velero.io/v1
+                kind: Backup
+                metadata:
+                  namespace: '{{hub fromConfigMap "" "hdr-app-configmap" "backupNS" hub}}'
+                  labels:
+                    velero.io/schedule-name: '{{hub fromConfigMap "" "hdr-app-configmap" "backup.prefix" hub}}-{{hub fromConfigMap "" "hdr-app-configmap" "backup.volumeSnapshotLocation" hub}}-{{ fromClusterClaim "name" }}'
+                    cluster-id: '{{ fromClusterClaim "id.openshift.io" }}'
+                    cluster-name: '{{ fromClusterClaim "name" }}'              
+                status:
+                  phase: Completed              
+          remediationAction: inform
+          severity: high
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: check-backup-error
+        spec:
+          object-templates:
+            - complianceType: mustnothave
+              objectDefinition:
+                apiVersion: velero.io/v1
+                kind: Backup
+                metadata:
+                  namespace: '{{hub fromConfigMap "" "hdr-app-configmap" "backupNS" hub}}'
+                  labels:
+                    velero.io/schedule-name: '{{hub fromConfigMap "" "hdr-app-configmap" "backup.prefix" hub}}-{{hub fromConfigMap "" "hdr-app-configmap" "backup.volumeSnapshotLocation" hub}}-{{ fromClusterClaim "name" }}'
+                    cluster-id: '{{ fromClusterClaim "id.openshift.io" }}'
+                    cluster-name: '{{ fromClusterClaim "name" }}'              
+                status:
+                  phase: Error                
+          remediationAction: inform
+          severity: high
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: check-backup-failed-validation
+        spec:
+          object-templates:
+            - complianceType: mustnothave
+              objectDefinition:
+                apiVersion: velero.io/v1
+                kind: Backup
+                metadata:
+                  namespace: '{{hub fromConfigMap "" "hdr-app-configmap" "backupNS" hub}}'
+                  labels:
+                    velero.io/schedule-name: '{{hub fromConfigMap "" "hdr-app-configmap" "backup.prefix" hub}}-{{hub fromConfigMap "" "hdr-app-configmap" "backup.volumeSnapshotLocation" hub}}-{{ fromClusterClaim "name" }}'
+                    cluster-id: '{{ fromClusterClaim "id.openshift.io" }}'
+                    cluster-name: '{{ fromClusterClaim "name" }}'              
+                status:
+                  phase: FailedValidation                
+          remediationAction: inform
+          severity: high
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: check-backup-partially-failed
+        spec:
+          object-templates:
+            - complianceType: mustnothave
+              objectDefinition:
+                apiVersion: velero.io/v1
+                kind: Backup
+                metadata:
+                  namespace: '{{hub fromConfigMap "" "hdr-app-configmap" "backupNS" hub}}'
+                  labels:
+                    velero.io/schedule-name: '{{hub fromConfigMap "" "hdr-app-configmap" "backup.prefix" hub}}-{{hub fromConfigMap "" "hdr-app-configmap" "backup.volumeSnapshotLocation" hub}}-{{ fromClusterClaim "name" }}'
+                    cluster-id: '{{ fromClusterClaim "id.openshift.io" }}'
+                    cluster-name: '{{ fromClusterClaim "name" }}'              
+                status:
+                  phase: PartiallyFailed                
+          remediationAction: inform
+          severity: high
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: check-backup-in-progress
+        spec:
+          object-templates:
+            - complianceType: mustnothave
+              objectDefinition:
+                apiVersion: velero.io/v1
+                kind: Backup
+                metadata:
+                  namespace: '{{hub fromConfigMap "" "hdr-app-configmap" "backupNS" hub}}'
+                  labels:
+                    velero.io/schedule-name: '{{hub fromConfigMap "" "hdr-app-configmap" "backup.prefix" hub}}-{{hub fromConfigMap "" "hdr-app-configmap" "backup.volumeSnapshotLocation" hub}}-{{ fromClusterClaim "name" }}'
+                    cluster-id: '{{ fromClusterClaim "id.openshift.io" }}'
+                    cluster-name: '{{ fromClusterClaim "name" }}'              
+                status:
+                  phase: InProgress                
+          remediationAction: inform
+          severity: low
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: check-backup-no-status
+        spec:
+          object-templates:
+            - complianceType: mustnothave
+              objectDefinition:
+                apiVersion: velero.io/v1
+                kind: Backup
+                metadata:
+                  namespace: '{{hub fromConfigMap "" "hdr-app-configmap" "backupNS" hub}}'
+                  labels:
+                    velero.io/schedule-name: '{{hub fromConfigMap "" "hdr-app-configmap" "backup.prefix" hub}}-{{hub fromConfigMap "" "hdr-app-configmap" "backup.volumeSnapshotLocation" hub}}-{{ fromClusterClaim "name" }}'
+                    cluster-id: '{{ fromClusterClaim "id.openshift.io" }}'
+                    cluster-name: '{{ fromClusterClaim "name" }}'              
+                status:
+                  phase: ''                                                            
+          remediationAction: inform
+          severity: low

--- a/policygenerator/policy-sets/community/acm-app-backup/policies/oadp-hdr-app-install.yaml
+++ b/policygenerator/policy-sets/community/acm-app-backup/policies/oadp-hdr-app-install.yaml
@@ -1,0 +1,212 @@
+#
+# This policy deploys velero using the OADP operator to all managed clusters 
+# matching the acm-app-backup-placement or acm-app-restore-placement rules.
+# Installs: 
+# - OADP Operator using the hdr-app-configmap channel and subscriptionName properties.
+# - Creates the cloud credentials secret used by the DataProtectionApplication to connect with the backup storage;
+#   The cloud credentials secret is set using the hdr-app-configmap dpa.aws.backup.cloud.credentials property.
+# - Creates the DataProtectionApplication resource used to configure Velero. Uses hdr-app-configmap dpaName for the
+#   DataProtectionApplication name and hdr-app-configmap dpa.spec for the resource spec settings.
+# Informs on: 
+# - Velero pod not running, DataProtectionApplication not properly configured.
+#
+# This policy is contained by the acm-app-backup and acm-app-restore policy sets. 
+#
+# Create this policy on the hub managing clusters where you want to create stateful applications backups,
+# or where you restore these backup.  
+# Before installing this policy, create the hdr-app-configmap ConfigMap and set all required properties.
+#
+# Make sure the hdr-app-configmap's storage settings are properly set before applying this policy.
+#
+# IMPORTANT: 
+# If the hub is one of the clusters where this policy will be placed, and the backupNS=open-cluster-management-backup
+# then first enable cluster-backup on MultiClusterHub. 
+# MCH looks for the cluster-backup option and if set to false, it uninstalls OADP from the
+# open-cluster-management-backup and deletes the namespace.
+#
+# Note that it is set to enforce by default.
+#
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: oadp-hdr-app-install
+  annotations:
+    policy.open-cluster-management.io/categories: PR.IP Information Protection Processes and Procedures
+    policy.open-cluster-management.io/controls: PR.IP-4 Backups of information are conducted maintained and tested
+    policy.open-cluster-management.io/standards: NIST-CSF
+spec:
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: check-ns-oadp-operators
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Namespace
+                metadata:
+                  name: '{{hub fromConfigMap "" "hdr-app-configmap" "backupNS" hub}}'
+          remediationAction: enforce
+          pruneObjectBehavior: DeleteIfCreated
+          severity: high
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: check-oadp-operator-group
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operators.coreos.com/v1
+                kind: OperatorGroup
+                metadata:
+                  name: redhat-oadp-operator-group
+                  namespace: '{{hub fromConfigMap "" "hdr-app-configmap" "backupNS" hub}}'
+                spec:
+                  targetNamespaces:
+                    - '{{hub fromConfigMap "" "hdr-app-configmap" "backupNS" hub}}'
+          remediationAction: enforce
+          pruneObjectBehavior: DeleteIfCreated
+          severity: high
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: check-oadp-operator-subscription
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operators.coreos.com/v1alpha1
+                kind: Subscription
+                metadata:
+                  name: redhat-oadp-operator-subscription
+                  namespace: '{{hub fromConfigMap "" "hdr-app-configmap" "backupNS" hub}}'
+                spec:
+                  name: '{{hub fromConfigMap "" "hdr-app-configmap" "subscriptionName" hub}}'
+                  channel: '{{hub fromConfigMap "" "hdr-app-configmap" "channel" hub}}'
+                  installPlanApproval: Automatic
+                  source: redhat-operators
+                  sourceNamespace: openshift-marketplace
+          remediationAction: enforce
+          pruneObjectBehavior: DeleteIfCreated
+          severity: high
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: check-backup-storage-credentials-secret
+        spec:
+          object-templates:
+          - complianceType: musthave
+            objectDefinition:
+              apiVersion: v1
+              data:
+                cloud: '{{hub fromConfigMap "" "hdr-app-configmap" "dpa.aws.backup.cloud.credentials" hub}}'
+              kind: Secret
+              metadata:
+                name: '{{hub fromConfigMap "" "hdr-app-configmap" "dpa.backup.cloud.credentials.name" hub}}'
+                namespace: '{{hub fromConfigMap "" "hdr-app-configmap" "backupNS" hub}}'
+              type: Opaque
+          remediationAction: enforce
+          pruneObjectBehavior: DeleteIfCreated 
+          severity: high
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: check-oadp-dpa-resource
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: oadp.openshift.io/v1alpha1
+                kind: DataProtectionApplication
+                metadata:
+                  name: '{{hub fromConfigMap "" "hdr-app-configmap" "dpaName" hub}}'
+                  namespace: '{{hub fromConfigMap "" "hdr-app-configmap" "backupNS" hub}}'
+                spec: '{{hub fromConfigMap "" "hdr-app-configmap" "dpa.spec" | toLiteral hub}}'
+          pruneObjectBehavior: DeleteIfCreated                
+          remediationAction: enforce
+          severity: high
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: check-app-oadp-pod-running
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  annotations:
+                    repository: https://github.com/openshift/oadp-operator
+                  namespace: '{{hub fromConfigMap "" "hdr-app-configmap" "backupNS" hub}}'
+                status:
+                  phase: Running
+          remediationAction: inform
+          severity: high 
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: check-app-velero-pod-running
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  labels:
+                    app.kubernetes.io/name: velero
+                  namespace: '{{hub fromConfigMap "" "hdr-app-configmap" "backupNS" hub}}'
+                status:
+                  phase: Running
+          remediationAction: inform
+          severity: high
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: check-app-dpa-complete
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: oadp.openshift.io/v1alpha1
+                kind: DataProtectionApplication
+                metadata:
+                  name: '{{hub fromConfigMap "" "hdr-app-configmap" "dpaName" hub}}'
+                  namespace: '{{hub fromConfigMap "" "hdr-app-configmap" "backupNS" hub}}'
+                status:
+                  conditions:
+                    - reason: Complete
+                      type: Reconciled
+          remediationAction: inform
+          severity: high
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: check-backup-storage-location-available
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: velero.io/v1
+                kind: BackupStorageLocation
+                metadata:
+                  name: '{{hub fromConfigMap "" "hdr-app-configmap" "dpaName" hub}}-1'
+                  namespace: '{{hub fromConfigMap "" "hdr-app-configmap" "backupNS" hub}}'
+                status:
+                  phase: Available                
+          remediationAction: inform
+          severity: high

--- a/policygenerator/policy-sets/community/acm-app-backup/policies/oadp-hdr-app-restore.yaml
+++ b/policygenerator/policy-sets/community/acm-app-backup/policies/oadp-hdr-app-restore.yaml
@@ -1,0 +1,193 @@
+#
+# This policy creates a velero restore resource on managed clusters matching the acm-app-restore-placement rule 
+# defined with the ../policy-sets/acm-app-restore-policy-set.yaml
+# The restore resource is used to restore applications resources and PVs from a selected backup.
+# The restore uses the `restore.nsToRestore` hdr-app-configmap property to specify the namespaces for the applications to restore 
+#
+# This policy is contained by the acm-app-restore policy set. 
+# Create this policy on the hub managing clusters where you plan to restore a backup 
+# created by the oadp-hdr-app-backup policy. 
+#
+# Both policies, oadp-hdr-app-backup and oadp-hdr-app-restore can be installed on the same hub,
+# if this hub manages clusters where applications need to be backed up or restored. 
+#
+# If the managed cluster (or hub) matches the acm-app-restore-placement then the oadp-hdr-app-restore policy 
+# is propagated to this cluster for a restore operation. 
+# Make sure the hdr-app-configmap's restore resource settings are properly set before applying this policy.
+#
+# Note that it is set to enforce by default.
+#
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: oadp-hdr-app-restore
+  annotations:
+    policy.open-cluster-management.io/categories: PR.IP Information Protection Processes and Procedures
+    policy.open-cluster-management.io/controls: PR.IP-4 Backups of information are conducted maintained and tested
+    policy.open-cluster-management.io/standards: NIST-CSF
+spec:
+  dependencies:
+  - apiVersion: policy.open-cluster-management.io/v1
+    compliance: Compliant
+    kind: Policy
+    name: oadp-hdr-app-install
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: check-storage-class-map
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: ConfigMap
+                metadata:
+                  name: '{{hub fromConfigMap "" "hdr-app-configmap" "restore.storage.config.name" hub}}'
+                  namespace: '{{hub fromConfigMap "" "hdr-app-configmap" "backupNS" hub}}'
+                  labels:
+                    velero.io/plugin-config: ""
+                    velero.io/change-storage-class: RestoreItemAction
+                data: '{{hub fromConfigMap "" "hdr-app-configmap" "restore.storage.config.mappings" | toLiteral hub}}'
+          remediationAction: enforce
+          severity: high
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: check-restore-resource
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: velero.io/v1
+                kind: Restore
+                metadata:
+                  name: 'restore-{{hub fromConfigMap "" "hdr-app-configmap" "restore.backupName" hub}}'
+                  namespace: '{{hub fromConfigMap "" "hdr-app-configmap" "backupNS" hub}}'
+                  labels:
+                    cluster-id: '{{ fromClusterClaim "id.openshift.io" }}'
+                    cluster-name: '{{ fromClusterClaim "name" }}'
+                spec:
+                  existingResourcePolicy: update
+                  includedNamespaces: '{{hub fromConfigMap "" "hdr-app-configmap" "restore.nsToRestore" | toLiteral hub}}'
+                  backupName: '{{hub fromConfigMap "" "hdr-app-configmap" "restore.backupName" hub}}'
+                  restorePVs: '{{hub fromConfigMap "" "hdr-app-configmap" "restore.restorePVs" | toBool hub}}'            
+          remediationAction: enforce
+          severity: high
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: check-restore-failed
+        spec:
+          object-templates:
+            - complianceType: mustnothave
+              objectDefinition:
+                apiVersion: velero.io/v1
+                kind: Restore
+                metadata:
+                  namespace: '{{hub fromConfigMap "" "hdr-app-configmap" "backupNS" hub}}'
+                spec:
+                  backupName: '{{hub fromConfigMap "" "hdr-app-configmap" "restore.backupName" hub}}'  
+                status:
+                  phase: Failed                                                            
+          remediationAction: inform
+          severity: high
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: check-restore-partially-failed
+        spec:
+          object-templates:
+            - complianceType: mustnothave
+              objectDefinition:
+                apiVersion: velero.io/v1
+                kind: Restore
+                metadata:
+                  namespace: '{{hub fromConfigMap "" "hdr-app-configmap" "backupNS" hub}}'
+                spec:
+                  backupName: '{{hub fromConfigMap "" "hdr-app-configmap" "restore.backupName" hub}}'  
+                status:
+                  phase: PartiallyFailed                                                            
+          remediationAction: inform
+          severity: high
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: check-restore-failed-validation
+        spec:
+          object-templates:
+            - complianceType: mustnothave
+              objectDefinition:
+                apiVersion: velero.io/v1
+                kind: Restore
+                metadata:
+                  namespace: '{{hub fromConfigMap "" "hdr-app-configmap" "backupNS" hub}}'
+                spec:
+                  backupName: '{{hub fromConfigMap "" "hdr-app-configmap" "restore.backupName" hub}}'  
+                status:
+                  phase: FailedValidation                                                            
+          remediationAction: inform
+          severity: high
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: check-restore-in-progress
+        spec:
+          object-templates:
+            - complianceType: mustnothave
+              objectDefinition:
+                apiVersion: velero.io/v1
+                kind: Restore
+                metadata:
+                  namespace: '{{hub fromConfigMap "" "hdr-app-configmap" "backupNS" hub}}'
+                spec:
+                  backupName: '{{hub fromConfigMap "" "hdr-app-configmap" "restore.backupName" hub}}'  
+                status:
+                  phase: InProgress                                                            
+          remediationAction: inform
+          severity: low
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: check-restore-no-status
+        spec:
+          object-templates:
+            - complianceType: mustnothave
+              objectDefinition:
+                apiVersion: velero.io/v1
+                kind: Restore
+                metadata:
+                  namespace: '{{hub fromConfigMap "" "hdr-app-configmap" "backupNS" hub}}'
+                spec:
+                  backupName: '{{hub fromConfigMap "" "hdr-app-configmap" "restore.backupName" hub}}'  
+                status:
+                  phase: ''                                                            
+          remediationAction: inform
+          severity: low
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: check-restore-completed
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: velero.io/v1
+                kind: Restore
+                metadata:
+                  namespace: '{{hub fromConfigMap "" "hdr-app-configmap" "backupNS" hub}}'
+                spec:
+                  backupName: '{{hub fromConfigMap "" "hdr-app-configmap" "restore.backupName" hub}}'  
+                status:
+                  phase: Completed                                                            
+          remediationAction: inform
+          severity: low

--- a/policygenerator/policy-sets/community/acm-app-backup/policy-sets/acm-app-backup-policy-set.yaml
+++ b/policygenerator/policy-sets/community/acm-app-backup/policy-sets/acm-app-backup-policy-set.yaml
@@ -1,0 +1,38 @@
+# The PolicySet is used to place the oadp-hdr-app-install and oadp-hdr-app-backup policies on managed clusters
+# using the acm-app-backup-placement rule in this file, which is all managed clusters with a label "acm-pv-dr=backup". 
+# Update the placement rule if you want to customize the target cluster list.
+apiVersion: policy.open-cluster-management.io/v1beta1
+kind: PolicySet
+metadata:
+  name: acm-app-backup
+spec:
+  description: backup support for stateful apps running on managed clusters
+  policies:
+    - oadp-hdr-app-install
+    - oadp-hdr-app-backup
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: acm-app-backup-placement
+spec:
+  clusterConditions: []
+  clusterSelector:
+    matchExpressions:
+      - key: acm-pv-dr
+        operator: In
+        values:
+          - backup
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: acm-app-backup-placement-binding
+placementRef:
+  name: acm-app-backup-placement
+  apiGroup: apps.open-cluster-management.io
+  kind: PlacementRule
+subjects:
+  - name: acm-app-backup
+    apiGroup: policy.open-cluster-management.io
+    kind: PolicySet

--- a/policygenerator/policy-sets/community/acm-app-backup/policy-sets/acm-app-restore-policy-set.yaml
+++ b/policygenerator/policy-sets/community/acm-app-backup/policy-sets/acm-app-restore-policy-set.yaml
@@ -1,0 +1,38 @@
+# The PolicySet is used to place the oadp-hdr-app-install and oadp-hdr-app-restore policies on managed clusters
+# using the acm-app-restore-placement rule in this file, which is all managed clusters with a label "acm-pv-dr=restore". 
+# Update the placement rule if you want to customize the target cluster list.
+apiVersion: policy.open-cluster-management.io/v1beta1
+kind: PolicySet
+metadata:
+  name: acm-app-restore
+spec:
+  description: restore support for stateful apps running on managed clusters
+  policies:
+    - oadp-hdr-app-install
+    - oadp-hdr-app-restore
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: acm-app-restore-placement
+spec:
+  clusterConditions: []
+  clusterSelector:
+    matchExpressions:
+      - key: acm-pv-dr
+        operator: In
+        values:
+          - restore
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: acm-app-restore-placement-binding
+placementRef:
+  name: acm-app-restore-placement
+  apiGroup: apps.open-cluster-management.io
+  kind: PlacementRule
+subjects:
+  - name: acm-app-restore
+    apiGroup: policy.open-cluster-management.io
+    kind: PolicySet


### PR DESCRIPTION
Created PolicySets and Policies used to backup and restore stateful application data on managed clusters.

The Policies available here provide backup and restore support for stateful applications running on  managed clusters or hub. Velero is used to backup and restore applications data. The product is installed using the OADP operator, which the [oadp-hdr-app-install](./policies/oadp-hdr-app-install.yaml) policy installs and configure on each target cluster.

The configmap in the PR sets configuration options for the backup storage location, for the backup schedule backing up applications, and for the restore resource used to restore applications backups.

Signed-off-by: Valentina Birsan vbirsan@redhat.com
