### PR TITLE
Make it easier to install openshift gitops argocd and include health

### DIFF
--- a/policygenerator/policy-sets/community/openshift-gitops/README.md
+++ b/policygenerator/policy-sets/community/openshift-gitops/README.md
@@ -1,0 +1,9 @@
+# Setup OpenShift Gitops
+
+## Installation
+
+This PolicySet only deploys OpenShift Gitops to the hub cluster.  In addition to deploying
+OpenShift Gitops, configuration sets up the following:
+- The plugin for the policy generator is configured
+- Health scripts for Policy resources are configured
+

--- a/policygenerator/policy-sets/community/openshift-gitops/kustomization.yml
+++ b/policygenerator/policy-sets/community/openshift-gitops/kustomization.yml
@@ -1,7 +1,6 @@
 generators:
 - ./policyGenerator.yaml
 commonLabels:
-  open-cluster-management.io/policy-set: openshift-plus-setup
+  open-cluster-management.io/policy-set: openshift-gitops
 commonAnnotations:
   argocd.argoproj.io/compare-options: IgnoreExtraneous
-

--- a/policygenerator/policy-sets/community/openshift-gitops/placement.yaml
+++ b/policygenerator/policy-sets/community/openshift-gitops/placement.yaml
@@ -1,0 +1,11 @@
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: placement-openshift-gitops
+  namespace: open-cluster-management-global-set
+spec:
+  predicates:
+  - requiredClusterSelector:
+      labelSelector:
+        matchExpressions:
+          - {key: name, operator: In, values: ["local-cluster"]}

--- a/policygenerator/policy-sets/community/openshift-gitops/policy-openshift-gitops-grc.yaml
+++ b/policygenerator/policy-sets/community/openshift-gitops/policy-openshift-gitops-grc.yaml
@@ -1,0 +1,139 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: openshift-gitops
+  namespace: openshift-gitops
+spec:
+  repo:
+    env:
+    - name: KUSTOMIZE_PLUGIN_HOME
+      value: /etc/kustomize/plugin
+    - name: POLICY_GEN_ENABLE_HELM
+      value: "true"
+    initContainers:
+    - args:
+      - -c
+      - cp /etc/kustomize/plugin/policy.open-cluster-management.io/v1/policygenerator/PolicyGenerator
+        /policy-generator/PolicyGenerator
+      command:
+      - /bin/bash
+      image: 'registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel8:v{{ (lookup "operator.open-cluster-management.io/v1" "MultiClusterHub" "open-cluster-management" "multiclusterhub").status.currentVersion }}'
+      name: policy-generator-install
+      volumeMounts:
+      - mountPath: /policy-generator
+        name: policy-generator
+    volumeMounts:
+    - mountPath: /etc/kustomize/plugin/policy.open-cluster-management.io/v1/policygenerator
+      name: policy-generator
+    volumes:
+    - emptyDir: {}
+      name: policy-generator
+  kustomizeBuildOptions: --enable-alpha-plugins
+  resourceHealthChecks:
+  - check: |
+      hs = {}
+      if obj.status ~= nil then
+        if obj.status.compliant ~= nil then
+          if obj.status.compliant == "Compliant" then
+            hs.status = "Healthy"
+            hs.message = "Policy is Compliant"
+            return hs
+          end
+          if obj.status.compliant == "Pending" then
+            hs.status = "Progressing"
+            hs.message = "Policy is waiting for a dependency"
+            return hs
+          end
+          if obj.status.compliant == "NonCompliant" then
+            hs.status = "Degraded"
+            hs.message = "Policy is NonCompliant"
+            return hs
+          end
+        end
+      end
+      hs.status = "Healthy"
+      hs.message = "Policy has not completed placement"
+      return hs
+    group: policy.open-cluster-management.io
+    kind: Policy
+  - check: |
+      hs = {}
+      hs.status = "Healthy"
+      hs.message = "PolicySet has not completed placement"
+      if obj.status ~= nil and obj.status.compliant ~= nil then
+        if obj.status.compliant == "Compliant" then
+          hs.status = "Healthy"
+        end
+        if obj.status.compliant == "Pending" then
+          hs.status = "Progressing"
+        end
+        if obj.status.compliant == "NonCompliant" then
+          hs.status = "Degraded"
+        end
+      end
+      if obj.status ~= nil and obj.status.statusMessage ~= nil then
+        hs.message = obj.status.statusMessage
+      end
+      return hs
+    group: policy.open-cluster-management.io
+    kind: PolicySet
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openshift-gitops-policy-admin
+rules:
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    apiGroups:
+      - policy.open-cluster-management.io
+    resources:
+      - policies
+      - policysets
+      - placementbindings
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    apiGroups:
+      - apps.open-cluster-management.io
+    resources:
+      - placementrules
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    apiGroups:
+      - cluster.open-cluster-management.io
+    resources:
+      - placements
+      - placements/status
+      - placementdecisions
+      - placementdecisions/status
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openshift-gitops-policy-admin
+subjects:
+  - kind: ServiceAccount
+    name: openshift-gitops-argocd-application-controller
+    namespace: openshift-gitops
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-gitops-policy-admin

--- a/policygenerator/policy-sets/community/openshift-gitops/policy-openshift-gitops.yaml
+++ b/policygenerator/policy-sets/community/openshift-gitops/policy-openshift-gitops.yaml
@@ -1,0 +1,13 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-gitops-operator
+  namespace: openshift-operators
+  labels:
+    operators.coreos.com/openshift-gitops-operator.openshift-operators: ''
+spec:
+  channel: latest
+  installPlanApproval: Automatic
+  name: openshift-gitops-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/policygenerator/policy-sets/community/openshift-gitops/policyGenerator.yaml
+++ b/policygenerator/policy-sets/community/openshift-gitops/policyGenerator.yaml
@@ -1,0 +1,33 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: policy-opp-prereqs
+placementBindingDefaults:
+  name: binding-policy-openshift-gitops
+policyDefaults:
+  categories:
+    - CM Configuration Management
+  controls: 
+    - CM-2 Baseline Configuration
+  namespace: open-cluster-management-global-set
+  policySets:
+    - openshift-gitops
+  remediationAction: enforce
+  severity: medium
+  standards:
+    - NIST SP 800-53
+policies:
+- name: openshift-gitops
+  manifests:
+    - path: policy-openshift-gitops.yaml
+- name: openshift-gitops-grc
+  dependencies:
+    - name: openshift-gitops
+  manifests:
+    - path: policy-openshift-gitops-grc.yaml
+policySets:
+  - description: Applies the OpenShift Gitops subscription and configures
+      OpenShift Gitops to work with the Governance APIs
+    name: openshift-gitops
+    placement:
+      placementPath: placement.yaml

--- a/policygenerator/policy-sets/stable/openshift-plus/kustomization.yml
+++ b/policygenerator/policy-sets/stable/openshift-plus/kustomization.yml
@@ -2,3 +2,5 @@ generators:
 - ./policyGenerator.yaml
 commonLabels:
   open-cluster-management.io/policy-set: openshift-plus
+commonAnnotations:
+  argocd.argoproj.io/compare-options: IgnoreExtraneous


### PR DESCRIPTION
Creating a policy set to make setup of openshift gitops easier. It sets up the generator and configures health checks for policies.