### PR TITLE
Fixed some issues I had with gitops

### DIFF
--- a/community/CM-Configuration-Management/policy-openshift-gitops-policygenerator.yaml
+++ b/community/CM-Configuration-Management/policy-openshift-gitops-policygenerator.yaml
@@ -38,7 +38,7 @@ spec:
                         /policy-generator/PolicyGenerator
                       command:
                       - /bin/bash
-                      image: registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel8:v2.7
+                      image: registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel8:v2.8
                       name: policy-generator-install
                       volumeMounts:
                       - mountPath: /policy-generator
@@ -69,6 +69,7 @@ spec:
                       - policy.open-cluster-management.io
                     resources:
                       - policies
+                      - policysets
                       - placementbindings
                   - verbs:
                       - get

--- a/community/CM-Configuration-Management/policy-openshift-gitops.yaml
+++ b/community/CM-Configuration-Management/policy-openshift-gitops.yaml
@@ -29,7 +29,7 @@ spec:
                   labels:
                     operators.coreos.com/openshift-gitops-operator.openshift-operators: ''
                 spec:
-                  channel: stable
+                  channel: latest
                   installPlanApproval: Automatic
                   name: openshift-gitops-operator
                   source: redhat-operators


### PR DESCRIPTION
The channel changed.  The stable channel didn't work, I had to pick something else.  The latest channel seems to be the best choice right now.
I couldn't deploy our PolicySet for ACM hardening because the ClusterRole was not right so made an update to include PolicySet