### PR TITLE
Removing policy dependencies

### DIFF
--- a/community/CM-Configuration-Management/policy-rhsso-configure-mc-spokeresources.yaml
+++ b/community/CM-Configuration-Management/policy-rhsso-configure-mc-spokeresources.yaml
@@ -21,12 +21,6 @@ metadata:
   name: configure-mc-rhsso-spokeresources
   namespace: rhsso
 spec:
-  dependencies:
-    - apiVersion: policy.open-cluster-management.io/v1
-      kind: Policy
-      name: configure-mc-rhsso-hubresources
-      namespace: rhsso-policies
-      compliance: Compliant
   disabled: false
   policy-templates:
   - objectDefinition:


### PR DESCRIPTION
I think having this dependency in this policy won't be ok because the other previous SSO policies are not deployed to managed clusters, so the dependency will stop this policy from being executed in managed clusters other than the local-cluster.