### PR TITLE
QE OPP environment has had problems that I think are due to gp2

### DIFF
--- a/policygenerator/policy-sets/stable/openshift-plus/input-odf/policy-odf.yaml
+++ b/policygenerator/policy-sets/stable/openshift-plus/input-odf/policy-odf.yaml
@@ -70,10 +70,10 @@ spec:
         resources:
           requests:
             storage: 100Gi
-        storageClassName: gp2-csi
+        storageClassName: gp3-csi
         volumeMode: Block
       status: {}
-    name: ocs-deviceset-gp2-csi
+    name: ocs-deviceset-gp3-csi
     placement: {}
     portable: true
     preparePlacement: {}


### PR DESCRIPTION
This is a suspicion that the QE environment is not working well due to switching from gp3 to gp2.  If this change doesn't resolve the issue I'll want to undo this change in the future.