### PR TITLE
fix replicationsource removal when PV no longer has volsync label

### DIFF
--- a/community/CM-Configuration-Management/acm-volsync-hub-backup/acm-volsync-cr-source.yaml
+++ b/community/CM-Configuration-Management/acm-volsync-hub-backup/acm-volsync-cr-source.yaml
@@ -38,25 +38,26 @@ spec:
             {{- /* Create the volsync ReplicationSource and secret - if BackupSchedule exists ; delete ReplicationSource otherwise */ -}}
             {{ if $volsync_backup_cond }}
               {{- range $rs := (lookup "volsync.backube/v1alpha1" "ReplicationSource" "" "" $volsync_label).items }}
-                  {{ $pvc_rs := lookup "v1" "PersistentVolumeClaim" $rs.metadata.namespace $rs.metadata.name $volsync_label}}
-                  {{ if or (not (eq $pvc_rs.metadata.name $rs.metadata.name)) ( not (index $pvc_rs.metadata.labels $volsync_label) )}}  
-                    - complianceType: mustnothave
-                      objectDefinition:
-                        kind: ReplicationSource
-                        apiVersion: volsync.backube/v1alpha1
-                        metadata:
-                          name: {{ $rs.metadata.name }}
-                          namespace: {{ $rs.metadata.namespace }}
-                          labels:
-                            {{ $volsync_label }}: acm
-                    - complianceType: mustnothave
-                      objectDefinition:
-                        kind: ConfigMap
-                        apiVersion: v1
-                        metadata:
-                          name: {{( (cat $volsync_map "-info-" $rs.metadata.name ) | replace " " "") }}
-                          namespace: {{ $rs.metadata.namespace }}
-                  {{- end }}   
+                {{- $pvc_rs := (lookup "v1" "PersistentVolumeClaim" $rs.metadata.namespace "" $volsync_label).items }}
+                {{- /* If the PVC in the ReplicationSource ns no longer exists or doesn't have the volsync label, delete the ReplicationSource */ -}}
+                {{ if eq (len $pvc_rs ) 0 }}  
+                  - complianceType: mustnothave
+                    objectDefinition:
+                      kind: ReplicationSource
+                      apiVersion: volsync.backube/v1alpha1
+                      metadata:
+                        name: {{ $rs.metadata.name }}
+                        namespace: {{ $rs.metadata.namespace }}
+                        labels:
+                          {{ $volsync_label }}: acm
+                  - complianceType: mustnothave
+                    objectDefinition:
+                      kind: ConfigMap
+                      apiVersion: v1
+                      metadata:
+                        name: {{( (cat $volsync_map "-info-" $rs.metadata.name ) | replace " " "") }}
+                        namespace: {{ $rs.metadata.namespace }} 
+                {{- end }}
               {{- end }}
 
               {{- $volsync_pvcs_str := "" }}
@@ -155,14 +156,6 @@ spec:
                           app: {{ $volsync_pvcs }}
                       data:
                         pvcs: {{ trimAll "##" $volsync_pvcs_str }}
-                  {{- else }}
-                  - complianceType: mustnothave
-                    objectDefinition:
-                      apiVersion: v1
-                      kind: ConfigMap
-                      metadata:
-                        name: {{ $volsync_pvcs }}
-                        namespace: {{ $ns }}
                   {{- end }}      
             {{- else }}
               {{- range $pvc := (lookup "v1" "PersistentVolumeClaim" "" "" $volsync_label).items }}  


### PR DESCRIPTION
Changes:
Fixed the scenario where a PV volsync label is removed while the ReplicationSource is already created
In this case the ReplicationSource should be deleted