### PR TITLE
update pvc label name

### DIFF
--- a/community/CM-Configuration-Management/acm-volsync-hub-backup/acm-volsync-config.yaml
+++ b/community/CM-Configuration-Management/acm-volsync-hub-backup/acm-volsync-config.yaml
@@ -30,7 +30,7 @@
 #  name: restic-secret
 #  namespace: open-cluster-management-backup
 #  labels:
-#    cluster.open-cluster-management.io/backup: volsync
+#    cluster.open-cluster-management.io/backup: cluster-activation
 #data:
 #  AWS_ACCESS_KEY_ID: a2V5X2lk
 #  AWS_SECRET_ACCESS_KEY: a2V5
@@ -139,7 +139,7 @@ spec:
                   name: {{ $volsync_secret }}
                   namespace: {{ $ns }}
                   labels:
-                    cluster.open-cluster-management.io/backup: volsync
+                    cluster.open-cluster-management.io/backup: cluster-activation
                 type: Opaque
             {{- end }}
           remediationAction: inform

--- a/community/CM-Configuration-Management/acm-volsync-hub-backup/acm-volsync-cr-source.yaml
+++ b/community/CM-Configuration-Management/acm-volsync-hub-backup/acm-volsync-cr-source.yaml
@@ -39,7 +39,7 @@ spec:
             {{ if $volsync_backup_cond }}
               {{- range $rs := (lookup "volsync.backube/v1alpha1" "ReplicationSource" "" "" $volsync_label).items }}
                   {{ $pvc_rs := lookup "v1" "PersistentVolumeClaim" $rs.metadata.namespace $rs.metadata.name $volsync_label}}
-                  {{ if or (not (eq $pvc_rs.metadata.name $rs.metadata.name)) (eq (index $pvc_rs.metadata.labels $volsync_label) "<no value>")}}   
+                  {{ if or (not (eq $pvc_rs.metadata.name $rs.metadata.name)) ( not (index $pvc_rs.metadata.labels $volsync_label) )}}  
                     - complianceType: mustnothave
                       objectDefinition:
                         kind: ReplicationSource
@@ -155,6 +155,14 @@ spec:
                           app: {{ $volsync_pvcs }}
                       data:
                         pvcs: {{ trimAll "##" $volsync_pvcs_str }}
+                  {{- else }}
+                  - complianceType: mustnothave
+                    objectDefinition:
+                      apiVersion: v1
+                      kind: ConfigMap
+                      metadata:
+                        name: {{ $volsync_pvcs }}
+                        namespace: {{ $ns }}
                   {{- end }}      
             {{- else }}
               {{- range $pvc := (lookup "v1" "PersistentVolumeClaim" "" "" $volsync_label).items }}  

--- a/community/CM-Configuration-Management/acm-volsync-hub-backup/acm-volsync-cr-source.yaml
+++ b/community/CM-Configuration-Management/acm-volsync-hub-backup/acm-volsync-cr-source.yaml
@@ -77,7 +77,7 @@ spec:
                         namespace: {{ $pvc.metadata.namespace }}
                         labels:
                           cluster.open-cluster-management.io/backup: cluster-activation
-                          cluster.open-cluster-management.io/volsync-pvc: {{ $pvc.metadata.name }}
+                          cluster.open-cluster-management.io/backup-pvc: {{ $pvc.metadata.name }}
                       data:
                         {{- if not ( eq  $pvc.spec.storageClassName "") }}
                         storageClassName: {{ $pvc.spec.storageClassName }}
@@ -142,6 +142,7 @@ spec:
                           schedule: '{{ fromConfigMap $ns $volsync_map "trigger_schedule" }}'
                 {{- end }}        
               {{- end }}
+                 {{ if not (eq $volsync_pvcs_str "") }}
                   - complianceType: musthave
                     objectDefinition:
                       apiVersion: v1
@@ -154,6 +155,7 @@ spec:
                           app: {{ $volsync_pvcs }}
                       data:
                         pvcs: {{ trimAll "##" $volsync_pvcs_str }}
+                  {{- end }}      
             {{- else }}
               {{- range $pvc := (lookup "v1" "PersistentVolumeClaim" "" "" $volsync_label).items }}  
                   - complianceType: mustnothave


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-9503

Changes:
- Rename PVC backup label to `cluster.open-cluster-management.io/backup-pvc` 
-  restore restic secret and user defined pvc config at cluster activation time
- on backup, create the `volsync-config-pvcs` ConfigMap only if any PVC resource with backup label
- update check on SourceReplication to check if corresponding PV still has the volsync label ( should remove the SourceReplication otherwise )
