### PR TITLE
Monitor the ACS certificate bundle with our certificate controller

### DIFF
--- a/policygenerator/policy-sets/stable/openshift-plus/input-sensor/acs-check-certificates.yaml
+++ b/policygenerator/policy-sets/stable/openshift-plus/input-sensor/acs-check-certificates.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: CertificatePolicy
+metadata:
+  name: acs-bundle-certificates
+spec:
+  namespaceSelector:
+    include: ["policies"]
+  remediationAction: inform
+  severity: high
+  minimumDuration: 720h

--- a/policygenerator/policy-sets/stable/openshift-plus/input-sensor/policy-acs-sync-resources.yaml
+++ b/policygenerator/policy-sets/stable/openshift-plus/input-sensor/policy-acs-sync-resources.yaml
@@ -29,6 +29,8 @@ data:
   ca.pem: '{{ fromSecret "stackrox" "admission-control-tls" "ca.pem" }}'
 kind: Secret
 metadata:
+  labels:
+    certificate_key_name: admission-control-cert.pem
   name: admission-control-tls
   namespace: policies
 type: Opaque
@@ -40,6 +42,8 @@ data:
   ca.pem: '{{ fromSecret "stackrox" "collector-tls" "ca.pem" }}'
 kind: Secret
 metadata:
+  labels:
+    certificate_key_name: collector-cert.pem
   name: collector-tls
   namespace: policies
 type: Opaque
@@ -52,6 +56,8 @@ data:
   acs-host: '{{ fromSecret "stackrox" "sensor-tls" "acs-host" }}'
 kind: Secret
 metadata:
+  labels:
+    certificate_key_name: sensor-cert.pem
   name: sensor-tls
   namespace: policies
 type: Opaque

--- a/policygenerator/policy-sets/stable/openshift-plus/policyGenerator.yaml
+++ b/policygenerator/policy-sets/stable/openshift-plus/policyGenerator.yaml
@@ -54,6 +54,15 @@ policies:
     - name: policy-acs-central-status
   manifests:
     - path: input-sensor/policy-acs-sync-resources.yaml
+- name: policy-acs-monitor-certs
+  categories:
+    - SC System and Communications Protection
+  controls:
+    - SC-8 Transmission Confidentiality and Integrity
+  dependencies:
+    - name: policy-acs-sync-resources
+  manifests:
+    - path: input-sensor/acs-check-certificates.yaml
 - name: policy-advanced-managed-cluster-security
   categories:
     - SI System and Information Integrity


### PR DESCRIPTION
The OPP policy set should monitor the certificates it creates for the ACS init bundle.  This adds that monitoring.

Refs:
 - https://issues.redhat.com/browse/ACM-8540

Reviewer note:
I couldn't find where we document the secret label. I'm thinking we should open a doc issue, what do you think?
```
  labels:
    certificate_key_name: admission-control-cert.pem
```