### PR TITLE
Add API versions to Kyverno policies

### DIFF
--- a/stable/CM-Configuration-Management/policy-kyverno-add-network-policy.yaml
+++ b/stable/CM-Configuration-Management/policy-kyverno-add-network-policy.yaml
@@ -49,6 +49,7 @@ spec:
                         kinds:
                         - Namespace
                     generate:
+                      apiVersion: networking.k8s.io/v1
                       kind: NetworkPolicy
                       name: default-deny
                       namespace: "{{ `{{request.object.metadata.name}}` }}"

--- a/stable/CM-Configuration-Management/policy-kyverno-add-quota.yaml
+++ b/stable/CM-Configuration-Management/policy-kyverno-add-quota.yaml
@@ -47,6 +47,7 @@ spec:
                         kinds:
                         - Namespace
                     generate:
+                      apiVersion: v1
                       kind: ResourceQuota
                       name: default-resourcequota
                       synchronize: true
@@ -64,6 +65,7 @@ spec:
                         kinds:
                         - Namespace
                     generate:
+                      apiVersion: v1
                       kind: LimitRange
                       name: default-limitrange
                       synchronize: true


### PR DESCRIPTION
Kyverno is now validating the API version:
```
path: spec.rules[0].generate.apiVersion.: apiVersion cannot be empty
```