### PR TITLE
Use the channel for ACS 4.0

### DIFF
--- a/policygenerator/policy-sets/stable/openshift-plus/input-acs-central/policy-acs-operator-central.yaml
+++ b/policygenerator/policy-sets/stable/openshift-plus/input-acs-central/policy-acs-operator-central.yaml
@@ -21,7 +21,7 @@ metadata:
   name: rhacs-operator
   namespace: rhacs-operator
 spec:
-  channel: latest
+  channel: stable
   installPlanApproval: Automatic
   name: rhacs-operator
   source: redhat-operators

--- a/policygenerator/policy-sets/stable/openshift-plus/input-sensor/policy-advanced-managed-cluster-security.yaml
+++ b/policygenerator/policy-sets/stable/openshift-plus/input-sensor/policy-advanced-managed-cluster-security.yaml
@@ -21,7 +21,7 @@ metadata:
   name: rhacs-operator
   namespace: rhacs-operator
 spec:
-  channel: latest
+  channel: stable
   installPlanApproval: Automatic
   name: rhacs-operator
   source: redhat-operators


### PR DESCRIPTION
To upgrade to ACS 4.0 you need to use the stable channel instead of the latest channel.  This update allows users to start with the stable channel.