### PR TITLE
The ACS Operator no longer support the KernelModule option for the Co…

### DIFF
--- a/policygenerator/policy-sets/stable/openshift-plus/input-sensor/policy-acs-sync-resources.yaml
+++ b/policygenerator/policy-sets/stable/openshift-plus/input-sensor/policy-acs-sync-resources.yaml
@@ -18,7 +18,7 @@ spec:
     scannerComponent: Disabled
   perNode:
     collector:
-      collection: KernelModule
+      collection: EBPF
       imageFlavor: Regular
     taintToleration: TolerateTaints
 ---


### PR DESCRIPTION
…llector

We see an error with the latest ACS that the KernelModule collector option is no longer supported.  I had changed one place where we used the old option but I missed another location which I am including with this PR.

Ref:
- https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_release/41022/rehearse-41022-periodic-ci-stolostron-policy-collection-main-opp-ocp4.13-interop-openshift-plus-interop-aws/1677014851441922048/artifacts/openshift-plus-interop-aws/acm-must-gather/artifacts/registry-redhat-io-rhacm2-acm-must-gather-rhel8-sha256-871327477907ad0dd7728795e1e487ab8231dc00a1ebae23e493b93b8af89bee/namespaces/local-cluster/policy.open-cluster-management.io/policies/policies.policy-acs-sync-resources.yaml