### PR TITLE
Change how the thanos configuration is obtained

### DIFF
--- a/policygenerator/policy-sets/stable/openshift-plus/input-acm-observability/policy-ocm-observability.yaml
+++ b/policygenerator/policy-sets/stable/openshift-plus/input-acm-observability/policy-ocm-observability.yaml
@@ -1,19 +1,3 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: thanos-object-storage
-  namespace: open-cluster-management-observability
-type: Opaque
-stringData:
-  thanos.yaml: |
-    type: s3
-    config:
-      bucket: {{ (lookup "objectbucket.io/v1alpha1" "ObjectBucket" "" "obc-openshift-storage-obc-observability").spec.endpoint.bucketName }}
-      endpoint: {{ (lookup "objectbucket.io/v1alpha1" "ObjectBucket" "" "obc-openshift-storage-obc-observability").spec.endpoint.bucketHost }}
-      insecure: true
-      access_key: {{ fromSecret "openshift-storage" "noobaa-admin" "AWS_ACCESS_KEY_ID" | base64dec }}
-      secret_key: {{ fromSecret "openshift-storage" "noobaa-admin" "AWS_SECRET_ACCESS_KEY" | base64dec }}
----
 apiVersion: observability.open-cluster-management.io/v1beta2
 kind: MultiClusterObservability
 metadata:

--- a/policygenerator/policy-sets/stable/openshift-plus/input-acm-observability/thanos-secret.yaml
+++ b/policygenerator/policy-sets/stable/openshift-plus/input-acm-observability/thanos-secret.yaml
@@ -1,0 +1,37 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: thanos-secret
+spec:
+  remediationAction: enforce
+  severity: high
+  object-templates-raw: |
+    {{- /* read the bucket data and noobaa endpoint access data */ -}}
+    {{- $objBucket := (lookup "objectbucket.io/v1alpha1" "ObjectBucket" "" "obc-openshift-storage-obc-observability") }}
+    {{- $awsAccess := (lookup "v1" "Secret" "openshift-storage" "noobaa-admin") }}
+    {{- /* create the thanos config file as a template */ -}}
+    {{- $thanosConfig := `
+    type: s3
+    config:
+      bucket: %[1]s
+      endpoint: %[2]s
+      insecure: true
+      access_key: %[3]s
+      secret_key: %[4]s`
+    }}
+
+    {{- /* create the secret using the thanos configuration template created above. */ -}}
+    - complianceType: mustonlyhave
+      objectDefinition:
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: thanos-object-storage
+          namespace: open-cluster-management-observability
+        type: Opaque
+        data:
+          thanos.yaml: {{ (printf $thanosConfig $objBucket.spec.endpoint.bucketName 
+                                                $objBucket.spec.endpoint.bucketHost 
+                                                ($awsAccess.data.AWS_ACCESS_KEY_ID | base64dec) 
+                                                ($awsAccess.data.AWS_SECRET_ACCESS_KEY | base64dec)
+                          ) | base64enc }}

--- a/policygenerator/policy-sets/stable/openshift-plus/policyGenerator.yaml
+++ b/policygenerator/policy-sets/stable/openshift-plus/policyGenerator.yaml
@@ -41,7 +41,7 @@ policies:
   controls:
     - SI-5 Security Alerts Advisories and Directives
   dependencies:
-    - name: policy-acs-operator-central
+    - name: policy-acs-central-status
   manifests:
     - path: input-sensor/policy-acs-central-ca-bundle.yaml
 - name: policy-acs-sync-resources
@@ -51,7 +51,7 @@ policies:
   controls:
     - SI-5 Security Alerts Advisories and Directives
   dependencies:
-    - name: policy-acs-operator-central
+    - name: policy-acs-central-status
   manifests:
     - path: input-sensor/policy-acs-sync-resources.yaml
 - name: policy-advanced-managed-cluster-security
@@ -84,7 +84,7 @@ policies:
   controls: 
     - CA-7 Continuous Monitoring
   dependencies:
-    - name: policy-odf
+    - name: policy-odf-status
   manifests:
     - path: input-acm-observability/
 # Observability Policy - end
@@ -114,7 +114,7 @@ policies:
   controls:
     - SI-7 Software Firmware and Information Integrity
   dependencies:
-    - name: policy-odf
+    - name: policy-odf-status
   manifests:
     - path: input-quay/policy-install-quay.yaml
 - name: policy-config-quay


### PR DESCRIPTION
There seems to be a problem with the stringdata updating of a secret when the lookup isn't initially working.  I haven't found a clear cause but switching away from stringdata does not cause this issue.