### PR TITLE
add pvc label to the pvc config

### DIFF
--- a/community/CM-Configuration-Management/acm-volsync-hub-backup/acm-volsync-cr-destination.yaml
+++ b/community/CM-Configuration-Management/acm-volsync-hub-backup/acm-volsync-cr-destination.yaml
@@ -59,11 +59,13 @@ spec:
               
               {{- $acm_restore_name_fixed := split $backup_name_prefix $restore_name }} 
               {{- $acm_restore_name := (cat $acm_restore_name_fixed._0 $backup_name) | replace " " "" }}
+              {{- $acm_restore_name_active := (cat $acm_restore_name "-active") | replace " " "" }}
 
               {{- $acm_restore := lookup $velero_api $kind_restore $ns $acm_restore_name  }}
+              {{- $acm_restore_active := lookup $velero_api $kind_restore $ns $acm_restore_name_active  }}
 
               {{- /* the acm restore should exist, so this is the passive hub */ -}}
-              {{ if and (eq $acm_restore.metadata.name  $acm_restore_name) }}
+              {{ if or (eq $acm_restore.metadata.name  $acm_restore_name) (eq $acm_restore_active.metadata.name  $acm_restore_name_active) }}
                 {{- range $pvc_data := split "##" (fromConfigMap $ns $volsync_pvcs "pvcs") }} 
 
                 {{- $pvc_list := splitn "#" 2 $pvc_data }}
@@ -243,15 +245,6 @@ spec:
                     status:
                       latestMoverStatus:
                         result: Successful
-                - complianceType: musthave
-                  objectDefinition:
-                    apiVersion: v1
-                    kind: PersistentVolumeClaim
-                    metadata:
-                      namespace: {{ $rd.metadata.namespace }}
-                      name: {{ $rd.spec.restic.destinationPVC }}
-                    status:
-                      phase: Bound
               {{- end }}
             {{- end }}
           remediationAction: inform

--- a/community/CM-Configuration-Management/acm-volsync-hub-backup/acm-volsync-cr-source.yaml
+++ b/community/CM-Configuration-Management/acm-volsync-hub-backup/acm-volsync-cr-source.yaml
@@ -77,6 +77,7 @@ spec:
                         namespace: {{ $pvc.metadata.namespace }}
                         labels:
                           cluster.open-cluster-management.io/backup: cluster-activation
+                          cluster.open-cluster-management.io/volsync-pvc: {{ $pvc.metadata.name }}
                       data:
                         {{- if not ( eq  $pvc.spec.storageClassName "") }}
                         storageClassName: {{ $pvc.spec.storageClassName }}


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-8622

Changes:
- add cluster.open-cluster-management.io/volsync-pvc: {{ $pvc.metadata.name }} to the configmap created by the replication source. It will be used on the restore hub , by the hub backup to wait on these pvcs to be created, after credentials backup is restored, and before restoring any other data
- updated the replication destination templated to remove the check for a PVC being bound; with the use of a ReplicationDestination of type copyMethod: Snapshot, the PVC will not be bound until the snapshot is completed and a user up bounds to it. So the check is not relevant and doesn't mark anything wrong with the replication
- replication destination template creating the resource, check for the existence of creds-time or creds-time-active restore. Depending on the type of restore ( sync versus all in once ) the creds-time-active  restore may be producing the PV configs
