### PR TITLE
Create ami ids for ocp 4.15 for the opp setup

### DIFF
--- a/policygenerator/policy-sets/community/openshift-plus-setup/ami-ids.yaml
+++ b/policygenerator/policy-sets/community/openshift-plus-setup/ami-ids.yaml
@@ -1,5 +1,7 @@
 apiVersion: v1
 data:
+  us-east-1-4.15: ami-0b56cb92505dea7ed
+  us-east-2-4.15: ami-0b577c67f5371f6d1
   us-east-1-4.14: ami-0b56cb92505dea7ed
   us-east-2-4.14: ami-0dc6c4d1bd5161f13
   us-east-1-4.13: ami-0624891c612b5eaa0


### PR DESCRIPTION
The OPP setup failed on OCP 4.15 because there are no defined AMI IDs in the policy set that creates additional storage nodes. This PR adds some initial AMI IDs that are specific to the 2 regions in AWS that we use -- us east 1 and 2.

Refs:
 - https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-stolostron-policy-collection-main-opp-ocp4.15-interop-openshift-plus-interop-aws/1732203507391401984