### PR TITLE
report error if volsync addon not available

### DIFF
--- a/community/CM-Configuration-Management/acm-hub-pvc-backup/acm-hub-pvc-backup-config.yaml
+++ b/community/CM-Configuration-Management/acm-hub-pvc-backup/acm-hub-pvc-backup-config.yaml
@@ -186,6 +186,7 @@ spec:
                     status:
                       conditions:
                         - status: 'True'
+                          type: Available  
                   {{- end }}      
                 {{- end }}
                 {{ if $has_local_cluster_ns }}
@@ -203,6 +204,7 @@ spec:
                     status:
                       conditions:
                         - status: 'True'
+                          type: Available     
                 {{- end }}        
             {{- end }}
           remediationAction: enforce


### PR DESCRIPTION
Change:

- create-volsync-addon template should report an error if the addon is installed but status is not Available
This is to cover the case when the volsync operator was not configured successfully 