### PR TITLE
use copyMethod: Snapshot for ReplicationDestination

### DIFF
--- a/community/CM-Configuration-Management/acm-volsync-hub-backup/README.md
+++ b/community/CM-Configuration-Management/acm-volsync-hub-backup/README.md
@@ -128,7 +128,7 @@ metadata:
  name: volsync-config
  namespace: open-cluster-management-backup
  labels:
-   cluster.open-cluster-management.io/backup: volsync
+   cluster.open-cluster-management.io/backup: cluster-activation
 data:
  cacheCapacity: 1Gi
  copyMethod: Snapshot
@@ -180,7 +180,7 @@ metadata:
  name: volsync-config-info-mongo-storage
  namespace: pacman-ns
  labels:
-   cluster.open-cluster-management.io/backup: volsync
+   cluster.open-cluster-management.io/backup: cluster-activation
 data:
  resources.accessModes: ReadWriteOnce
  resources.requests.storage: 8Gi
@@ -201,7 +201,7 @@ metadata:
  namespace: open-cluster-management-backup
  labels:
    app: volsync-config-pvcs
-   cluster.open-cluster-management.io/backup: volsync
+   cluster.open-cluster-management.io/backup: cluster-activation
  data:
  pvcs: 'pacman-restore#mongo-storage##pacman-vb#mongo-storage##pacman#mongo-storage'
 ```
@@ -211,14 +211,13 @@ metadata:
 
 ## Scenario
 
-ACM components installed on the hub
-Add the cluster.open-cluster-management.io/volsync  label to the PVC to be backed up
+ACM components installed on the hub.
+User adds the cluster.open-cluster-management.io/volsync  label to the PVC to be backed up.
 
 
 ACM user, on Primary hub:
 1. Enables backup on MultiClusterHub. This installs the hub backup component
 2. The user manually installs the policy from the community project
-  - The above are open to review and decision
 3. Creates a BackupSchedule 
   - The volsync policy informs the user if missing the volsync restic-secret secret and volsync-config ConfigMap 
 3. User creates the restic-secret secret and volsync-config ConfigMap 
@@ -228,9 +227,9 @@ ACM user, on Primary hub:
 ACM user, on Restore hub:
 5. Enables backup on MultiClusterHub. This installs the hub backup component
   - The user manually installs the policy from the community project
-  - The above are open to review and decision
-6. Creates an ACM Restore resource and restores passive data
+6. Creates an ACM Restore resource and restores active data
   - The policy creates the volsync `ReplicationDestination` for all PVCs defined in the restored volsync-config-pvcs ConfigMap
+  - the app using the PVC must be restored after the PVC is created 
 
 ## References
 - [Volsync](https://access.redhat.com/login?redirectTo=https%3A%2F%2Faccess.redhat.com%2Fdocumentation%2Fen-us%2Fred_hat_advanced_cluster_management_for_kubernetes%2F2.8%2Fhtml%2Fbusiness_continuity%2Fbusiness-cont-overview%23restic-backup-volsync)

--- a/community/CM-Configuration-Management/acm-volsync-hub-backup/acm-volsync-config.yaml
+++ b/community/CM-Configuration-Management/acm-volsync-hub-backup/acm-volsync-config.yaml
@@ -8,7 +8,7 @@
 #  name: volsync-config
 #  namespace: open-cluster-management-backup
 #  labels:
-#    cluster.open-cluster-management.io/backup: volsync
+#    cluster.open-cluster-management.io/backup: cluster-activation
 #data:
 #  cacheCapacity: 2Gi
 #  copyMethod: Snapshot
@@ -130,7 +130,7 @@ spec:
                   name: {{ $volsync_map }}
                   namespace: {{ $ns }}
                   labels:
-                    cluster.open-cluster-management.io/backup: volsync
+                    cluster.open-cluster-management.io/backup: cluster-activation
             - complianceType: musthave
               objectDefinition:
                 apiVersion: v1

--- a/community/CM-Configuration-Management/acm-volsync-hub-backup/acm-volsync-cr-destination.yaml
+++ b/community/CM-Configuration-Management/acm-volsync-hub-backup/acm-volsync-cr-destination.yaml
@@ -86,6 +86,11 @@ spec:
                       {{ $storageClassPVC = $mappingClass }}
                     {{- end }}
                   {{- end }}
+                {{- $secretName := ( (cat $pvc_name "-"  (fromConfigMap $ns $volsync_map "repository") ) | replace " " "" ) }}
+                {{- /* truncate from the front, the Dest name, if the string is longer than 50 chars ; a job batch starting with volsync-dst- is generated from this name and it must be less than 63 chars */ -}}
+                {{- $rd_name :=  trunc -50 (cat $pvc_name $restore_timestamp_trim | replace " " "") }}
+
+                {{- $common_restic_repo := ( lookup "v1" "Secret" $ns $volsync_secret ).data.RESTIC_REPOSITORY | base64dec }}
 
                   - complianceType: musthave
                     objectDefinition:
@@ -97,6 +102,10 @@ spec:
                         labels:
                           {{ $volsync_label }}: volsync
                       spec:
+                        dataSourceRef:
+                          kind: ReplicationDestination
+                          apiGroup: volsync.backube
+                          name: {{ $rd_name }}
                         storageClassName: {{ $storageClassPVC }}
                         resources:
                           requests:
@@ -109,11 +118,6 @@ spec:
                           - {{ $modes }}
                           {{- end }}
                         {{- end }}  
-                {{- $secretName := ( (cat $pvc_name "-"  (fromConfigMap $ns $volsync_map "repository") ) | replace " " "" ) }}
-                {{- /* truncate from the front, the Dest name, if the string is longer than 50 chars ; a job batch starting with volsync-dst- is generated from this name and it must be less than 63 chars */ -}}
-                {{- $rd_name :=  trunc -50 (cat $pvc_name $restore_timestamp_trim | replace " " "") }}
-
-                {{- $common_restic_repo := ( lookup "v1" "Secret" $ns $volsync_secret ).data.RESTIC_REPOSITORY | base64dec }}
       
                   - complianceType: musthave
                     objectDefinition:
@@ -142,9 +146,16 @@ spec:
                           "backup-name": {{ $backup_name }}
                       spec:
                         restic:
+                          {{ $accessModes := trimAll " " (fromConfigMap $pvc_namespace $pvc_config_info_name "resources.accessModes") }}                  
+                          {{- if not (eq $accessModes "" ) }}
+                          accessModes:
+                            {{- range $modes := split " " $accessModes }} 
+                            - {{ $modes }}
+                            {{- end }}
+                          {{- end }} 
+                          capacity: '{{ fromConfigMap $pvc_namespace $pvc_config_info_name "resources.requests.storage" }}' 
                           repository: {{ $secretName }} 
-                          destinationPVC: {{ $pvc_name }}
-                          copyMethod: Direct
+                          copyMethod: Snapshot
                         trigger:
                           manual: restore-once
                   {{- end }}        

--- a/community/CM-Configuration-Management/acm-volsync-hub-backup/acm-volsync-cr-source.yaml
+++ b/community/CM-Configuration-Management/acm-volsync-hub-backup/acm-volsync-cr-source.yaml
@@ -76,7 +76,7 @@ spec:
                         name: {{ $pvc_config_info_name }}
                         namespace: {{ $pvc.metadata.namespace }}
                         labels:
-                          cluster.open-cluster-management.io/backup: volsync
+                          cluster.open-cluster-management.io/backup: cluster-activation
                       data:
                         {{- if not ( eq  $pvc.spec.storageClassName "") }}
                         storageClassName: {{ $pvc.spec.storageClassName }}
@@ -149,7 +149,7 @@ spec:
                         name: {{ $volsync_pvcs }}
                         namespace: {{ $ns }}
                         labels:
-                          cluster.open-cluster-management.io/backup: volsync
+                          cluster.open-cluster-management.io/backup: cluster-activation
                           app: {{ $volsync_pvcs }}
                       data:
                         pvcs: {{ trimAll "##" $volsync_pvcs_str }}


### PR DESCRIPTION
Update ReplicationDestination to use `copyMethod: Snapshot` 
This will force the applications using the PVC to wait until the restore completes, before being able to use the PVC