### PR TITLE
remove replicationDestination when PVC is bound

### DIFF
--- a/community/CM-Configuration-Management/acm-hub-pvc-backup/acm-hub-pvc-backup-destination.yaml
+++ b/community/CM-Configuration-Management/acm-hub-pvc-backup/acm-hub-pvc-backup-destination.yaml
@@ -92,6 +92,17 @@ spec:
                 {{- /* truncate from the front, the Dest name, if the string is longer than 50 chars ; a job batch starting with volsync-dst- is generated from this name and it must be less than 63 chars */ -}}
                 {{- $rd_name :=  trunc -50 (cat $pvc_name $restore_timestamp_trim | replace " " "") }}
 
+                {{- /* If a PVC with this identity already exists in Bound state, delete the corresponding ResourceDestination then exit */ -}}
+                {{- $bound_pvc := lookup "v1" "PersistentVolumeClaim" $pvc_namespace $pvc_name }}
+                {{ if and (eq $bound_pvc.metadata.name  $pvc_name) (eq $bound_pvc.status.phase "Bound") }}
+                  - complianceType: mustnothave
+                    objectDefinition:
+                      kind: ReplicationDestination
+                      apiVersion: volsync.backube/v1alpha1
+                      metadata:
+                        name: {{ $rd_name }}
+                        namespace: {{ $pvc_namespace }}
+                {{- else }}
                 {{- $common_restic_repo := ( lookup "v1" "Secret" $ns $volsync_secret ).data.RESTIC_REPOSITORY | base64dec }}
 
                   - complianceType: musthave
@@ -160,7 +171,8 @@ spec:
                           copyMethod: Snapshot
                         trigger:
                           manual: restore-once
-                  {{- end }}        
+                  {{- end }}  
+                {{- end }}      
                 {{- end }}  
               {{- end }}
             {{- end }}  
@@ -212,7 +224,7 @@ spec:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
         metadata:
-          name: check-destination-replication-success 
+          name: check-pvc-bound 
         spec:
           object-templates-raw: |
             {{- $volsync_label := "cluster.open-cluster-management.io/backup-hub-pvc" }}
@@ -223,28 +235,26 @@ spec:
             {{- $kind_restore := "Restore" }} 
             {{- $schedule_label := "cluster.open-cluster-management.io/backup-schedule-type, cluster.open-cluster-management.io/backup-schedule-type in (resources)"}}
             {{- $volsync_backup_cond := gt (len ( lookup $velero_api $kind_schedule $ns "" $schedule_label).items ) 0 }}
-            
+            {{- $volsync_label := "cluster.open-cluster-management.io/backup-hub-pvc" }}            
             {{- /* acm-hub-pvc-backup-config-pvcs map should exist */ -}}
             {{- $volsync_pvcs := "hub-pvc-backup-pvcs" }}
             {{- $volsync_pvcs_map := lookup "v1" "ConfigMap" $ns $volsync_pvcs }}
             {{- $volsync_restore_cond := eq $volsync_pvcs_map.metadata.name $volsync_pvcs }}
 
-            {{- /* The volsync destination-source should be successful */ -}}
+            {{- /* The PVC with cluster.open-cluster-management.io/backup-hub-pvc should be Bound eventually */ -}}
             {{ if and ( not $volsync_backup_cond ) ($volsync_restore_cond)}}
               {{- $backup_name := (index $volsync_pvcs_map.metadata.labels "velero.io/backup-name") }}
 
-              {{- range $rd := (lookup "volsync.backube/v1alpha1" "ReplicationDestination" "" "" "backup-name").items }}
-                - complianceType: musthave
-                  objectDefinition:
-                    apiVersion: volsync.backube/v1alpha1
-                    kind: ReplicationDestination
-                    metadata:
-                      namespace: {{ $rd.metadata.namespace }}
-                      labels:
-                        backup-name: {{ $backup_name }}
-                    status:
-                      latestMoverStatus:
-                        result: Successful
+              {{- range $pvc := (lookup "v1" "PersistentVolumeClaim" "" "" $volsync_label).items }}  
+                  - complianceType: musthave
+                    objectDefinition:
+                      kind: PersistentVolumeClaim
+                      apiVersion: v1
+                      metadata:
+                        name: {{ $pvc.metadata.name }}
+                        namespace: {{ $pvc.metadata.namespace }}
+                      status:
+                        phase: Bound
               {{- end }}
             {{- end }}
           remediationAction: inform

--- a/community/CM-Configuration-Management/acm-hub-pvc-backup/acm-hub-pvc-backup-source.yaml
+++ b/community/CM-Configuration-Management/acm-hub-pvc-backup/acm-hub-pvc-backup-source.yaml
@@ -35,12 +35,6 @@ spec:
             {{- $volsync_backup_cond := gt (len ( lookup $velero_api $kind_schedule $ns "" $schedule_label).items ) 0  }}
             {{- $volsync_pvcs := "hub-pvc-backup-pvcs" }}
 
-            {{- /* PVC labels  */ -}}
-            {{- $last_backup_schedule_label := "cluster.open-cluster-management.io/backup-last-schedule" }}
-            {{- $last_sync_name_label := "cluster.open-cluster-management.io/backup-last-sync-name" }}
-            {{- $last_sync_time_label := "cluster.open-cluster-management.io/backup-last-sync-time" }}
-            {{- $last_sync_status_label := "cluster.open-cluster-management.io/backup-last-sync-status" }}
-
             {{- /* Create the volsync ReplicationSource and secret - if BackupSchedule exists ; delete ReplicationSource otherwise */ -}}
             {{ if $volsync_backup_cond }}
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-9840

Changes:
- verify PVC is in Bound state
- remove the template that verifies the ReplicationDestination status is Successful ( there is a template checking for status Error ; the verification for status is Successful  is replaced by the check for the PVC to be Bound )
- remove ReplicationDestination when the PVC is bound, after the restore operation

<img width="1401" alt="Screenshot 2024-02-07 at 1 28 55 PM" src="https://github.com/open-cluster-management-io/policy-collection/assets/43010150/d75f584e-f5b9-4ba5-ab90-27bad68353ef">

<img width="1407" alt="Screenshot 2024-02-07 at 1 21 38 PM" src="https://github.com/open-cluster-management-io/policy-collection/assets/43010150/976d42f3-2707-46a4-97aa-f39d09a430c7">


<img width="1407" alt="Screenshot 2024-02-07 at 1 36 24 PM" src="https://github.com/open-cluster-management-io/policy-collection/assets/43010150/7eb7d1f4-f504-4479-9fad-f5f56e3b5941">


