### PR TITLE
Use v1beta2 ManagedClusterSet API since v1beta1 is deprecated

### DIFF
--- a/community/CM-Configuration-Management/policy-idp-sample-github.yaml
+++ b/community/CM-Configuration-Management/policy-idp-sample-github.yaml
@@ -33,7 +33,7 @@ spec:
               name: authrealm-sample-github-ns
         - complianceType: musthave
           objectDefinition:
-            apiVersion: cluster.open-cluster-management.io/v1beta1
+            apiVersion: cluster.open-cluster-management.io/v1beta2
             kind: ManagedClusterSet
             metadata:
               name: authrealm-sample-github-clusterset
@@ -53,7 +53,7 @@ spec:
                       authdeployment: sample-github
         - complianceType: musthave
           objectDefinition:
-            apiVersion: cluster.open-cluster-management.io/v1beta1
+            apiVersion: cluster.open-cluster-management.io/v1beta2
             kind: ManagedClusterSetBinding
             metadata:
               name: authrealm-sample-github-clusterset

--- a/community/CM-Configuration-Management/policy-managedclustersetbinding.yaml
+++ b/community/CM-Configuration-Management/policy-managedclustersetbinding.yaml
@@ -29,7 +29,7 @@ spec:
               name: policies
         - complianceType: musthave
           objectDefinition:
-            apiVersion: cluster.open-cluster-management.io/v1beta1
+            apiVersion: cluster.open-cluster-management.io/v1beta2
             kind: ManagedClusterSetBinding
             metadata:
               namespace: policies

--- a/policygenerator/policy-sets/community/kyverno/multitenancy/input/generateManagedClusterSetBinding/generateManagedClusterSetBindingblueteam-hub.yaml
+++ b/policygenerator/policy-sets/community/kyverno/multitenancy/input/generateManagedClusterSetBinding/generateManagedClusterSetBindingblueteam-hub.yaml
@@ -30,7 +30,7 @@ spec:
         - CREATE
         - UPDATE             
     generate:
-      apiVersion: cluster.open-cluster-management.io/v1beta1
+      apiVersion: cluster.open-cluster-management.io/v1beta2
       kind: ManagedClusterSetBinding
       name: blueteam
       namespace: "{{request.object.metadata.name}}"

--- a/policygenerator/policy-sets/community/kyverno/multitenancy/input/generateManagedClusterSetBinding/generateManagedClusterSetBindingredteam-hub.yaml
+++ b/policygenerator/policy-sets/community/kyverno/multitenancy/input/generateManagedClusterSetBinding/generateManagedClusterSetBindingredteam-hub.yaml
@@ -29,7 +29,7 @@ spec:
         value:
         - CREATE
     generate:
-      apiVersion: cluster.open-cluster-management.io/v1beta1
+      apiVersion: cluster.open-cluster-management.io/v1beta2
       kind: ManagedClusterSetBinding
       name: redteam
       namespace: "{{request.object.metadata.name}}"

--- a/policygenerator/policy-sets/community/kyverno/multitenancy/input/generateall/generate-all-blueteam-spoke.yml
+++ b/policygenerator/policy-sets/community/kyverno/multitenancy/input/generateall/generate-all-blueteam-spoke.yml
@@ -59,7 +59,7 @@ spec:
         - CREATE
         - UPDATE             
     generate:
-      apiVersion: cluster.open-cluster-management.io/v1beta1
+      apiVersion: cluster.open-cluster-management.io/v1beta2
       kind: ManagedClusterSetBinding
       name: blueteam
       namespace: "{{request.object.metadata.name}}"

--- a/policygenerator/policy-sets/community/kyverno/multitenancy/input/generateall/generate-all-redteam-spoke.yml
+++ b/policygenerator/policy-sets/community/kyverno/multitenancy/input/generateall/generate-all-redteam-spoke.yml
@@ -59,7 +59,7 @@ spec:
         - CREATE
         - UPDATE             
     generate:
-      apiVersion: cluster.open-cluster-management.io/v1beta1
+      apiVersion: cluster.open-cluster-management.io/v1beta2
       kind: ManagedClusterSetBinding
       name: redteam
       namespace: "{{request.object.metadata.name}}"

--- a/policygenerator/policy-sets/community/kyverno/multitenancy/input/sharedresources/add-managedclustersetbinding-shared-sre-group.yaml
+++ b/policygenerator/policy-sets/community/kyverno/multitenancy/input/sharedresources/add-managedclustersetbinding-shared-sre-group.yaml
@@ -35,7 +35,7 @@ spec:
         operator: AnyNotIn
         value: shared*              
     generate:
-      apiVersion: cluster.open-cluster-management.io/v1beta1
+      apiVersion: cluster.open-cluster-management.io/v1beta2
       kind: ManagedClusterSetBinding
       name: blueteam
       namespace: "{{request.object.metadata.name}}"
@@ -65,7 +65,7 @@ spec:
         operator: AnyNotIn
         value: shared*           
     generate:
-      apiVersion: cluster.open-cluster-management.io/v1beta1
+      apiVersion: cluster.open-cluster-management.io/v1beta2
       kind: ManagedClusterSetBinding
       name: redteam
       namespace: "{{request.object.metadata.name}}"

--- a/policygenerator/policy-sets/community/openshift-plus-setup/managedclustersetbinding.yaml
+++ b/policygenerator/policy-sets/community/openshift-plus-setup/managedclustersetbinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.open-cluster-management.io/v1beta1
+apiVersion: cluster.open-cluster-management.io/v1beta2
 kind: ManagedClusterSetBinding
 metadata:
   namespace: policies

--- a/policygenerator/policy-sets/stable/acm-hardening/README.md
+++ b/policygenerator/policy-sets/stable/acm-hardening/README.md
@@ -10,7 +10,7 @@ This `PolicySet` needs to be deployed only to the Advanced Cluster Management hu
 
 **Note**: The `PolicySet` uses cluster `Placement` and not the `PlacementRule` placement mechanism, so the namespace of
 the `Placement` must also be bound to a `ManagedClusterSet` using a `ManagedClusterSetBinding`. See the
-[Placement](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.6/html-single/multicluster_engine/index#placement-overview)
+[Placement](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#placement-overview)
 and
-[ManagedClusterSetBinding](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.6/html-single/multicluster_engine/index#creating-a-managedclustersetbinding)
+[ManagedClusterSetBinding](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#creating-managedclustersetbinding)
 documentation.

--- a/policygenerator/policy-sets/stable/openshift-plus/README.md
+++ b/policygenerator/policy-sets/stable/openshift-plus/README.md
@@ -18,7 +18,7 @@ Prior to applying the `PolicySet`, perform these steps:
 2. Install the Policy generator Kustomize plugin by following the [installation instructions](https://github.com/stolostron/policy-generator-plugin#installation). It is recommended to use Kustomize v4.5+.
 3. Policies are installed to the `policies` namespace.  Make sure the placement bindings match this namespace for the hub and other managed clusters.
    Example yaml to apply a ManagedClusterSetBinding for the policies namespace.
-    ```apiVersion: cluster.open-cluster-management.io/v1beta1
+    ```apiVersion: cluster.open-cluster-management.io/v1beta2
     kind: ManagedClusterSetBinding
     metadata:
         name: default


### PR DESCRIPTION
Need to switch to the new ManagedClusterSet and ManagedClusterSetBinding APIs since v1beta1 is deprecated.  Moving to v1beta2