### PR TITLE
Add back init container name for ArgoCD

### DIFF
--- a/community/CM-Configuration-Management/policy-openshift-gitops-policygenerator.yaml
+++ b/community/CM-Configuration-Management/policy-openshift-gitops-policygenerator.yaml
@@ -41,6 +41,7 @@ spec:
                       command:
                       - /bin/bash
                       image: 'registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel8:v{{ (lookup "operator.open-cluster-management.io/v1" "MultiClusterHub" "open-cluster-management" "multiclusterhub").status.currentVersion }}'
+                      name: policy-generator-install
                       volumeMounts:
                       - mountPath: /policy-generator
                         name: policy-generator


### PR DESCRIPTION
Add back container name, which was inadvertently removed in:
- https://github.com/open-cluster-management-io/policy-collection/pull/443