### PR TITLE
Remove `ManagedClusterConditionAvailable`

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,8 @@ for details on installing the Application addon.
 not require the Application Lifecycle addon.
 
 The policies are applied to all managed clusters that are available, and have the `environment` set
-to `dev`. Specifically, an available managed cluster has the `status` parameter set to `true` by the
-system, for the `ManagedClusterConditionAvailable` condition. If policies need to be applied to
-another set of clusters, update the `PlacementRule.spec.clusterSelector.matchExpressions` section in
-the policies.
+to `dev`. If policies need to be applied to another set of clusters, update the 
+`PlacementRule.spec.clusterSelector.matchExpressions` section in the policies.
 
 **Note**: As new clusters are added that fit the criteria previously mentioned, the policies are
 applied automatically.

--- a/community/AC-Access-Control/policy-configure-appworkloads-rbac-sample.yaml
+++ b/community/AC-Access-Control/policy-configure-appworkloads-rbac-sample.yaml
@@ -173,18 +173,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-configure-appworkloads-rbac
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-configure-appworkloads-rbac
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-configure-appworkloads-rbac
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/community/AC-Access-Control/policy-configure-clusterlevel-rbac.yaml
+++ b/community/AC-Access-Control/policy-configure-clusterlevel-rbac.yaml
@@ -88,7 +88,7 @@ spec:
                 roleRef:
                   apiGroup: rbac.authorization.k8s.io
                   kind: ClusterRole
-                  name: admin   
+                  name: admin
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -108,9 +108,6 @@ kind: PlacementRule
 metadata:
   name: placement-policy-configure-clusterlevel-rbac
 spec:
-  clusterConditions:
-    - status: "True"
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: local-cluster, operator: In, values: ['true']}

--- a/community/AC-Access-Control/policy-gatekeeper-disallow-anonymous.yaml
+++ b/community/AC-Access-Control/policy-gatekeeper-disallow-anonymous.yaml
@@ -7,7 +7,7 @@ metadata:
     policy.open-cluster-management.io/categories: AC Access Control
     policy.open-cluster-management.io/controls: AC-2 Account Management
 spec:
-  remediationAction: enforce 
+  remediationAction: enforce
   disabled: false
   policy-templates:
     - objectDefinition:
@@ -18,7 +18,7 @@ spec:
         spec:
           remediationAction: enforce
           severity: low
-          object-templates: 
+          object-templates:
             - complianceType: musthave
               objectDefinition:
                 apiVersion: templates.gatekeeper.sh/v1beta1
@@ -47,7 +47,7 @@ spec:
 
                         review(subject) = true {
                           subject.name == "system:anonymous"
-                        }                
+                        }
             - complianceType: musthave
               objectDefinition:
                 apiVersion: constraints.gatekeeper.sh/v1beta1
@@ -98,7 +98,7 @@ spec:
                     constraint_action: deny
                     constraint_kind: K8sDisallowAnonymous
                     constraint_name: no-anonymous
-                    event_type: violation       
+                    event_type: violation
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -118,9 +118,6 @@ kind: PlacementRule
 metadata:
   name: placement-policy-gatekeeper-disallow-anonymous
 spec:
-  clusterConditions:
-    - status: "True"
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
-      - { key: environment, operator: In, values: ["dev"] }
+      - {key: environment, operator: In, values: ["dev"]}

--- a/community/AC-Access-Control/policy-rbac-adminiterpolicies-sample.yaml
+++ b/community/AC-Access-Control/policy-rbac-adminiterpolicies-sample.yaml
@@ -139,18 +139,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-rbac-adminiterpolicies
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-rbac-adminiterpolicies
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-rbac-adminiterpolicies
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - key: local-cluster

--- a/community/AC-Access-Control/policy-roles-no-wildcards.yaml
+++ b/community/AC-Access-Control/policy-roles-no-wildcards.yaml
@@ -42,18 +42,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-disallowed-roles
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-disallowed-roles
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-disallowed-roles
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/community/AU-Audit-and-Accountability/policy-openshift-audit-logs-sample.yaml
+++ b/community/AU-Audit-and-Accountability/policy-openshift-audit-logs-sample.yaml
@@ -27,13 +27,12 @@ spec:
                   name: cluster
                 spec:
                   audit:
-                    customRules:                        
-                    - group: system:authenticated:oauth
-                      profile: WriteRequestBodies
-                    - group: system:authenticated
-                      profile: AllRequestBodies
-                  profile: Default  
-
+                    customRules:
+                      - group: system:authenticated:oauth
+                        profile: WriteRequestBodies
+                      - group: system:authenticated
+                        profile: AllRequestBodies
+                  profile: Default
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -53,13 +52,9 @@ kind: PlacementRule
 metadata:
   name: placement-config-audit
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - key: environment
         operator: In
         values:
           - dev
-

--- a/community/CA-Security-Assessment-and-Authorization/policy-check-fips.yaml
+++ b/community/CA-Security-Assessment-and-Authorization/policy-check-fips.yaml
@@ -10,35 +10,35 @@ spec:
   remediationAction: inform
   disabled: false
   policy-templates:
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: ConfigurationPolicy
-      metadata:
-        name: 'checkfipscompliance'
-      spec:
-        remediationAction: inform
-        severity: low
-        object-templates:
-          - complianceType: musthave
-            objectDefinition:
-              apiVersion: machineconfiguration.openshift.io/v1
-              kind: MachineConfig
-              metadata:
-                labels:
-                  machineconfiguration.openshift.io/role: worker
-                name: 99-worker-fips
-              spec:
-                fips: true
-          - complianceType: musthave
-            objectDefinition:
-              apiVersion: machineconfiguration.openshift.io/v1
-              kind: MachineConfig
-              metadata:
-                labels:
-                  machineconfiguration.openshift.io/role: master
-                name: 99-master-fips
-              spec:
-                fips: true
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: 'checkfipscompliance'
+        spec:
+          remediationAction: inform
+          severity: low
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: machineconfiguration.openshift.io/v1
+                kind: MachineConfig
+                metadata:
+                  labels:
+                    machineconfiguration.openshift.io/role: worker
+                  name: 99-worker-fips
+                spec:
+                  fips: true
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: machineconfiguration.openshift.io/v1
+                kind: MachineConfig
+                metadata:
+                  labels:
+                    machineconfiguration.openshift.io/role: master
+                  name: 99-master-fips
+                spec:
+                  fips: true
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -49,18 +49,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: checkfipscompliance
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: checkfipscompliance
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-checkfipscompliance
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/community/CA-Security-Assessment-and-Authorization/policy-compliance-operator-install-upstream.yaml
+++ b/community/CA-Security-Assessment-and-Authorization/policy-compliance-operator-install-upstream.yaml
@@ -102,18 +102,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-comp-operator
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-comp-operator
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-comp-operator
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: vendor, operator: In, values: ["OpenShift"]}

--- a/community/CM-Configuration-Management/policy-acs-operator-central.yaml
+++ b/community/CM-Configuration-Management/policy-acs-operator-central.yaml
@@ -12,96 +12,96 @@ spec:
   remediationAction: enforce
   disabled: false
   policy-templates:
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: ConfigurationPolicy
-      metadata:
-        name: advanced-cluster-security-namespace
-      spec:
-        remediationAction: inform
-        severity: high
-        object-templates:
-          - complianceType: musthave
-            objectDefinition:
-              apiVersion: v1
-              kind: Namespace
-              metadata:
-                name: stackrox
-          - complianceType: musthave
-            objectDefinition:
-              apiVersion: v1
-              kind: Namespace
-              metadata:
-                name: rhacs-operator
-          - complianceType: musthave
-            objectDefinition:
-              apiVersion: operators.coreos.com/v1
-              kind: OperatorGroup
-              metadata:
-                name: rhacs-operator-group
-                namespace: rhacs-operator
-              spec: {}
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: ConfigurationPolicy
-      metadata:
-        name: advanced-cluster-security-operator-subscription
-      spec:
-        remediationAction: inform
-        severity: high
-        object-templates:
-          - complianceType: musthave
-            objectDefinition:
-              apiVersion: operators.coreos.com/v1alpha1
-              kind: Subscription
-              metadata:
-                name: rhacs-operator
-                namespace: rhacs-operator
-              spec:
-                channel: latest
-                installPlanApproval: Automatic
-                name: rhacs-operator
-                source: redhat-operators
-                sourceNamespace: openshift-marketplace
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: ConfigurationPolicy
-      metadata:
-        name: advanced-cluster-security-central
-      spec:
-        remediationAction: inform
-        severity: high
-        object-templates:
-          - complianceType: musthave
-            objectDefinition:
-              apiVersion: platform.stackrox.io/v1alpha1
-              kind: Central
-              metadata:
-                namespace: stackrox
-                name: stackrox-central-services
-              spec:
-                central:
-                  exposure:
-                    loadBalancer:
-                      enabled: false
-                      port: 443
-                    nodePort:
-                      enabled: false
-                    route:
-                      enabled: true
-                  persistence:
-                    persistentVolumeClaim:
-                      claimName: stackrox-db
-                egress:
-                  connectivityPolicy: Online
-                scanner:
-                  analyzer:
-                    scaling:
-                      autoScaling: Enabled
-                      maxReplicas: 5
-                      minReplicas: 2
-                      replicas: 3
-                  scannerComponent: Enabled
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: advanced-cluster-security-namespace
+        spec:
+          remediationAction: inform
+          severity: high
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Namespace
+                metadata:
+                  name: stackrox
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Namespace
+                metadata:
+                  name: rhacs-operator
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operators.coreos.com/v1
+                kind: OperatorGroup
+                metadata:
+                  name: rhacs-operator-group
+                  namespace: rhacs-operator
+                spec: {}
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: advanced-cluster-security-operator-subscription
+        spec:
+          remediationAction: inform
+          severity: high
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operators.coreos.com/v1alpha1
+                kind: Subscription
+                metadata:
+                  name: rhacs-operator
+                  namespace: rhacs-operator
+                spec:
+                  channel: latest
+                  installPlanApproval: Automatic
+                  name: rhacs-operator
+                  source: redhat-operators
+                  sourceNamespace: openshift-marketplace
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: advanced-cluster-security-central
+        spec:
+          remediationAction: inform
+          severity: high
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: platform.stackrox.io/v1alpha1
+                kind: Central
+                metadata:
+                  namespace: stackrox
+                  name: stackrox-central-services
+                spec:
+                  central:
+                    exposure:
+                      loadBalancer:
+                        enabled: false
+                        port: 443
+                      nodePort:
+                        enabled: false
+                      route:
+                        enabled: true
+                    persistence:
+                      persistentVolumeClaim:
+                        claimName: stackrox-db
+                  egress:
+                    connectivityPolicy: Online
+                  scanner:
+                    analyzer:
+                      scaling:
+                        autoScaling: Enabled
+                        maxReplicas: 5
+                        minReplicas: 2
+                        replicas: 3
+                    scannerComponent: Enabled
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -112,18 +112,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-advanced-cluster-security-central
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-advanced-cluster-security-central
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-advanced-cluster-security-central
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: local-cluster, operator: In, values: ["true"]}

--- a/community/CM-Configuration-Management/policy-acs-operator-secured-clusters.yaml
+++ b/community/CM-Configuration-Management/policy-acs-operator-secured-clusters.yaml
@@ -20,89 +20,89 @@ spec:
   remediationAction: enforce
   disabled: false
   policy-templates:
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: ConfigurationPolicy
-      metadata:
-        name: managed-cluster-security-ns
-      spec:
-        remediationAction: inform
-        severity: high
-        object-templates:
-          - complianceType: musthave
-            objectDefinition:
-              apiVersion: v1
-              kind: Namespace
-              metadata:
-                name: stackrox
-          - complianceType: musthave
-            objectDefinition:
-              apiVersion: v1
-              kind: Namespace
-              metadata:
-                name: rhacs-operator
-          - complianceType: musthave
-            objectDefinition:
-              apiVersion: operators.coreos.com/v1
-              kind: OperatorGroup
-              metadata:
-                name: rhacs-operator-group
-                namespace: rhacs-operator
-              spec: {}
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: ConfigurationPolicy
-      metadata:
-        name: managed-cluster-security-operator-sub
-      spec:
-        remediationAction: inform
-        severity: high
-        object-templates:
-          - complianceType: musthave
-            objectDefinition:
-              apiVersion: operators.coreos.com/v1alpha1
-              kind: Subscription
-              metadata:
-                name: rhacs-operator
-                namespace: rhacs-operator
-              spec:
-                channel: latest
-                installPlanApproval: Automatic
-                name: rhacs-operator
-                source: redhat-operators
-                sourceNamespace: openshift-marketplace
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: ConfigurationPolicy
-      metadata:
-        name: managed-cluster-security-endpoints
-      spec:
-        remediationAction: inform
-        severity: high
-        object-templates:
-          - complianceType: musthave
-            objectDefinition:
-              apiVersion: platform.stackrox.io/v1alpha1
-              kind: SecuredCluster
-              metadata:
-                namespace: stackrox
-                name: stackrox-secured-cluster-services
-              spec:
-                clusterName: |
-                  {{ fromSecret "open-cluster-management-agent" "hub-kubeconfig-secret" "cluster-name" | base64dec }}
-                auditLogs:
-                  collection: Auto
-                centralEndpoint: |
-                  {{ fromSecret "stackrox" "sensor-tls" "acs-host" | base64dec }}
-                admissionControl:
-                  listenOnCreates: false
-                  listenOnEvents: true
-                  listenOnUpdates: false
-                perNode:
-                  collector:
-                    collection: EBPF
-                    imageFlavor: Regular
-                  taintToleration: TolerateTaints
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: managed-cluster-security-ns
+        spec:
+          remediationAction: inform
+          severity: high
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Namespace
+                metadata:
+                  name: stackrox
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Namespace
+                metadata:
+                  name: rhacs-operator
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operators.coreos.com/v1
+                kind: OperatorGroup
+                metadata:
+                  name: rhacs-operator-group
+                  namespace: rhacs-operator
+                spec: {}
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: managed-cluster-security-operator-sub
+        spec:
+          remediationAction: inform
+          severity: high
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operators.coreos.com/v1alpha1
+                kind: Subscription
+                metadata:
+                  name: rhacs-operator
+                  namespace: rhacs-operator
+                spec:
+                  channel: latest
+                  installPlanApproval: Automatic
+                  name: rhacs-operator
+                  source: redhat-operators
+                  sourceNamespace: openshift-marketplace
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: managed-cluster-security-endpoints
+        spec:
+          remediationAction: inform
+          severity: high
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: platform.stackrox.io/v1alpha1
+                kind: SecuredCluster
+                metadata:
+                  namespace: stackrox
+                  name: stackrox-secured-cluster-services
+                spec:
+                  clusterName: |
+                    {{ fromSecret "open-cluster-management-agent" "hub-kubeconfig-secret" "cluster-name" | base64dec }}
+                  auditLogs:
+                    collection: Auto
+                  centralEndpoint: |
+                    {{ fromSecret "stackrox" "sensor-tls" "acs-host" | base64dec }}
+                  admissionControl:
+                    listenOnCreates: false
+                    listenOnEvents: true
+                    listenOnUpdates: false
+                  perNode:
+                    collector:
+                      collection: EBPF
+                      imageFlavor: Regular
+                    taintToleration: TolerateTaints
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -113,18 +113,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-advanced-managed-cluster-security
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-advanced-managed-cluster-security
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-advanced-managed-cluster-security
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: vendor, operator: In, values: ["OpenShift"]}

--- a/community/CM-Configuration-Management/policy-ansible-awx-operator.yaml
+++ b/community/CM-Configuration-Management/policy-ansible-awx-operator.yaml
@@ -34,7 +34,7 @@ spec:
                   namespace: awx-resource-operator
                 spec:
                   targetNamespaces:
-                  - awx-resource-operator
+                    - awx-resource-operator
             - complianceType: musthave
               objectDefinition:
                 apiVersion: operators.coreos.com/v1alpha1
@@ -68,13 +68,9 @@ kind: PlacementRule
 metadata:
   name: placement-policy-awx-resource-operator
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - key: environment
         operator: In
         values:
           - dev
-

--- a/community/CM-Configuration-Management/policy-argocd-kubernetes.yaml
+++ b/community/CM-Configuration-Management/policy-argocd-kubernetes.yaml
@@ -105,13 +105,9 @@ kind: PlacementRule
 metadata:
   name: placement-argocd-kubernetes
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - key: local-cluster
         operator: In
         values:
           - 'true'
-

--- a/community/CM-Configuration-Management/policy-automation-operator.yaml
+++ b/community/CM-Configuration-Management/policy-automation-operator.yaml
@@ -116,7 +116,7 @@ spec:
         metadata:
           name: ansible-automation-platform-status
         spec:
-          remediationAction: inform 
+          remediationAction: inform
           severity: high
           object-templates:
             - complianceType: musthave
@@ -128,7 +128,7 @@ spec:
                 spec:
                   displayName: Ansible Automation Platform
                 status:
-                  phase: Succeeded   # check the csv status to determine if operator is running or not
+                  phase: Succeeded # check the csv status to determine if operator is running or not
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -148,13 +148,9 @@ kind: PlacementRule
 metadata:
   name: placement-policy-ansible-automation-operator
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - key: environment
         operator: In
         values:
           - dev
-

--- a/community/CM-Configuration-Management/policy-autoscaler-templatized.yaml
+++ b/community/CM-Configuration-Management/policy-autoscaler-templatized.yaml
@@ -42,28 +42,28 @@ spec:
                 metadata:
                   name: default #clusterscoped , no namespace needed
                 spec:
-                  podPriorityThreshold: -10 
+                  podPriorityThreshold: -10
                   resourceLimits:
                     maxNodesTotal: '{{hub fromConfigMap "" "autoscaler-config"  (printf "%s-maxnodes" .ManagedClusterName) | toInt hub}}'
                     cores:
-                      min: 8 
-                      max: '{{hub fromConfigMap "" "autoscaler-config"  (printf "%s-cores-max" .ManagedClusterName) | toInt hub}}' 
+                      min: 8
+                      max: '{{hub fromConfigMap "" "autoscaler-config"  (printf "%s-cores-max" .ManagedClusterName) | toInt hub}}'
                     memory:
-                      min: 4 
-                      max: '{{hub fromConfigMap "" "autoscaler-config"  (printf "%s-memory-max" .ManagedClusterName) | toInt hub}}' 
+                      min: 4
+                      max: '{{hub fromConfigMap "" "autoscaler-config"  (printf "%s-memory-max" .ManagedClusterName) | toInt hub}}'
                     gpus:
-                      - type: nvidia.com/gpu 
-                        min: 0 
-                        max: 16 
-                      - type: amd.com/gpu 
-                        min: 0 
-                        max: 4 
-                  scaleDown: 
-                    enabled: true 
-                    delayAfterAdd: 10m 
-                    delayAfterDelete: 5m 
+                      - type: nvidia.com/gpu
+                        min: 0
+                        max: 16
+                      - type: amd.com/gpu
+                        min: 0
+                        max: 4
+                  scaleDown:
+                    enabled: true
+                    delayAfterAdd: 10m
+                    delayAfterDelete: 5m
                     delayAfterFailure: '{{hub- fromConfigMap "" "autoscaler-config"  (printf "%s-failuredelay" .ManagedClusterName) -hub}}'
-                    unneededTime: 5m 
+                    unneededTime: 5m
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
@@ -96,7 +96,7 @@ spec:
                 data:
                   # Configuration values can be set as key-value properties
                   cluster1-maxnodes: '24'
-                  cluster1-cores-max: '128' 
+                  cluster1-cores-max: '128'
                   cluster1-memory-max: "256"
                   cluster1-failuredelay: 30s
                   cluster2-maxnodes: "36"
@@ -163,13 +163,9 @@ kind: PlacementRule
 metadata:
   name: placement-policy-autoscaler-templatized-common
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - key: local-cluster
         operator: In
         values:
           - 'true'
-

--- a/community/CM-Configuration-Management/policy-autoscaler.yaml
+++ b/community/CM-Configuration-Management/policy-autoscaler.yaml
@@ -26,28 +26,28 @@ spec:
                 metadata:
                   name: "default"
                 spec:
-                  podPriorityThreshold: -10 
+                  podPriorityThreshold: -10
                   resourceLimits:
-                    maxNodesTotal: 24 
+                    maxNodesTotal: 24
                     cores:
-                      min: 8 
-                      max: 128 
+                      min: 8
+                      max: 128
                     memory:
-                      min: 4 
-                      max: 256 
+                      min: 4
+                      max: 256
                     gpus:
-                      - type: nvidia.com/gpu 
-                        min: 0 
-                        max: 16 
-                      - type: amd.com/gpu 
-                        min: 0 
-                        max: 4 
-                  scaleDown: 
-                    enabled: true 
-                    delayAfterAdd: 10m 
-                    delayAfterDelete: 5m 
-                    delayAfterFailure: 30s 
-                    unneededTime: 5m 
+                      - type: nvidia.com/gpu
+                        min: 0
+                        max: 16
+                      - type: amd.com/gpu
+                        min: 0
+                        max: 4
+                  scaleDown:
+                    enabled: true
+                    delayAfterAdd: 10m
+                    delayAfterDelete: 5m
+                    delayAfterFailure: 30s
+                    unneededTime: 5m
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -67,13 +67,9 @@ kind: PlacementRule
 metadata:
   name: placement-policy-autoscaler
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - key: environment
         operator: In
         values:
           - 'dev'
-

--- a/community/CM-Configuration-Management/policy-cert-manager-operator.yaml
+++ b/community/CM-Configuration-Management/policy-cert-manager-operator.yaml
@@ -13,27 +13,27 @@ spec:
   remediationAction: enforce
   disabled: false
   policy-templates:
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: ConfigurationPolicy
-      metadata:
-        name: cert-manager-operator-subscription
-      spec:
-        remediationAction: inform
-        severity: high
-        object-templates:
-          - complianceType: musthave
-            objectDefinition:
-              apiVersion: operators.coreos.com/v1alpha1
-              kind: Subscription
-              metadata:
-                name: cert-manager
-                namespace: openshift-operators
-              spec:
-                channel: stable
-                name: cert-manager
-                source: community-operators
-                sourceNamespace: openshift-marketplace
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: cert-manager-operator-subscription
+        spec:
+          remediationAction: inform
+          severity: high
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operators.coreos.com/v1alpha1
+                kind: Subscription
+                metadata:
+                  name: cert-manager
+                  namespace: openshift-operators
+                spec:
+                  channel: stable
+                  name: cert-manager
+                  source: community-operators
+                  sourceNamespace: openshift-marketplace
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -44,18 +44,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-cert-manager-operator
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-cert-manager-operator
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-cert-manager-operator
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/community/CM-Configuration-Management/policy-check-policyreports.yaml
+++ b/community/CM-Configuration-Management/policy-check-policyreports.yaml
@@ -60,18 +60,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-check-policyreports
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-check-policyreports
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-check-policyreports
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/community/CM-Configuration-Management/policy-check-reports.yaml
+++ b/community/CM-Configuration-Management/policy-check-reports.yaml
@@ -60,18 +60,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-check-reports
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-check-reports
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-check-reports
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/community/CM-Configuration-Management/policy-cluster-dns-sample.yaml
+++ b/community/CM-Configuration-Management/policy-cluster-dns-sample.yaml
@@ -24,7 +24,7 @@ spec:
                 apiVersion: config.openshift.io/v1
                 kind: DNS
                 metadata:
-                 name: cluster
+                  name: cluster
                 spec:
                   baseDomain: <base_domain>
                   privateZone:
@@ -41,18 +41,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-config-dns
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-config-dns
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-config-dns
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/community/CM-Configuration-Management/policy-cluster-logforwarder-templatized.yaml
+++ b/community/CM-Configuration-Management/policy-cluster-logforwarder-templatized.yaml
@@ -57,9 +57,6 @@ kind: PlacementRule
 metadata:
   name: placement-policy-enableclusterlogforwarder-templated
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - key: environment

--- a/community/CM-Configuration-Management/policy-cluster-network-sample.yaml
+++ b/community/CM-Configuration-Management/policy-cluster-network-sample.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/standards: NIST 800-53
     policy.open-cluster-management.io/categories: CM Configuration Management
-    policy.open-cluster-management.io/controls: CM-2 Baseline 
+    policy.open-cluster-management.io/controls: CM-2 Baseline
 spec:
   remediationAction: inform
   disabled: false
@@ -27,10 +27,10 @@ spec:
                   name: cluster
                 spec:
                   clusterNetwork:
-                  - cidr: 10.128.0.0/1
-                    hostPrefix: 23
+                    - cidr: 10.128.0.0/1
+                      hostPrefix: 23
                   serviceNetwork:
-                  - 172.30.0.0/16
+                    - 172.30.0.0/16
                   defaultNetwork:
                     type: OpenShiftSDN
                     openshiftSDNConfig:
@@ -41,7 +41,7 @@ spec:
                     iptablesSyncPeriod: 30s
                     proxyArguments:
                       iptables-min-sync-period:
-                      - 0s
+                        - 0s
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -52,23 +52,18 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-config-network
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-config-network
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-config-network
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - key: environment
         operator: In
         values:
-          - dev  
-
-
+          - dev

--- a/community/CM-Configuration-Management/policy-cluster-proxy-sample.yaml
+++ b/community/CM-Configuration-Management/policy-cluster-proxy-sample.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/standards: NIST 800-53
     policy.open-cluster-management.io/categories: CM Configuration Management
-    policy.open-cluster-management.io/controls: CM-2 Baseline 
+    policy.open-cluster-management.io/controls: CM-2 Baseline
 spec:
   remediationAction: inform
   disabled: false
@@ -44,16 +44,15 @@ spec:
           severity: low
           object-templates:
             - complianceType: musthave
-              objectDefinition: 
+              objectDefinition:
                 kind: ConfigMap
                 apiVersion: v1
                 metadata:
                   name: user-ca-bundle
                   namespace: openshift-config
-                data: 
+                data:
                   ca-bundle.crt: |-
                     'CONTENT'
-                 
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -64,18 +63,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-config-proxy
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-config-proxy
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-config-pod
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/community/CM-Configuration-Management/policy-compliance-operator-high-scan.yaml
+++ b/community/CM-Configuration-Management/policy-compliance-operator-high-scan.yaml
@@ -30,17 +30,17 @@ spec:
                   name: high
                   namespace: openshift-compliance
                 profiles:
-                - apiGroup: compliance.openshift.io/v1alpha1
-                  kind: Profile
-                  name: ocp4-high
-                - apiGroup: compliance.openshift.io/v1alpha1
-                  kind: Profile
-                  name: ocp4-high-node
+                  - apiGroup: compliance.openshift.io/v1alpha1
+                    kind: Profile
+                    name: ocp4-high
+                  - apiGroup: compliance.openshift.io/v1alpha1
+                    kind: Profile
+                    name: ocp4-high-node
                 settingsRef:
                   apiGroup: compliance.openshift.io/v1alpha1
                   kind: ScanSetting
                   name: default
-    - objectDefinition: 
+    - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
         metadata:
@@ -86,18 +86,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-high-scan
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-high-scan
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-high-scan
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: vendor, operator: In, values: ["OpenShift"]}

--- a/community/CM-Configuration-Management/policy-compliance-operator-hypershift-hosted-cluster.yaml
+++ b/community/CM-Configuration-Management/policy-compliance-operator-hypershift-hosted-cluster.yaml
@@ -33,9 +33,9 @@ spec:
                   name: hypershift-cis-scan
                   namespace: openshift-compliance
                 profiles:
-                - apiGroup: compliance.openshift.io/v1alpha1
-                  kind: Profile
-                  name: hypershift-tailored-profile
+                  - apiGroup: compliance.openshift.io/v1alpha1
+                    kind: Profile
+                    name: hypershift-tailored-profile
                 settingsRef:
                   apiGroup: compliance.openshift.io/v1alpha1
                   kind: ScanSetting
@@ -155,7 +155,7 @@ spec:
                       rationale: NetworkPolicy for each namespace must be configured manually
                     - name: ocp4-kubeadmin-removed
                       rationale: kubeadmin password needs to be stored in secrets
-    - objectDefinition: 
+    - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
         metadata:
@@ -202,21 +202,18 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-hypershift-scan
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-hypershift-scan
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: hypershift-cis-scan-placement
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
-    - key: name
-      operator: In
-      values:
-      - local-cluster
+      - key: name
+        operator: In
+        values:
+          - local-cluster

--- a/community/CM-Configuration-Management/policy-compliance-operator-moderate-scan.yaml
+++ b/community/CM-Configuration-Management/policy-compliance-operator-moderate-scan.yaml
@@ -30,17 +30,17 @@ spec:
                   name: moderate
                   namespace: openshift-compliance
                 profiles:
-                - apiGroup: compliance.openshift.io/v1alpha1
-                  kind: Profile
-                  name: ocp4-moderate
-                - apiGroup: compliance.openshift.io/v1alpha1
-                  kind: Profile
-                  name: ocp4-moderate-node
+                  - apiGroup: compliance.openshift.io/v1alpha1
+                    kind: Profile
+                    name: ocp4-moderate
+                  - apiGroup: compliance.openshift.io/v1alpha1
+                    kind: Profile
+                    name: ocp4-moderate-node
                 settingsRef:
                   apiGroup: compliance.openshift.io/v1alpha1
                   kind: ScanSetting
                   name: default
-    - objectDefinition: 
+    - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
         metadata:
@@ -86,18 +86,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-moderate-scan
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-moderate-scan
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-moderate-scan
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: vendor, operator: In, values: ["OpenShift"]}

--- a/community/CM-Configuration-Management/policy-compliance-operator-nerc-cip-scan.yaml
+++ b/community/CM-Configuration-Management/policy-compliance-operator-nerc-cip-scan.yaml
@@ -30,17 +30,17 @@ spec:
                   name: nerc-cip
                   namespace: openshift-compliance
                 profiles:
-                - apiGroup: compliance.openshift.io/v1alpha1
-                  kind: Profile
-                  name: ocp4-nerc-cip
-                - apiGroup: compliance.openshift.io/v1alpha1
-                  kind: Profile
-                  name: ocp4-nerc-cip-node
+                  - apiGroup: compliance.openshift.io/v1alpha1
+                    kind: Profile
+                    name: ocp4-nerc-cip
+                  - apiGroup: compliance.openshift.io/v1alpha1
+                    kind: Profile
+                    name: ocp4-nerc-cip-node
                 settingsRef:
                   apiGroup: compliance.openshift.io/v1alpha1
                   kind: ScanSetting
                   name: default
-    - objectDefinition: 
+    - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
         metadata:
@@ -86,18 +86,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-nerc-cip-scan
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-nerc-cip-scan
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-nerc-cip-scan
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: vendor, operator: In, values: ["OpenShift"]}

--- a/community/CM-Configuration-Management/policy-compliance-operator-pci-dss-scan.yaml
+++ b/community/CM-Configuration-Management/policy-compliance-operator-pci-dss-scan.yaml
@@ -30,17 +30,17 @@ spec:
                   name: pci-dss
                   namespace: openshift-compliance
                 profiles:
-                - apiGroup: compliance.openshift.io/v1alpha1
-                  kind: Profile
-                  name: ocp4-pci-dss
-                - apiGroup: compliance.openshift.io/v1alpha1
-                  kind: Profile
-                  name: ocp4-pci-dss-node
+                  - apiGroup: compliance.openshift.io/v1alpha1
+                    kind: Profile
+                    name: ocp4-pci-dss
+                  - apiGroup: compliance.openshift.io/v1alpha1
+                    kind: Profile
+                    name: ocp4-pci-dss-node
                 settingsRef:
                   apiGroup: compliance.openshift.io/v1alpha1
                   kind: ScanSetting
                   name: default
-    - objectDefinition: 
+    - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
         metadata:
@@ -86,18 +86,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-pci-dss-scan
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-pci-dss-scan
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-pci-dss-scan
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: vendor, operator: In, values: ["OpenShift"]}

--- a/community/CM-Configuration-Management/policy-configure-logforwarding.yaml
+++ b/community/CM-Configuration-Management/policy-configure-logforwarding.yaml
@@ -67,18 +67,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-enableclusterlogforwarder
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-enableclusterlogforwarder
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-enableclusterlogforwarder
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/community/CM-Configuration-Management/policy-configure-subscription-admin-hub.yaml
+++ b/community/CM-Configuration-Management/policy-configure-subscription-admin-hub.yaml
@@ -26,26 +26,26 @@ spec:
                 metadata:
                   name: open-cluster-management:subscription-admin
                 rules:
-                - apiGroups:
-                  - app.k8s.io
-                  resources:
-                  - applications
-                  verbs:
-                  - '*'
-                - apiGroups:
-                  - apps.open-cluster-management.io
-                  resources:
-                  - '*'
-                  verbs:
-                  - '*'
-                - apiGroups:
-                  - ""
-                  resources:
-                  - configmaps
-                  - secrets
-                  - namespaces
-                  verbs:
-                  - '*'
+                  - apiGroups:
+                      - app.k8s.io
+                    resources:
+                      - applications
+                    verbs:
+                      - '*'
+                  - apiGroups:
+                      - apps.open-cluster-management.io
+                    resources:
+                      - '*'
+                    verbs:
+                      - '*'
+                  - apiGroups:
+                      - ""
+                    resources:
+                      - configmaps
+                      - secrets
+                      - namespaces
+                    verbs:
+                      - '*'
             - complianceType: musthave
               objectDefinition:
                 apiVersion: rbac.authorization.k8s.io/v1
@@ -57,12 +57,12 @@ spec:
                   kind: ClusterRole
                   name: open-cluster-management:subscription-admin
                 subjects:
-                - apiGroup: rbac.authorization.k8s.io
-                  kind: User
-                  name: kube:admin
-                - apiGroup: rbac.authorization.k8s.io
-                  kind: User
-                  name: system:admin
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: User
+                    name: kube:admin
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: User
+                    name: system:admin
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -73,18 +73,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-configure-subscription-admin-hub
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-configure-subscription-admin-hub
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-configure-subscription-admin-hub
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: name, operator: In, values: ["local-cluster"]}

--- a/community/CM-Configuration-Management/policy-custom-catalog.yaml
+++ b/community/CM-Configuration-Management/policy-custom-catalog.yaml
@@ -14,7 +14,7 @@ spec:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
         metadata:
-          name:  policy-acm-catalogsource
+          name: policy-acm-catalogsource
         spec:
           remediationAction: inform
           severity: medium
@@ -48,9 +48,6 @@ kind: PlacementRule
 metadata:
   name: placement-policy-acm-catalogsource
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - key: environment

--- a/community/CM-Configuration-Management/policy-egress-firewall-sample.yaml
+++ b/community/CM-Configuration-Management/policy-egress-firewall-sample.yaml
@@ -34,13 +34,13 @@ spec:
                       to:
                         cidrSelector: 192.168.12.0/24
                     - type: Allow
-                      to: 
+                      to:
                         dnsName: db-srv.example.com
                     - type: Allow
-                      to: 
+                      to:
                         dnsName: analytics.example.com
                     - type: Deny
-                      to: 
+                      to:
                         cidrSelector: 0.0.0.0/0
 ---
 apiVersion: policy.open-cluster-management.io/v1
@@ -52,18 +52,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: egress-example
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: egress-example
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-egress-example
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/community/CM-Configuration-Management/policy-enable-if-etcd-encrypted-templatized.yaml
+++ b/community/CM-Configuration-Management/policy-enable-if-etcd-encrypted-templatized.yaml
@@ -70,7 +70,7 @@ spec:
                 metadata:
                   name: policy-conditionalsecret #name should match the name of the root policy that is being enabled
                   namespace: <POLICIESNS> #namespace should match the ns of the root policy that is being enabled
-                spec: 
+                spec:
                   # disable is set to true if encryption.type != aescbc else it is set to false , 
                   disabled: '{{ ne (lookup "config.openshift.io/v1" "APIServer" "" "cluster").spec.encryption.type "aescbc" |  print | toBool }}'
 ---
@@ -95,9 +95,6 @@ kind: PlacementRule
 metadata:
   name: placement-policy-conditionalsecret-common
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - key: local-cluster

--- a/community/CM-Configuration-Management/policy-enable-if-ns-exists-templatized.yaml
+++ b/community/CM-Configuration-Management/policy-enable-if-ns-exists-templatized.yaml
@@ -69,7 +69,7 @@ spec:
                 metadata:
                   name: policy-conditionalconfigmap #name should match the name of the root policy that is being enabled
                   namespace: <POLICIESNS> #namespace should match the ns of the root policy that is being enabled
-                spec: 
+                spec:
                   # disable is set to true if namespace does not exist else it is set to false , 
                   disabled: '{{ ne (lookup "v1" "Namespace" "" "test").metadata.name "test" |  print | toBool }}'
 ---
@@ -94,9 +94,6 @@ kind: PlacementRule
 metadata:
   name: placement-policy-conditionalconfigmap-common
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - key: local-cluster

--- a/community/CM-Configuration-Management/policy-engineering-configmap.yaml
+++ b/community/CM-Configuration-Management/policy-engineering-configmap.yaml
@@ -27,7 +27,7 @@ spec:
                 kind: ConfigMap
                 apiVersion: v1
                 metadata:
-                 name: example-configmap
+                  name: example-configmap
                 data:
                   application.properties: |-
                     globalkey = global key value
@@ -59,18 +59,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-configmap-example
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-configmap-example
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-configmap-example
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/community/CM-Configuration-Management/policy-engineering-pod-disruption-budget.yaml
+++ b/community/CM-Configuration-Management/policy-engineering-pod-disruption-budget.yaml
@@ -28,8 +28,8 @@ spec:
                 metadata:
                   name: my-pdb
                 spec:
-                  minAvailable: 2  
-                  selector:  
+                  minAvailable: 2
+                  selector:
                     matchLabels:
                       foo: bar
     - objectDefinition:
@@ -50,11 +50,10 @@ spec:
                 metadata:
                   name: my-pdb2
                 spec:
-                  maxUnavailable: 25% 
-                  selector: 
+                  maxUnavailable: 25%
+                  selector:
                     matchLabels:
                       foo: bar
-
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -65,19 +64,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-example-pod-disruption-budget
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
-
----  
+  - name: policy-example-pod-disruption-budget
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
+---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-example-pod-disruption-budget
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
-      - {key: environment, operator: In, values: ["dev"]}  
+      - {key: environment, operator: In, values: ["dev"]}

--- a/community/CM-Configuration-Management/policy-etcd-backup.yaml
+++ b/community/CM-Configuration-Management/policy-etcd-backup.yaml
@@ -4,7 +4,7 @@ metadata:
   name: policy-etcd-backup
   annotations:
     policy.open-cluster-management.io/categories: NIST SP 800-53
-    policy.open-cluster-management.io/controls: CM Configuration Management 
+    policy.open-cluster-management.io/controls: CM Configuration Management
     policy.open-cluster-management.io/standards: CM-2 Baseline Configuration
 spec:
   disabled: false
@@ -55,23 +55,23 @@ spec:
                 apiVersion: v1
                 data:
                   etcd-backup.sh: |+
-                    
+
                     DATE=$(date +%Y%m%dT%H%M%S)
 
                     /usr/local/bin/etcd-snapshot-backup-disconnected.sh /assets/backup
- 
+
                     if [ $? -eq 0 ]; then
                         mkdir /etcd-backup/${DATE}
                         cp -r /assets/backup/*  /etcd-backup/${DATE}/
                         echo 'Copied backup files to PVC mount point.'
                         exit 0
                     fi
- 
+
                     echo "Backup attempts failed. Please FIX !!!"
                     exit 1
 
                   etcd-snapshot-backup-disconnected.sh: |+
-                    
+
                     set -o errexit
                     set -o pipefail
                     set -o errtrace
@@ -90,13 +90,13 @@ spec:
                     if [ -z "$1" ] || [ -f "$1" ]; then
                       usage
                     fi
-                    
+
                     if [ ! -d "$1" ]; then
                       mkdir -p $1
                     fi
 
                     function backup_latest_kube_static_resources {
-                      
+
                       RESOURCES=("$@")
 
                       LATEST_RESOURCE_DIRS=()
@@ -115,19 +115,19 @@ spec:
                      }
 
                       BACKUP_DIR="$1"
-                      
+
                       DATESTRING=$(date "+%F_%H%M%S")
-                      
+
                       BACKUP_TAR_FILE=${BACKUP_DIR}/static_kuberesources_${DATESTRING}.tar.gz
-                      
+
                       SNAPSHOT_FILE="${BACKUP_DIR}/snapshot_${DATESTRING}.db"
-                      
+
                       BACKUP_RESOURCE_LIST=("kube-apiserver-pod" "kube-controller-manager-pod" "kube-scheduler-pod" "etcd-pod")
 
                       trap "rm -f ${BACKUP_TAR_FILE} ${SNAPSHOT_FILE}" ERR
 
                       source /etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-scripts/etcd.env
-                      
+
                       source /etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-scripts/etcd-common-tools
 
                       if [ ! -f "$ETCDCTL_CACERT" ] && [ ! -d "${CONFIG_FILE_DIR}/static-pod-certs" ]; then
@@ -135,9 +135,9 @@ spec:
                       fi
 
                       backup_latest_kube_static_resources "${BACKUP_RESOURCE_LIST[@]}"
-                      
+
                       etcdctl snapshot save ${SNAPSHOT_FILE}
-                      
+
                       echo "snapshot db and kube resources are successfully saved to ${BACKUP_DIR}"
 
                 kind: ConfigMap
@@ -163,7 +163,7 @@ spec:
                             - name: etcd-backup
                               command:
                                 - /bin/sh
-                                - '-c'
+                                - "-c"
                                 - >-
                                   /usr/local/bin/etcd-backup.sh && ls -1
                                   /etcd-backup/* | sort -r | tail -n +6 | xargs
@@ -200,7 +200,7 @@ spec:
                                   mountPath: /usr/local/bin
                           hostNetwork: true
                           nodeSelector:
-                            node-role.kubernetes.io/master: ''
+                            node-role.kubernetes.io/master: ""
                           restartPolicy: Never
                           serviceAccount: approver
                           serviceAccountName: approver
@@ -214,19 +214,19 @@ spec:
                               hostPath:
                                 path: >-
                                   /etc/kubernetes/static-pod-resources/etcd-member
-                                type: ''
+                                type: ""
                             - name: conf
                               hostPath:
                                 path: /etc/etcd
-                                type: ''
+                                type: ""
                             - name: kubeconfig
                               hostPath:
                                 path: /etc/kubernetes
-                                type: ''
+                                type: ""
                             - name: scripts
                               hostPath:
                                 path: /usr/local/bin
-                                type: ''
+                                type: ""
                             - name: etcd-backup
                               persistentVolumeClaim:
                                 claimName: etcd-backup
@@ -234,7 +234,7 @@ spec:
                               configMap:
                                 name: etcd-backup-script
                                 defaultMode: 493
-                  schedule: '0 */6 * * *'
+                  schedule: "0 */6 * * *"
                   startingDeadlineSeconds: 200
                   suspend: false
           remediationAction: inform
@@ -250,18 +250,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-etcd-backup
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-etcd-backup
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-etcd-backup
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/community/CM-Configuration-Management/policy-file-integrity-operator.yaml
+++ b/community/CM-Configuration-Management/policy-file-integrity-operator.yaml
@@ -11,104 +11,104 @@ spec:
   remediationAction: inform
   disabled: false
   policy-templates:
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: ConfigurationPolicy
-      metadata:
-        name: file-integrity-namespace
-      spec:
-        remediationAction: inform
-        severity: high
-        object-templates:
-          - complianceType: musthave
-            objectDefinition:
-              apiVersion: v1
-              kind: Namespace
-              metadata:
-                name: openshift-file-integrity
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: ConfigurationPolicy
-      metadata:
-        name: openshift-file-integrity-og
-      spec:
-        remediationAction: inform
-        severity: high
-        object-templates:
-          - complianceType: musthave
-            objectDefinition:
-              apiVersion: operators.coreos.com/v1
-              kind: OperatorGroup
-              metadata:
-                name: openshift-file-integrity-og
-                namespace: openshift-file-integrity
-              spec:
-                targetNamespaces:
-                - openshift-file-integrity
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: ConfigurationPolicy
-      metadata:
-        name: file-integrity-subscription
-      spec:
-        remediationAction: inform
-        severity: high
-        object-templates:
-          - complianceType: musthave
-            objectDefinition:
-              apiVersion: operators.coreos.com/v1alpha1
-              kind: Subscription
-              metadata:
-                name: file-integrity-operator
-                namespace: openshift-file-integrity
-              spec:
-                channel: release-0.1
-                installPlanApproval: Automatic
-                name: file-integrity-operator
-                source: redhat-operators
-                sourceNamespace: openshift-marketplace
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: ConfigurationPolicy
-      metadata:
-        name: file-integrity-example
-      spec:
-        remediationAction: inform
-        severity: high
-        object-templates:
-          - complianceType: musthave
-            objectDefinition:
-              apiVersion: fileintegrity.openshift.io/v1alpha1
-              kind: FileIntegrity
-              metadata:
-                name: example-fileintegrity
-                namespace: openshift-file-integrity
-              spec:
-                config:
-                  gracePeriod: 900
-                nodeSelector:
-                  node-role.kubernetes.io/worker: ""
-                tolerations:
-                - effect: NoSchedule
-                  key: node-role.kubernetes.io/master
-                  operator: Exists
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: ConfigurationPolicy
-      metadata:
-        name: file-integrity-node-status
-      spec:
-        remediationAction: inform
-        severity: high
-        object-templates:
-          - complianceType: mustnothave
-            objectDefinition:
-              apiVersion: fileintegrity.openshift.io/v1alpha1
-              kind: FileIntegrityNodeStatus
-              metadata:
-                namespace: openshift-file-integrity
-              results:
-              - condition: Failed
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: file-integrity-namespace
+        spec:
+          remediationAction: inform
+          severity: high
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Namespace
+                metadata:
+                  name: openshift-file-integrity
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: openshift-file-integrity-og
+        spec:
+          remediationAction: inform
+          severity: high
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operators.coreos.com/v1
+                kind: OperatorGroup
+                metadata:
+                  name: openshift-file-integrity-og
+                  namespace: openshift-file-integrity
+                spec:
+                  targetNamespaces:
+                    - openshift-file-integrity
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: file-integrity-subscription
+        spec:
+          remediationAction: inform
+          severity: high
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operators.coreos.com/v1alpha1
+                kind: Subscription
+                metadata:
+                  name: file-integrity-operator
+                  namespace: openshift-file-integrity
+                spec:
+                  channel: release-0.1
+                  installPlanApproval: Automatic
+                  name: file-integrity-operator
+                  source: redhat-operators
+                  sourceNamespace: openshift-marketplace
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: file-integrity-example
+        spec:
+          remediationAction: inform
+          severity: high
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: fileintegrity.openshift.io/v1alpha1
+                kind: FileIntegrity
+                metadata:
+                  name: example-fileintegrity
+                  namespace: openshift-file-integrity
+                spec:
+                  config:
+                    gracePeriod: 900
+                  nodeSelector:
+                    node-role.kubernetes.io/worker: ""
+                  tolerations:
+                    - effect: NoSchedule
+                      key: node-role.kubernetes.io/master
+                      operator: Exists
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: file-integrity-node-status
+        spec:
+          remediationAction: inform
+          severity: high
+          object-templates:
+            - complianceType: mustnothave
+              objectDefinition:
+                apiVersion: fileintegrity.openshift.io/v1alpha1
+                kind: FileIntegrityNodeStatus
+                metadata:
+                  namespace: openshift-file-integrity
+                results:
+                  - condition: Failed
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -119,18 +119,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-file-integrity-operator
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-file-integrity-operator
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-file-integrity-operator
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/community/CM-Configuration-Management/policy-gatekeeper-allowed-external-ips.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-allowed-external-ips.yaml
@@ -113,18 +113,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-gatekeeper-allowed-external-ips
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-gatekeeper-allowed-external-ips
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-gatekeeper-allowed-external-ips
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/community/CM-Configuration-Management/policy-gatekeeper-annotation-owner.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-annotation-owner.yaml
@@ -24,7 +24,7 @@ spec:
                 apiVersion: mutations.gatekeeper.sh/v1alpha1
                 kind: AssignMetadata
                 metadata:
-                  name: pod-annotation-owner 
+                  name: pod-annotation-owner
                 spec:
                   match:
                     scope: Namespaced
@@ -32,8 +32,8 @@ spec:
                       - apiGroups: ["*"]
                         kinds: ["Pod"]
                   location: "metadata.annotations.owner"
-                  parameters: 
-                    assign: 
+                  parameters:
+                    assign:
                       value: "admin"
 ---
 apiVersion: policy.open-cluster-management.io/v1
@@ -54,9 +54,6 @@ kind: PlacementRule
 metadata:
   name: placement-policy-gatekeeper-annotation-owner
 spec:
-  clusterConditions:
-    - status: "True"
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
-      - { key: environment, operator: In, values: ["dev"] }
+      - {key: environment, operator: In, values: ["dev"]}

--- a/community/CM-Configuration-Management/policy-gatekeeper-config-exclude-namespaces.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-config-exclude-namespaces.yaml
@@ -53,18 +53,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-gatekeeper-config-exclude-namespaces
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-gatekeeper-config-exclude-namespaces
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-gatekeeper-config-exclude-namespaces
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/community/CM-Configuration-Management/policy-gatekeeper-container-image-latest.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-container-image-latest.yaml
@@ -451,9 +451,6 @@ kind: PlacementRule
 metadata:
   name: placement-policy-gatekeeper-containerimagelatest
 spec:
-  clusterConditions:
-    - status: "True"
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
-      - { key: environment, operator: In, values: ["dev"] }
+      - {key: environment, operator: In, values: ["dev"]}

--- a/community/CM-Configuration-Management/policy-gatekeeper-container-livenessprobenotset.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-container-livenessprobenotset.yaml
@@ -451,9 +451,6 @@ kind: PlacementRule
 metadata:
   name: placement-policy-gatekeeper-containerlivenessprobenotset
 spec:
-  clusterConditions:
-    - status: "True"
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
-      - { key: environment, operator: In, values: ["dev"] }
+      - {key: environment, operator: In, values: ["dev"]}

--- a/community/CM-Configuration-Management/policy-gatekeeper-container-readinessprobenotset.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-container-readinessprobenotset.yaml
@@ -451,9 +451,6 @@ kind: PlacementRule
 metadata:
   name: placement-policy-gatekeeper-containerreadinessprobenotset
 spec:
-  clusterConditions:
-    - status: "True"
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
-      - { key: environment, operator: In, values: ["dev"] }
+      - {key: environment, operator: In, values: ["dev"]}

--- a/community/CM-Configuration-Management/policy-gatekeeper-container-tgps.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-container-tgps.yaml
@@ -27,14 +27,14 @@ spec:
                   name: policy-gatekeeper-container-tgps
                 spec:
                   applyTo:
-                  - groups: [""]
-                    kinds: ["Pod"]
-                    versions: ["v1"]
+                    - groups: [""]
+                      kinds: ["Pod"]
+                      versions: ["v1"]
                   match:
                     scope: Namespaced
                     kinds:
-                    - apiGroups: ["*"]
-                      kinds: ["Pod"]
+                      - apiGroups: ["*"]
+                        kinds: ["Pod"]
                   location: "spec.terminationGracePeriodSeconds"
                   parameters:
                     assign:
@@ -58,9 +58,6 @@ kind: PlacementRule
 metadata:
   name: placement-policy-gatekeeper-container-tgps
 spec:
-  clusterConditions:
-    - status: "True"
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
-      - { key: environment, operator: In, values: ["dev"] }
+      - {key: environment, operator: In, values: ["dev"]}

--- a/community/CM-Configuration-Management/policy-gatekeeper-image-pull-policy.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-image-pull-policy.yaml
@@ -26,19 +26,19 @@ spec:
                 metadata:
                   name: policy-gatekeeper-image-pull-policy
                 spec:
-                    applyTo:
-                      - groups: [""]
+                  applyTo:
+                    - groups: [""]
+                      kinds: ["Pod"]
+                      versions: ["v1"]
+                  match:
+                    scope: Namespaced
+                    kinds:
+                      - apiGroups: ["*"]
                         kinds: ["Pod"]
-                        versions: ["v1"]
-                    match:
-                      scope: Namespaced
-                      kinds:
-                        - apiGroups: ["*"]
-                          kinds: ["Pod"]
-                    location: "spec.containers[name:*].imagePullPolicy"
-                    parameters: 
-                      assign: 
-                        value: Always
+                  location: "spec.containers[name:*].imagePullPolicy"
+                  parameters:
+                    assign:
+                      value: Always
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -58,9 +58,6 @@ kind: PlacementRule
 metadata:
   name: placement-policy-gatekeeper-image-pull-policy
 spec:
-  clusterConditions:
-    - status: "True"
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
-      - { key: environment, operator: In, values: ["dev"] }
+      - {key: environment, operator: In, values: ["dev"]}

--- a/community/CM-Configuration-Management/policy-gatekeeper-sample.yaml
+++ b/community/CM-Configuration-Management/policy-gatekeeper-sample.yaml
@@ -111,18 +111,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-gatekeeper
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-gatekeeper
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-gatekeeper
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/community/CM-Configuration-Management/policy-github-oauth-sample.yaml
+++ b/community/CM-Configuration-Management/policy-github-oauth-sample.yaml
@@ -28,7 +28,7 @@ spec:
                 spec:
                   identityProviders:
                     - github:
-                        clientID: ID 
+                        clientID: ID
                         clientSecret:
                           name: github
                         organizations:
@@ -65,19 +65,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-github-oauth
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-github-oauth
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-github-oauth
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}
-

--- a/community/CM-Configuration-Management/policy-idp-operator.yaml
+++ b/community/CM-Configuration-Management/policy-idp-operator.yaml
@@ -14,47 +14,46 @@ metadata:
 spec:
   disabled: false
   policy-templates:
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: ConfigurationPolicy
-      metadata:
-        name: policy-idp-operator
-      spec:
-        object-templates:
-        - complianceType: musthave
-          objectDefinition:
-            apiVersion: v1
-            kind: Namespace
-            metadata:
-              name: idp-mgmt-config
-        - complianceType: musthave
-          objectDefinition:
-            apiVersion: operators.coreos.com/v1
-            kind: OperatorGroup
-            metadata:
-              name: idp-mgmt-operator-grp
-              namespace: idp-mgmt-config
-            spec:
-              targetNamespaces:
-              - idp-mgmt-config
-        - complianceType: musthave
-          objectDefinition:
-            apiVersion: operators.coreos.com/v1alpha1
-            kind: Subscription
-            metadata:
-              name: idp-mgmt-operator-product
-              namespace: idp-mgmt-config
-            spec:
-              channel: alpha
-              installPlanApproval: Automatic
-              name: idp-mgmt-operator-product
-              source: redhat-operators
-              sourceNamespace: openshift-marketplace
-              startingCSV: idp-mgmt-operator-product.v0.1.0
-        remediationAction: inform
-        severity: medium
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-idp-operator
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Namespace
+                metadata:
+                  name: idp-mgmt-config
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operators.coreos.com/v1
+                kind: OperatorGroup
+                metadata:
+                  name: idp-mgmt-operator-grp
+                  namespace: idp-mgmt-config
+                spec:
+                  targetNamespaces:
+                    - idp-mgmt-config
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operators.coreos.com/v1alpha1
+                kind: Subscription
+                metadata:
+                  name: idp-mgmt-operator-product
+                  namespace: idp-mgmt-config
+                spec:
+                  channel: alpha
+                  installPlanApproval: Automatic
+                  name: idp-mgmt-operator-product
+                  source: redhat-operators
+                  sourceNamespace: openshift-marketplace
+                  startingCSV: idp-mgmt-operator-product.v0.1.0
+          remediationAction: inform
+          severity: medium
   remediationAction: enforce
-
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -74,9 +73,6 @@ kind: PlacementRule
 metadata:
   name: placement-policy-idp-operator
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - key: local-cluster

--- a/community/CM-Configuration-Management/policy-idp-sample-github.yaml
+++ b/community/CM-Configuration-Management/policy-idp-sample-github.yaml
@@ -16,84 +16,83 @@ metadata:
 spec:
   disabled: false
   policy-templates:
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: ConfigurationPolicy
-      metadata:
-        name: policy-idp-sample-github
-      spec:
-        object-templates:
-        - complianceType: musthave
-          objectDefinition:
-            apiVersion: v1
-            kind: Namespace
-            metadata:
-              labels:
-                control-plane: controller-manager
-              name: authrealm-sample-github-ns
-        - complianceType: musthave
-          objectDefinition:
-            apiVersion: cluster.open-cluster-management.io/v1beta2
-            kind: ManagedClusterSet
-            metadata:
-              name: authrealm-sample-github-clusterset
-              namespace: authrealm-sample-github-ns
-        - complianceType: musthave
-          objectDefinition:
-            apiVersion: cluster.open-cluster-management.io/v1alpha1
-            kind: Placement
-            metadata:
-              name: authrealm-sample-github-placement
-              namespace: authrealm-sample-github-ns
-            spec:
-              predicates:
-              - requiredClusterSelector:
-                  labelSelector:
-                    matchLabels:
-                      authdeployment: sample-github
-        - complianceType: musthave
-          objectDefinition:
-            apiVersion: cluster.open-cluster-management.io/v1beta2
-            kind: ManagedClusterSetBinding
-            metadata:
-              name: authrealm-sample-github-clusterset
-              namespace: authrealm-sample-github-ns
-            spec:
-              clusterSet: authrealm-sample-github-clusterset
-        - complianceType: musthave
-          objectDefinition:
-            apiVersion: v1
-            data:
-              clientSecret: CLIENTSECRET # # Replace with Github OAuth App Client Secret
-            kind: Secret
-            metadata:
-              name: authrealm-sample-github-client-secret
-              namespace: authrealm-sample-github-ns
-            type: Opaque
-        - complianceType: musthave
-          objectDefinition:
-            apiVersion: identityconfig.identitatem.io/v1alpha1
-            kind: AuthRealm
-            metadata:
-              name: authrealm-sample-github
-              namespace: authrealm-sample-github-ns
-            spec:
-              identityProviders:
-              - github:
-                  clientID: CLIENTID # Replace with Github OAuth App Client Id
-                  clientSecret:
-                    name: authrealm-sample-github-client-secret
-                mappingMethod: add
-                name: sample-github-idp
-                type: GitHub
-              placementRef:
-                name: authrealm-sample-github-placement
-              routeSubDomain: sample-github-idp
-              type: dex
-        remediationAction: inform
-        severity: medium
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-idp-sample-github
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Namespace
+                metadata:
+                  labels:
+                    control-plane: controller-manager
+                  name: authrealm-sample-github-ns
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: cluster.open-cluster-management.io/v1beta2
+                kind: ManagedClusterSet
+                metadata:
+                  name: authrealm-sample-github-clusterset
+                  namespace: authrealm-sample-github-ns
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: cluster.open-cluster-management.io/v1alpha1
+                kind: Placement
+                metadata:
+                  name: authrealm-sample-github-placement
+                  namespace: authrealm-sample-github-ns
+                spec:
+                  predicates:
+                    - requiredClusterSelector:
+                        labelSelector:
+                          matchLabels:
+                            authdeployment: sample-github
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: cluster.open-cluster-management.io/v1beta2
+                kind: ManagedClusterSetBinding
+                metadata:
+                  name: authrealm-sample-github-clusterset
+                  namespace: authrealm-sample-github-ns
+                spec:
+                  clusterSet: authrealm-sample-github-clusterset
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                data:
+                  clientSecret: CLIENTSECRET # # Replace with Github OAuth App Client Secret
+                kind: Secret
+                metadata:
+                  name: authrealm-sample-github-client-secret
+                  namespace: authrealm-sample-github-ns
+                type: Opaque
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: identityconfig.identitatem.io/v1alpha1
+                kind: AuthRealm
+                metadata:
+                  name: authrealm-sample-github
+                  namespace: authrealm-sample-github-ns
+                spec:
+                  identityProviders:
+                    - github:
+                        clientID: CLIENTID # Replace with Github OAuth App Client Id
+                        clientSecret:
+                          name: authrealm-sample-github-client-secret
+                      mappingMethod: add
+                      name: sample-github-idp
+                      type: GitHub
+                  placementRef:
+                    name: authrealm-sample-github-placement
+                  routeSubDomain: sample-github-idp
+                  type: dex
+          remediationAction: inform
+          severity: medium
   remediationAction: enforce
-
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -113,9 +112,6 @@ kind: PlacementRule
 metadata:
   name: placement-policy-idp-sample-github
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - key: local-cluster

--- a/community/CM-Configuration-Management/policy-image-policy-sample.yaml
+++ b/community/CM-Configuration-Management/policy-image-policy-sample.yaml
@@ -42,19 +42,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: image-policy
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: image-policy
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-image-policy
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}
-

--- a/community/CM-Configuration-Management/policy-ingress-controller.yaml
+++ b/community/CM-Configuration-Management/policy-ingress-controller.yaml
@@ -55,13 +55,9 @@ kind: PlacementRule
 metadata:
   name: placement-policy-ingress-controller
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - key: environment
         operator: In
         values:
           - dev
-

--- a/community/CM-Configuration-Management/policy-install-external-secrets.yaml
+++ b/community/CM-Configuration-Management/policy-install-external-secrets.yaml
@@ -72,7 +72,7 @@ spec:
                   annotations:
                     apps.open-cluster-management.io/reconcile-rate: medium
                   name: external-secrets
-                  namespace: external-secrets-system 
+                  namespace: external-secrets-system
                 spec:
                   pathname: https://external-secrets.github.io/kubernetes-external-secrets/
                   type: HelmRepo
@@ -93,7 +93,7 @@ spec:
                   labels:
                     app: external-secrets
                   name: external-secrets-subscription
-                  namespace: external-secrets-system 
+                  namespace: external-secrets-system
                 spec:
                   channel: external-secrets-system/external-secrets
                   name: kubernetes-external-secrets
@@ -147,9 +147,6 @@ kind: PlacementRule
 metadata:
   name: placement-external-secrets-policy-app
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchLabels:
       name: local-cluster

--- a/community/CM-Configuration-Management/policy-install-kyverno.yaml
+++ b/community/CM-Configuration-Management/policy-install-kyverno.yaml
@@ -92,8 +92,8 @@ spec:
                     - packageAlias: kyverno
                       packageName: kyverno
                       packageOverrides:
-                      - path: spec
-                        value:
+                        - path: spec
+                          value:
                             extraArgs:
                               - '--clientRateLimitQPS=20'
                               - '--clientRateLimitBurst=50'
@@ -126,7 +126,7 @@ spec:
                 spec:
                   clusterSelector:
                     matchLabels:
-                      environment: dev                      
+                      environment: dev
             - complianceType: musthave
               objectDefinition:
                 apiVersion: apps.open-cluster-management.io/v1
@@ -158,9 +158,6 @@ kind: PlacementRule
 metadata:
   name: placement-policy-install-kyverno
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - key: local-cluster

--- a/community/CM-Configuration-Management/policy-integrity-shield-events.yaml
+++ b/community/CM-Configuration-Management/policy-integrity-shield-events.yaml
@@ -54,10 +54,6 @@ kind: PlacementRule
 metadata:
   name: placement-policy-integrity-shield-events
 spec:
-  clusterConditions:
-    - status: "True"
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}
-

--- a/community/CM-Configuration-Management/policy-integrity-shield-observer.yaml
+++ b/community/CM-Configuration-Management/policy-integrity-shield-observer.yaml
@@ -49,9 +49,6 @@ kind: PlacementRule
 metadata:
   name: placement-policy-integrity-shield-observer
 spec:
-  clusterConditions:
-    - status: "True"
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - key: environment

--- a/community/CM-Configuration-Management/policy-integrity-shield.yaml
+++ b/community/CM-Configuration-Management/policy-integrity-shield.yaml
@@ -1,5 +1,5 @@
 # This policy verifies the installation of Integrity Shield on the managed clusters.
-# 
+#
 # "enforce", it will install Integirty Shield operator
 
 apiVersion: policy.open-cluster-management.io/v1
@@ -129,7 +129,7 @@ spec:
                   requestHandlerConfig: |
                     defaultConstraintAction:
                       mode: inform
-                    sideEffect: 
+                    sideEffect:
                       createDenyEvent: true
                     log:
                       level: info
@@ -137,7 +137,7 @@ spec:
                       format: json
                     decisionReporterConfig:
                       enabled: true
-                    requestFilterProfile: 
+                    requestFilterProfile:
                       skipObjects:
                       - kind: ConfigMap
                         name: kube-root-ca.crt
@@ -194,7 +194,7 @@ spec:
                         objects:
                         - kind: ClusterServiceVersion
                       skipUsers:
-                      - users: 
+                      - users:
                         - system:admin
                         - system:apiserver
                         - system:kube-scheduler
@@ -221,41 +221,41 @@ spec:
                         - system:serviceaccount:kube-system:resourcequota-controller
                         - system:serviceaccount:kube-system:service-account-controller
                         - system:serviceaccount:kube-system:statefulset-controller
-                      - objects: 
+                      - objects:
                         - kind: ControllerRevision
                         - kind: Pod
-                        users: 
+                        users:
                         - system:serviceaccount:kube-system:daemon-set-controller
-                      - objects: 
+                      - objects:
                         - kind: Pod
                         - kind: PersistentVolumeClaim
-                        users: 
+                        users:
                         - system:serviceaccount:kube-system:persistent-volume-binder
-                      - objects: 
+                      - objects:
                         - kind: ReplicaSet
-                        users: 
+                        users:
                         - system:serviceaccount:kube-system:deployment-controller
-                      - objects: 
+                      - objects:
                         - kind: Pod
-                        users:  
+                        users:
                         - system:serviceaccount:kube-system:replicaset-controller
-                      - objects: 
+                      - objects:
                         - kind: PersistentVolumeClaim
-                        users: 
+                        users:
                         - system:serviceaccount:kube-system:statefulset-controller
-                      - objects: 
+                      - objects:
                         - kind: ServiceAccount
-                        users: 
+                        users:
                         - system:kube-controller-manager
-                      - objects: 
+                      - objects:
                         - kind: EndpointSlice
-                        users: 
+                        users:
                         - system:serviceaccount:kube-system:endpointslice-controller
-                      - objects: 
+                      - objects:
                         - kind: Secret
-                        users: 
+                        users:
                         - system:kube-controller-manager
-                      - users: 
+                      - users:
                         - system:serviceaccount:openshift-marketplace:marketplace-operator
                         - system:serviceaccount:openshift-monitoring:cluster-monitoring-operator
                         - system:serviceaccount:openshift-network-operator:default
@@ -287,74 +287,74 @@ spec:
                       - objects:
                         - namespace: openshift-service-ca, openshift-network-operator
                           kind: ConfigMap
-                        users: 
+                        users:
                         - system:serviceaccount:openshift-service-ca:configmap-cabundle-injector-sa
-                      - objects: 
+                      - objects:
                         - namespace: openshift-service-ca-operator
                           kind: ConfigMap
-                        users: 
+                        users:
                         - system:serviceaccount:openshift-service-ca-operator:service-ca-operator
-                      - objects: 
+                      - objects:
                         - namespace: openshift-service-catalog-controller-manager-operator
                           kind: ConfigMap
-                        users: 
+                        users:
                         - system:serviceaccount:openshift-service-catalog-controller-manager-operator:openshift-service-catalog-controller-manager-operator
-                      - objects: 
+                      - objects:
                         - namespace: openshift-console-operator, openshift-console
-                        users: 
+                        users:
                         - system:serviceaccount:openshift-console-operator:console-operator
-                      - objects: 
+                      - objects:
                         - namespace: openshift-service-ca
                           kind: ConfigMap
-                        users: 
+                        users:
                         - system:serviceaccount:openshift-service-ca:apiservice-cabundle-injector-sa
                         - namespace: openshift-service-ca
                           kind: ConfigMap
-                        users: 
+                        users:
                         - system:serviceaccount:openshift-service-ca:service-serving-cert-signer-sa
-                      - objects: 
+                      - objects:
                         - namespace: openshift-service-catalog-apiserver-operator
                           kind: ConfigMap
-                        users: 
+                        users:
                         - system:serviceaccount:openshift-service-catalog-apiserver-operator:openshift-service-catalog-apiserver-operator
-                      - objects: 
+                      - objects:
                         - namespace: openshift-operator-lifecycle-manager
-                        users: 
+                        users:
                         - system:serviceaccount:openshift-operator-lifecycle-manager:olm-operator-serviceaccount
-                      - objects: 
+                      - objects:
                         - namespace: openshift-cluster-node-tuning-operator
                           kind: ConfigMap,DaemonSet
-                        users: 
+                        users:
                         - system:serviceaccount:openshift-cluster-node-tuning-operator:cluster-node-tuning-operator
-                      - objects: 
+                      - objects:
                         - namespace: openshift
                           kind: Secret
-                        users: 
+                        users:
                         - system:serviceaccount:openshift-cluster-samples-operator:cluster-samples-operator
-                      - objects: 
+                      - objects:
                         - namespace: openshift-ingress
                           kind: Deployment
-                        users: 
+                        users:
                         - system:serviceaccount:openshift-ingress-operator:ingress-operator
-                      - objects: 
+                      - objects:
                         - kind: ServiceAccount, Secret
-                        users: 
+                        users:
                         - system:serviceaccount:openshift-infra:serviceaccount-pull-secrets-controller
-                      - objects: 
+                      - objects:
                         - namespace: openshift-marketplace
                           kind: Pod
-                        users: 
+                        users:
                         - system:node:*
-                      - objects: 
+                      - objects:
                         - kind: ServiceAccount, InstallPlan, OperatorGroup, Role, RoleBinding, Deployment
-                        users: 
+                        users:
                         - system:serviceaccount:openshift-operator-lifecycle-manager:olm-operator-serviceaccount
-                      - objects: 
+                      - objects:
                         - kind: InstallPlan, Role, RoleBinding, Deployment
-                        users: 
+                        users:
                         - system:serviceaccount:openshift-operator-lifecycle-manager:olm-operator-serviceaccount
                   useGatekeeper: true
-                  rego: | 
+                  rego: |
                     package integrityshieldcheck
                     violation[{"msg": msg}] {
                       not is_allowed_kind
@@ -417,7 +417,7 @@ spec:
                       allow := object.get(result, "allow", false)
                       allow == false
                     }
-                    
+
                     # request check
                     is_create_or_update { is_create }
                     is_create_or_update { is_update }
@@ -432,7 +432,7 @@ spec:
                     # detect mode
                     is_detect_mode { enforce_mode == "detect" }
 
-                    ################### 
+                    ###################
                     # Default setting #
                     ###################
 
@@ -547,7 +547,6 @@ spec:
                     logLevel: info
                     interval: "5"
                     exportDetailResult: false
-
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
@@ -680,9 +679,6 @@ kind: PlacementRule
 metadata:
   name: placement-policy-integrity-shield
 spec:
-  clusterConditions:
-    - status: "True"
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/community/CM-Configuration-Management/policy-kernel-devel.yaml
+++ b/community/CM-Configuration-Management/policy-kernel-devel.yaml
@@ -63,18 +63,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-kernel-devel
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-kernel-devel
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-kernel-devel
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/community/CM-Configuration-Management/policy-kyverno-config-exclude-resources.yaml
+++ b/community/CM-Configuration-Management/policy-kyverno-config-exclude-resources.yaml
@@ -38,7 +38,7 @@ spec:
                     helm.sh/chart: kyverno-v2.1.2
                   name: kyverno
                   namespace: kyverno
-                data:       # specify all filters you need to exclude
+                data: # specify all filters you need to exclude
                   resourceFilters: '[*,kyverno,*][Event,*,*][*,kube-system,*][*,kube-public,*][*,kube-node-lease,*][Node,*,*][APIService,*,*][TokenReview,*,*][SubjectAccessReview,*,*][SelfSubjectAccessReview,*,*][Binding,*,*][ReplicaSet,*,*][ReportChangeRequest,*,*][ClusterReportChangeRequest,*,*][ClusterRole,*,kyverno:*][ClusterRoleBinding,*,kyverno:*][ServiceAccount,kyverno,kyverno][ConfigMap,kyverno,kyverno][ConfigMap,kyverno,kyverno-metrics][Deployment,kyverno,kyverno][Job,kyverno,kyverno-hook-pre-delete][NetworkPolicy,kyverno,kyverno][PodDisruptionBudget,kyverno,kyverno][Role,kyverno,kyverno:*][RoleBinding,kyverno,kyverno:*][Secret,kyverno,kyverno-svc.kyverno.svc.*][Service,kyverno,kyverno-svc][Service,kyverno,kyverno-svc-metrics][ServiceMonitor,kyverno,kyverno-svc-service-monitor][Pod,kyverno,kyverno-test][*,openshift-*,*][*,open-cluster-*,*][*,stackrox,*][*,ansible-automation-platform,*][*,hive,*][*,multicluster-engine,*][*,rhacs-operator,*][*,local-quay,*]'
                   webhooks: '[{"namespaceSelector": {"matchExpressions": [{"key":"kubernetes.io/metadata.name","operator":"NotIn","values":["kyverno"]}]}}]'
 ---
@@ -60,9 +60,6 @@ kind: PlacementRule
 metadata:
   name: placement-policy-kyverno-config-exclude-resources
 spec:
-  clusterConditions:
-    - status: "True"
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/community/CM-Configuration-Management/policy-kyverno-container-tgps.yaml
+++ b/community/CM-Configuration-Management/policy-kyverno-container-tgps.yaml
@@ -46,7 +46,7 @@ spec:
                       preconditions:
                         - key: "{{`{request.object.spec.terminationGracePeriodSeconds}}`}}"
                           operator: GreaterThan
-                          value: 50   # maximum tGPS allowed by admin
+                          value: 50 # maximum tGPS allowed by admin
                       mutate:
                         patchStrategicMerge:
                           spec:
@@ -70,9 +70,6 @@ kind: PlacementRule
 metadata:
   name: placement-policy-kyverno-container-tgps
 spec:
-  clusterConditions:
-    - status: "True"
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/community/CM-Configuration-Management/policy-kyverno-image-pull-policy.yaml
+++ b/community/CM-Configuration-Management/policy-kyverno-image-pull-policy.yaml
@@ -69,9 +69,6 @@ kind: PlacementRule
 metadata:
   name: placement-policy-kyverno-image-pull-policy
 spec:
-  clusterConditions:
-    - status: "True"
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/community/CM-Configuration-Management/policy-kyverno-sample.yaml
+++ b/community/CM-Configuration-Management/policy-kyverno-sample.yaml
@@ -28,17 +28,17 @@ spec:
                 spec:
                   validationFailureAction: enforce
                   rules:
-                  - name: check-for-labels
-                    match:
-                      resources:
-                        kinds:
-                        - Pod
-                    validate:
-                      message: "label `app.kubernetes.io/name` is required"
-                      pattern:
-                        metadata:
-                          labels:
-                            app.kubernetes.io/name: "?*"
+                    - name: check-for-labels
+                      match:
+                        resources:
+                          kinds:
+                            - Pod
+                      validate:
+                        message: "label `app.kubernetes.io/name` is required"
+                        pattern:
+                          metadata:
+                            labels:
+                              app.kubernetes.io/name: "?*"
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -49,18 +49,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-kyverno-sample
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-kyverno-sample
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-kyverno-sample
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/community/CM-Configuration-Management/policy-label-cluster.yaml
+++ b/community/CM-Configuration-Management/policy-label-cluster.yaml
@@ -39,18 +39,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-label-cluster
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-label-cluster
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-label-cluster
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: name, operator: In, values: ["local-cluster"]}

--- a/community/CM-Configuration-Management/policy-label-worker-nodes.yaml
+++ b/community/CM-Configuration-Management/policy-label-worker-nodes.yaml
@@ -55,18 +55,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-clustercnf10-tag-workers
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-clustercnf10-tag-workers
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: cluster-cnf10
 spec:
-  clusterConditions:
-  - type: ManagedClusterConditionAvailable
-    status: "True"
   clusterSelector:
     matchLabels:
       name: cnf10

--- a/community/CM-Configuration-Management/policy-local-storage-operator.yaml
+++ b/community/CM-Configuration-Management/policy-local-storage-operator.yaml
@@ -9,62 +9,59 @@ metadata:
 spec:
   disabled: false
   remediationAction: inform
-  policy-templates:      
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: ConfigurationPolicy
-      metadata:
-        name: policy-local-storage-operator
-      spec:
-        object-templates:
-        - complianceType: musthave
-          objectDefinition:
-            apiVersion: v1
-            kind: Namespace
-            metadata:
-              labels:
-                openshift.io/cluster-monitoring: "true"
-              name: openshift-local-storage
-        - complianceType: musthave
-          objectDefinition:
-            apiVersion: operators.coreos.com/v1
-            kind: OperatorGroup
-            metadata:
-              name: openshift-storage-operatorgroup
-              namespace: openshift-local-storage
-            spec:
-              targetNamespaces:
-              - openshift-local-storage
-        - complianceType: musthave
-          objectDefinition:
-            apiVersion: operators.coreos.com/v1alpha1
-            kind: Subscription
-            metadata:
-              name: local-storage-operator
-              namespace: openshift-local-storage
-            spec:
-              channel: stable
-              installPlanApproval: Automatic
-              name: local-storage-operator
-              source: redhat-operators
-              sourceNamespace: openshift-marketplace
-        remediationAction: enforce
-        severity: low
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-local-storage-operator
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Namespace
+                metadata:
+                  labels:
+                    openshift.io/cluster-monitoring: "true"
+                  name: openshift-local-storage
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operators.coreos.com/v1
+                kind: OperatorGroup
+                metadata:
+                  name: openshift-storage-operatorgroup
+                  namespace: openshift-local-storage
+                spec:
+                  targetNamespaces:
+                    - openshift-local-storage
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operators.coreos.com/v1alpha1
+                kind: Subscription
+                metadata:
+                  name: local-storage-operator
+                  namespace: openshift-local-storage
+                spec:
+                  channel: stable
+                  installPlanApproval: Automatic
+                  name: local-storage-operator
+                  source: redhat-operators
+                  sourceNamespace: openshift-marketplace
+          remediationAction: enforce
+          severity: low
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-local-storage-operator
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
-    - key: environment
-      operator: In
-      values:
-      - dev
+      - key: environment
+        operator: In
+        values:
+          - dev
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -75,6 +72,6 @@ placementRef:
   kind: PlacementRule
   name: placement-policy-local-storage-operator
 subjects:
-- apiGroup: policy.open-cluster-management.io
-  kind: Policy
-  name: policy-local-storage-operator
+  - apiGroup: policy.open-cluster-management.io
+    kind: Policy
+    name: policy-local-storage-operator

--- a/community/CM-Configuration-Management/policy-lvm-operator.yaml
+++ b/community/CM-Configuration-Management/policy-lvm-operator.yaml
@@ -9,88 +9,85 @@ metadata:
 spec:
   disabled: false
   remediationAction: inform
-  policy-templates:      
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: ConfigurationPolicy
-      metadata:
-        name: policy-odf-lvm-operator
-      spec:
-        object-templates:
-        - complianceType: musthave
-          objectDefinition:
-            apiVersion: v1
-            kind: Namespace
-            metadata:
-              labels:
-                openshift.io/cluster-monitoring: "true"
-                pod-security.kubernetes.io/enforce: privileged
-                pod-security.kubernetes.io/audit: privileged
-                pod-security.kubernetes.io/warn: privileged
-              name: openshift-storage
-        - complianceType: musthave
-          objectDefinition:
-            apiVersion: operators.coreos.com/v1
-            kind: OperatorGroup
-            metadata:
-              name: openshift-storage-operatorgroup
-              namespace: openshift-storage
-            spec:
-              targetNamespaces:
-              - openshift-storage
-        - complianceType: musthave
-          objectDefinition:
-            apiVersion: operators.coreos.com/v1alpha1
-            kind: Subscription
-            metadata:
-              name: lvm-operator
-              namespace: openshift-storage
-            spec:
-              installPlanApproval: Automatic
-              name: odf-lvm-operator
-              source: redhat-operators
-              sourceNamespace: openshift-marketplace
-        remediationAction: enforce
-        severity: low
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: ConfigurationPolicy
-      metadata:
-        name: odf-lvmcluster
-      spec:
-        object-templates:
-           - complianceType: musthave
-             objectDefinition:
-               apiVersion: lvm.topolvm.io/v1alpha1
-               kind: LVMCluster
-               metadata:
-                 name: odf-lvmcluster
-                 namespace: openshift-storage
-               spec:
-                 storage:
-                   deviceClasses:
-                   - name: vg1
-                     thinPoolConfig:
-                       name: thin-pool-1
-                       sizePercent: 80
-                       overprovisionRatio: 10
-        remediationAction: enforce
-        severity: low                       
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-odf-lvm-operator
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Namespace
+                metadata:
+                  labels:
+                    openshift.io/cluster-monitoring: "true"
+                    pod-security.kubernetes.io/enforce: privileged
+                    pod-security.kubernetes.io/audit: privileged
+                    pod-security.kubernetes.io/warn: privileged
+                  name: openshift-storage
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operators.coreos.com/v1
+                kind: OperatorGroup
+                metadata:
+                  name: openshift-storage-operatorgroup
+                  namespace: openshift-storage
+                spec:
+                  targetNamespaces:
+                    - openshift-storage
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operators.coreos.com/v1alpha1
+                kind: Subscription
+                metadata:
+                  name: lvm-operator
+                  namespace: openshift-storage
+                spec:
+                  installPlanApproval: Automatic
+                  name: odf-lvm-operator
+                  source: redhat-operators
+                  sourceNamespace: openshift-marketplace
+          remediationAction: enforce
+          severity: low
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: odf-lvmcluster
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: lvm.topolvm.io/v1alpha1
+                kind: LVMCluster
+                metadata:
+                  name: odf-lvmcluster
+                  namespace: openshift-storage
+                spec:
+                  storage:
+                    deviceClasses:
+                      - name: vg1
+                        thinPoolConfig:
+                          name: thin-pool-1
+                          sizePercent: 80
+                          overprovisionRatio: 10
+          remediationAction: enforce
+          severity: low
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-install-odf-lvm-operator
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
-    - key: environment
-      operator: In
-      values:
-      - dev
+      - key: environment
+        operator: In
+        values:
+          - dev
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -101,6 +98,6 @@ placementRef:
   kind: PlacementRule
   name: placement-install-odf-lvm-operator
 subjects:
-- apiGroup: policy.open-cluster-management.io
-  kind: Policy
-  name: policy-odf-lvm-operator
+  - apiGroup: policy.open-cluster-management.io
+    kind: Policy
+    name: policy-odf-lvm-operator

--- a/community/CM-Configuration-Management/policy-machineconfig-chrony.yaml
+++ b/community/CM-Configuration-Management/policy-machineconfig-chrony.yaml
@@ -30,12 +30,12 @@ spec:
                       version: 2.2.0
                     storage:
                       files:
-                      - contents:
-                          filesystem: root
-                          mode: 420
-                          path: /etc/chrony.conf
-                          source: >-
-                            data:,server%200.fedora.pool.ntp.org%0A%0Aserver%201.fedora.pool.ntp.org%0A%0Aserver%202.fedora.pool.ntp.org%0A%0Adriftfile%20/var/lib/chrony/drift%0A%0Amakestep%201.0%203%0A%0Artcsync%0A%0Akeyfile%20/etc/chrony.keys%0A%0Aleapsectz%20right/UTC%0A%0Alogdir%20/var/log/chrony%0A
+                        - contents:
+                            filesystem: root
+                            mode: 420
+                            path: /etc/chrony.conf
+                            source: >-
+                              data:,server%200.fedora.pool.ntp.org%0A%0Aserver%201.fedora.pool.ntp.org%0A%0Aserver%202.fedora.pool.ntp.org%0A%0Adriftfile%20/var/lib/chrony/drift%0A%0Amakestep%201.0%203%0A%0Artcsync%0A%0Akeyfile%20/etc/chrony.keys%0A%0Aleapsectz%20right/UTC%0A%0Alogdir%20/var/log/chrony%0A
           remediationAction: enforce
           severity: low
   remediationAction: inform
@@ -49,18 +49,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: add-chrony
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: add-chrony
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-add-chrony
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/community/CM-Configuration-Management/policy-managedclusterinfo-templatized.yaml
+++ b/community/CM-Configuration-Management/policy-managedclusterinfo-templatized.yaml
@@ -20,29 +20,28 @@ spec:
   disabled: false
   remediationAction: enforce
   policy-templates:
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: ConfigurationPolicy
-      metadata:
-        name: policy-build-clusterinfo
-      spec:
-        object-templates:
-        - complianceType: musthave
-          objectDefinition:
-            apiVersion: v1
-            data:
-              clusterid: '{{ fromClusterClaim "id.openshift.io" }} '
-              clustername: '{{ fromClusterClaim "name" }}'
-              ocpversion: '{{ fromClusterClaim "version.openshift.io" }}'
-              platform: '{{ fromClusterClaim "platform.open-cluster-management.io"
-                }}'
-              product: '{{ fromClusterClaim "product.open-cluster-management.io" }}'
-            kind: ConfigMap
-            metadata:
-              name: clusterinfo
-              namespace: default
-        remediationAction: inform
-        severity: low
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-build-clusterinfo
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                data:
+                  clusterid: '{{ fromClusterClaim "id.openshift.io" }} '
+                  clustername: '{{ fromClusterClaim "name" }}'
+                  ocpversion: '{{ fromClusterClaim "version.openshift.io" }}'
+                  platform: '{{ fromClusterClaim "platform.open-cluster-management.io" }}'
+                  product: '{{ fromClusterClaim "product.open-cluster-management.io" }}'
+                kind: ConfigMap
+                metadata:
+                  name: clusterinfo
+                  namespace: default
+          remediationAction: inform
+          severity: low
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -53,18 +52,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-managedclusterinfo-templatized
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-managedclusterinfo-templatized
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-managedclusterinfo-templatized
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: vendor, operator: In, values: ["OpenShift"]}

--- a/community/CM-Configuration-Management/policy-managedclustersetbinding.yaml
+++ b/community/CM-Configuration-Management/policy-managedclustersetbinding.yaml
@@ -13,46 +13,43 @@ metadata:
 spec:
   disabled: false
   remediationAction: inform
-  policy-templates:      
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: ConfigurationPolicy
-      metadata:
-        name: policy-managed-clusterset-binding
-      spec:
-        object-templates:
-        - complianceType: musthave
-          objectDefinition:
-            apiVersion: v1
-            kind: Namespace
-            metadata:
-              name: policies
-        - complianceType: musthave
-          objectDefinition:
-            apiVersion: cluster.open-cluster-management.io/v1beta2
-            kind: ManagedClusterSetBinding
-            metadata:
-              namespace: policies
-              name: default
-            spec:
-              clusterSet: default
-        remediationAction: enforce
-        severity: low
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-managed-clusterset-binding
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Namespace
+                metadata:
+                  name: policies
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: cluster.open-cluster-management.io/v1beta2
+                kind: ManagedClusterSetBinding
+                metadata:
+                  namespace: policies
+                  name: default
+                spec:
+                  clusterSet: default
+          remediationAction: enforce
+          severity: low
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-managed-clusterset-binding
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
-    - key: name
-      operator: In
-      values:
-      - local-cluster
+      - key: name
+        operator: In
+        values:
+          - local-cluster
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -63,6 +60,6 @@ placementRef:
   kind: PlacementRule
   name: placement-policy-managed-clusterset-binding
 subjects:
-- apiGroup: policy.open-cluster-management.io
-  kind: Policy
-  name: policy-managed-clusterset-binding
+  - apiGroup: policy.open-cluster-management.io
+    kind: Policy
+    name: policy-managed-clusterset-binding

--- a/community/CM-Configuration-Management/policy-network-policy-samples.yaml
+++ b/community/CM-Configuration-Management/policy-network-policy-samples.yaml
@@ -99,16 +99,16 @@ spec:
                   name: allow-pod-and-namespace-both
                 spec:
                   podSelector:
-                    matchLabels: 
+                    matchLabels:
                       name: test-pods
                   ingress:
                     - from:
-                      - namespaceSelector: 
-                          matchLabels: 
-                            project: project_name
-                        podSelector:
-                          matchLabels: 
-                            name: test-pods
+                        - namespaceSelector:
+                            matchLabels:
+                              project: project_name
+                          podSelector:
+                            matchLabels:
+                              name: test-pods
               severity: low
               remediationAction: inform
   remediationAction: inform
@@ -122,19 +122,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: sample-network-policy-99
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: sample-network-policy-99
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-sample-network-policy
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}
-

--- a/community/CM-Configuration-Management/policy-nginx-deployment-templatized.yaml
+++ b/community/CM-Configuration-Management/policy-nginx-deployment-templatized.yaml
@@ -53,10 +53,10 @@ spec:
                           ports:
                             - containerPort: 80
                           env: # tls key and crt to communicate to hub are dynamically set
-                          - name: hub.tls.crt
-                            value: '{{- fromSecret "open-cluster-management-agent" "hub-kubeconfig-secret" "tls.crt" | base64dec -}}'
-                          - name: hub.tls.key
-                            value: '{{- fromSecret "open-cluster-management-agent" "hub-kubeconfig-secret" "tls.key" | base64dec -}}'
+                            - name: hub.tls.crt
+                              value: '{{- fromSecret "open-cluster-management-agent" "hub-kubeconfig-secret" "tls.crt" | base64dec -}}'
+                            - name: hub.tls.key
+                              value: '{{- fromSecret "open-cluster-management-agent" "hub-kubeconfig-secret" "tls.key" | base64dec -}}'
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -67,19 +67,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-nginx-deployment-templatized
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-nginx-deployment-templatized
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-nginx-deployment-templatized
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: vendor, operator: In, values: ["OpenShift"]}
-

--- a/community/CM-Configuration-Management/policy-nginx-deployment.yaml
+++ b/community/CM-Configuration-Management/policy-nginx-deployment.yaml
@@ -55,19 +55,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-deployment
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-deployment
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-deployment
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}
-

--- a/community/CM-Configuration-Management/policy-oadp.yaml
+++ b/community/CM-Configuration-Management/policy-oadp.yaml
@@ -96,27 +96,24 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
- name: binding-policy-oadp-operator
+  name: binding-policy-oadp-operator
 placementRef:
- apiGroup: apps.open-cluster-management.io
- kind: PlacementRule
- name: placement-policy-oadp-operator
+  apiGroup: apps.open-cluster-management.io
+  kind: PlacementRule
+  name: placement-policy-oadp-operator
 subjects:
- - apiGroup: policy.open-cluster-management.io
-   kind: Policy
-   name: policy-oadp-operator
+  - apiGroup: policy.open-cluster-management.io
+    kind: Policy
+    name: policy-oadp-operator
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
- name: placement-policy-oadp-operator
+  name: placement-policy-oadp-operator
 spec:
- clusterConditions:
-   - status: 'True'
-     type: ManagedClusterConditionAvailable
- clusterSelector:
-   matchExpressions:
-     - key: environment
-       operator: In
-       values:
-         - dev
+  clusterSelector:
+    matchExpressions:
+      - key: environment
+        operator: In
+        values:
+          - dev

--- a/community/CM-Configuration-Management/policy-oauth-config.yaml
+++ b/community/CM-Configuration-Management/policy-oauth-config.yaml
@@ -42,18 +42,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-oauth-config
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-oauth-config
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-oauth-config
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/community/CM-Configuration-Management/policy-oauth-htpasswd.yaml
+++ b/community/CM-Configuration-Management/policy-oauth-htpasswd.yaml
@@ -88,6 +88,3 @@ spec:
         operator: In
         values:
           - dev
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable

--- a/community/CM-Configuration-Management/policy-oauth-ldapsync.yaml
+++ b/community/CM-Configuration-Management/policy-oauth-ldapsync.yaml
@@ -298,6 +298,3 @@ spec:
         operator: In
         values:
           - dev
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable

--- a/community/CM-Configuration-Management/policy-oc-client-cronjob.yaml
+++ b/community/CM-Configuration-Management/policy-oc-client-cronjob.yaml
@@ -10,81 +10,81 @@ spec:
   remediationAction: inform
   disabled: false
   policy-templates:
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: ConfigurationPolicy
-      metadata:
-        name: policy-oc-client
-      spec:
-        object-templates:
-          - complianceType: musthave
-            objectDefinition:
-              kind: Namespace # must have namespace 'jobnamespace'
-              apiVersion: v1
-              metadata:
-                name: jobnamespace     
-          - complianceType: musthave
-            objectDefinition:
-              apiVersion: v1
-              kind: ServiceAccount
-              metadata:
-                name: occlient
-                namespace: jobnamespace 
-          - complianceType: musthave
-            objectDefinition:
-              apiVersion: rbac.authorization.k8s.io/v1
-              kind: ClusterRoleBinding
-              metadata:
-                name: cluster-admin-occlient-sa-crb
-              roleRef:
-                name: cluster-admin
-                apiGroup: rbac.authorization.k8s.io
-                kind: ClusterRole
-              subjects:
-                - name: occlient
-                  kind: ServiceAccount
-                  namespace: jobnamespace 
-          - complianceType: musthave
-            objectDefinition:
-              apiVersion: batch/v1beta1
-              kind: CronJob
-              metadata:
-                name: basic-oc-client
-                namespace: jobnamespace 
-                labels:
-                  purpose: basic-oc-client
-              spec:
-                concurrencyPolicy: Forbid
-                jobTemplate:
-                  spec:
-                    backoffLimit: 0
-                    template:
-                      spec:
-                        activeDeadlineSeconds: 200
-                        containers:
-                          - name: occlient
-                            image: 'registry.redhat.io/openshift4/ose-cli:v4.10'
-                            command: ["/bin/bash"]
-                            args: ["-c", "oc version"]
-                        securityContext:
-                          privileged: true
-                        terminationMessagePath: /dev/termination-log
-                        terminationMessagePolicy: FallbackToLogsOnError
-                        nodeSelector:
-                          node-role.kubernetes.io/master: ''
-                        restartPolicy: Never
-                        serviceAccount: occlient
-                        serviceAccountName: occlient
-                        tolerations:
-                          - effect: NoSchedule
-                            operator: Exists
-                          - effect: NoExecute
-                            operator: Exists
-                schedule: '* * * * *'
-                startingDeadlineSeconds: 200
-                suspend: false
-        remediationAction: inform
-        severity: low
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-oc-client
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                kind: Namespace # must have namespace 'jobnamespace'
+                apiVersion: v1
+                metadata:
+                  name: jobnamespace
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: ServiceAccount
+                metadata:
+                  name: occlient
+                  namespace: jobnamespace
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: rbac.authorization.k8s.io/v1
+                kind: ClusterRoleBinding
+                metadata:
+                  name: cluster-admin-occlient-sa-crb
+                roleRef:
+                  name: cluster-admin
+                  apiGroup: rbac.authorization.k8s.io
+                  kind: ClusterRole
+                subjects:
+                  - name: occlient
+                    kind: ServiceAccount
+                    namespace: jobnamespace
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: batch/v1beta1
+                kind: CronJob
+                metadata:
+                  name: basic-oc-client
+                  namespace: jobnamespace
+                  labels:
+                    purpose: basic-oc-client
+                spec:
+                  concurrencyPolicy: Forbid
+                  jobTemplate:
+                    spec:
+                      backoffLimit: 0
+                      template:
+                        spec:
+                          activeDeadlineSeconds: 200
+                          containers:
+                            - name: occlient
+                              image: 'registry.redhat.io/openshift4/ose-cli:v4.10'
+                              command: ["/bin/bash"]
+                              args: ["-c", "oc version"]
+                          securityContext:
+                            privileged: true
+                          terminationMessagePath: /dev/termination-log
+                          terminationMessagePolicy: FallbackToLogsOnError
+                          nodeSelector:
+                            node-role.kubernetes.io/master: ''
+                          restartPolicy: Never
+                          serviceAccount: occlient
+                          serviceAccountName: occlient
+                          tolerations:
+                            - effect: NoSchedule
+                              operator: Exists
+                            - effect: NoExecute
+                              operator: Exists
+                  schedule: '* * * * *'
+                  startingDeadlineSeconds: 200
+                  suspend: false
+          remediationAction: inform
+          severity: low
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -95,18 +95,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-oc-client
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-oc-client
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-oc-client
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: vendor, operator: In, values: ["OpenShift"]}

--- a/community/CM-Configuration-Management/policy-odf.yaml
+++ b/community/CM-Configuration-Management/policy-odf.yaml
@@ -5,178 +5,172 @@
 # Used APIs: OLM, OCS, ODF #https://github.com/operator-framework/operator-lifecycle-manager
 # https://github.com/openshift/ocs-operator
 # https://github.com/red-hat-storage/odf-operator
- 
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
- annotations:
-   policy.open-cluster-management.io/categories: CM Configuration Management
-   policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
-   policy.open-cluster-management.io/standards: NIST SP 800-53
- name: policy-odf-operator
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+  name: policy-odf-operator
 spec:
- disabled: false
- policy-templates:
-   - objectDefinition:
-       apiVersion: policy.open-cluster-management.io/v1
-       kind: ConfigurationPolicy
-       metadata:
-         name: policy-odf-namespace
-       spec:
-         object-templates:
-           - complianceType: musthave
-             objectDefinition:
-               apiVersion: v1
-               kind: Namespace
-               metadata:
-                 name: openshift-storage
-         remediationAction: inform
-         severity: high
-   - objectDefinition:
-       apiVersion: policy.open-cluster-management.io/v1
-       kind: ConfigurationPolicy
-       metadata:
-         name: policy-odf-operator-operatorgroup
-       spec:
-         object-templates:
-           - complianceType: musthave
-             objectDefinition:
-               apiVersion: operators.coreos.com/v1alpha2
-               kind: OperatorGroup
-               metadata:
-                 name: openshift-storage-operatorgroup
-                 namespace: openshift-storage
-               spec:
-                 targetNamespaces:
-                   - openshift-storage
-         remediationAction: inform
-         severity: high
-   - objectDefinition:
-       apiVersion: policy.open-cluster-management.io/v1
-       kind: ConfigurationPolicy
-       metadata:
-         name: policy-odf-operator-catalog-source
-       spec:
-         object-templates:
-           - complianceType: musthave
-             objectDefinition:
-               apiVersion: operators.coreos.com/v1alpha1
-               kind: CatalogSource
-               metadata:
-                 name: odf-catalogsource
-                 namespace: openshift-marketplace
-               spec:
-                 displayName: OpenShift Data Foundation
-                 image: quay.io/ocs-dev/odf-operator-catalog:main
-                 publisher: Red Hat
-                 sourceType: grpc
-         remediationAction: inform
-         severity: high
-   - objectDefinition:
-       apiVersion: policy.open-cluster-management.io/v1
-       kind: ConfigurationPolicy
-       metadata:
-         name: policy-odf-operator-subscription
-       spec:
-         object-templates:
-           - complianceType: musthave
-             objectDefinition:
-               apiVersion: operators.coreos.com/v1alpha1
-               kind: Subscription
-               metadata:
-                 name: odf-operator
-                 namespace: openshift-storage
-               spec:
-                 channel: alpha
-                 installPlanApproval: Automatic
-                 name: odf-operator
-                 source: odf-catalogsource
-                 sourceNamespace: openshift-marketplace
-                 startingCSV: odf-operator.v0.0.1
-         remediationAction: inform
-         severity: high
-   - objectDefinition:
-       apiVersion: policy.open-cluster-management.io/v1
-       kind: ConfigurationPolicy
-       metadata:
-         name: policy-storagesystem
-       spec:
-         object-templates:
-           - complianceType: musthave
-             objectDefinition:
-               apiVersion: odf.openshift.io/v1alpha1
-               kind: StorageSystem
-               metadata:
-                 name: odf-storagecluster-storagesystem
-                 namespace: openshift-storage
-               spec:
-                 kind: storagecluster.ocs.openshift.io/v1
-                 name: ocs-storagecluster
-                 namespace: openshift-storage
-         remediationAction: inform
-         severity: low
-   - objectDefinition:
-       apiVersion: policy.open-cluster-management.io/v1
-       kind: ConfigurationPolicy
-       metadata:
-         name: policy-storagecluster
-       spec:
-         object-templates:
-           - complianceType: musthave
-             objectDefinition:
-               apiVersion: ocs.openshift.io/v1
-               kind: StorageCluster
-               metadata:
-                 annotations:
-                   uninstall.ocs.openshift.io/cleanup-policy: delete
-                   uninstall.ocs.openshift.io/mode: graceful
-                 name: ocs-storagecluster
-                 namespace: openshift-storage
-               spec:
-                 storageDeviceSets:
-                   - count: 1
-                     dataPVCTemplate:
-                       spec:
-                         accessModes:
-                           - ReadWriteOnce
-                         resources:
-                           requests:
-                             storage: 512Gi
-                         storageClassName: gp2
-                         volumeMode: Block
-                     name: ocs-deviceset-gp2
-                     portable: true
-                     replica: 3
-         remediationAction: inform
-         severity: low
- remediationAction: enforce
- 
- 
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-odf-namespace
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Namespace
+                metadata:
+                  name: openshift-storage
+          remediationAction: inform
+          severity: high
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-odf-operator-operatorgroup
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operators.coreos.com/v1alpha2
+                kind: OperatorGroup
+                metadata:
+                  name: openshift-storage-operatorgroup
+                  namespace: openshift-storage
+                spec:
+                  targetNamespaces:
+                    - openshift-storage
+          remediationAction: inform
+          severity: high
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-odf-operator-catalog-source
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operators.coreos.com/v1alpha1
+                kind: CatalogSource
+                metadata:
+                  name: odf-catalogsource
+                  namespace: openshift-marketplace
+                spec:
+                  displayName: OpenShift Data Foundation
+                  image: quay.io/ocs-dev/odf-operator-catalog:main
+                  publisher: Red Hat
+                  sourceType: grpc
+          remediationAction: inform
+          severity: high
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-odf-operator-subscription
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operators.coreos.com/v1alpha1
+                kind: Subscription
+                metadata:
+                  name: odf-operator
+                  namespace: openshift-storage
+                spec:
+                  channel: alpha
+                  installPlanApproval: Automatic
+                  name: odf-operator
+                  source: odf-catalogsource
+                  sourceNamespace: openshift-marketplace
+                  startingCSV: odf-operator.v0.0.1
+          remediationAction: inform
+          severity: high
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-storagesystem
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: odf.openshift.io/v1alpha1
+                kind: StorageSystem
+                metadata:
+                  name: odf-storagecluster-storagesystem
+                  namespace: openshift-storage
+                spec:
+                  kind: storagecluster.ocs.openshift.io/v1
+                  name: ocs-storagecluster
+                  namespace: openshift-storage
+          remediationAction: inform
+          severity: low
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-storagecluster
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: ocs.openshift.io/v1
+                kind: StorageCluster
+                metadata:
+                  annotations:
+                    uninstall.ocs.openshift.io/cleanup-policy: delete
+                    uninstall.ocs.openshift.io/mode: graceful
+                  name: ocs-storagecluster
+                  namespace: openshift-storage
+                spec:
+                  storageDeviceSets:
+                    - count: 1
+                      dataPVCTemplate:
+                        spec:
+                          accessModes:
+                            - ReadWriteOnce
+                          resources:
+                            requests:
+                              storage: 512Gi
+                          storageClassName: gp2
+                          volumeMode: Block
+                      name: ocs-deviceset-gp2
+                      portable: true
+                      replica: 3
+          remediationAction: inform
+          severity: low
+  remediationAction: enforce
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
- name: binding-policy-odf-operator
+  name: binding-policy-odf-operator
 placementRef:
- apiGroup: apps.open-cluster-management.io
- kind: PlacementRule
- name: placement-policy-odf-operator
+  apiGroup: apps.open-cluster-management.io
+  kind: PlacementRule
+  name: placement-policy-odf-operator
 subjects:
- - apiGroup: policy.open-cluster-management.io
-   kind: Policy
-   name: policy-odf-operator
+  - apiGroup: policy.open-cluster-management.io
+    kind: Policy
+    name: policy-odf-operator
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
- name: placement-policy-odf-operator
+  name: placement-policy-odf-operator
 spec:
- clusterConditions:
-   - status: 'True'
-     type: ManagedClusterConditionAvailable
- clusterSelector:
-   matchExpressions:
-     - key: environment
-       operator: In
-       values:
-         - dev
+  clusterSelector:
+    matchExpressions:
+      - key: environment
+        operator: In
+        values:
+          - dev

--- a/community/CM-Configuration-Management/policy-opa-sample.yaml
+++ b/community/CM-Configuration-Management/policy-opa-sample.yaml
@@ -47,18 +47,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-opa-sample
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-opa-sample
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-opa
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/community/CM-Configuration-Management/policy-openshift-serverless.yaml
+++ b/community/CM-Configuration-Management/policy-openshift-serverless.yaml
@@ -20,7 +20,7 @@ spec:
           severity: high
           object-templates:
             - complianceType: musthave
-              objectDefinition:   
+              objectDefinition:
                 apiVersion: v1
                 kind: Namespace
                 metadata:
@@ -28,7 +28,7 @@ spec:
                     openshift.io/cluster-monitoring: "true"
                   name: openshift-serverless
             - complianceType: musthave
-              objectDefinition:   
+              objectDefinition:
                 apiVersion: v1
                 kind: Namespace
                 metadata:
@@ -36,7 +36,7 @@ spec:
                     kubernetes.io/metadata.name: knative-serving
                   name: knative-serving
             - complianceType: musthave
-              objectDefinition:   
+              objectDefinition:
                 apiVersion: v1
                 kind: Namespace
                 metadata:
@@ -89,8 +89,8 @@ spec:
                 apiVersion: operator.knative.dev/v1alpha1
                 kind: KnativeServing
                 metadata:
-                    name: knative-serving
-                    namespace: knative-serving
+                  name: knative-serving
+                  namespace: knative-serving
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -110,9 +110,6 @@ kind: PlacementRule
 metadata:
   name: placement-policy-openshift-serverless
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/community/CM-Configuration-Management/policy-openshift-servicemesh.yaml
+++ b/community/CM-Configuration-Management/policy-openshift-servicemesh.yaml
@@ -191,35 +191,35 @@ spec:
                       enabled: true
                       service:
                         ports:
-                        - name: http
-                          port: 80
-                          targetPort: 8080
-                        - name: https
-                          port: 443
-                          targetPort: 8443
-                        - name: http2-secure
-                          port: 9443
-                          targetPort: 9443
-                        - name: status-port
-                          port: 15020
-                          targetPort: 15020
+                          - name: http
+                            port: 80
+                            targetPort: 8080
+                          - name: https
+                            port: 443
+                            targetPort: 8443
+                          - name: http2-secure
+                            port: 9443
+                            targetPort: 9443
+                          - name: status-port
+                            port: 15020
+                            targetPort: 15020
                     ingress:
                       enabled: true
                       namespace: istio-system
                       service:
                         ports:
-                        - name: http
-                          port: 80
-                          targetPort: 8080
-                        - name: https
-                          port: 443
-                          targetPort: 8443
-                        - name: tls
-                          port: 15443
-                          targetPort: 15443
-                        - name: status-port
-                          port: 15020
-                          targetPort: 15020
+                          - name: http
+                            port: 80
+                            targetPort: 8080
+                          - name: https
+                            port: 443
+                            targetPort: 8443
+                          - name: tls
+                            port: 15443
+                            targetPort: 15443
+                          - name: status-port
+                            port: 15020
+                            targetPort: 15020
                         type: ClusterIP
                     openshiftRoute:
                       enabled: true
@@ -251,7 +251,7 @@ spec:
           pruneObjectBehavior: None
           remediationAction: inform
           severity: high
-      # Create a Service Mesh Member Roll resource which defines the projects that belong to the Service Mesh.
+          # Create a Service Mesh Member Roll resource which defines the projects that belong to the Service Mesh.
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
@@ -296,6 +296,3 @@ spec:
         operator: In
         values:
           - dev
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable

--- a/community/CM-Configuration-Management/policy-pao-operator.yaml
+++ b/community/CM-Configuration-Management/policy-pao-operator.yaml
@@ -69,7 +69,7 @@ spec:
                     matchExpressions:
                       - key: machineconfiguration.openshift.io/role
                         operator: In
-                        values: [worker,worker-cnf]
+                        values: [worker, worker-cnf]
                   nodeSelector:
                     matchLabels:
                       node-role.kubernetes.io/worker-cnf: ""
@@ -83,18 +83,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-pao-operator
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-pao-operator
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-pao
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: pao, operator: In, values: ["true"]}

--- a/community/CM-Configuration-Management/policy-persistent-data-management.yaml
+++ b/community/CM-Configuration-Management/policy-persistent-data-management.yaml
@@ -98,16 +98,16 @@ spec:
                     - packageAlias: volsync
                       packageName: volsync
                       packageOverrides:
-                      - path: spec
-                        value:
-                          image:
-                            image: registry.redhat.io/rhacm2/volsync-rhel8:v0.4
-                          rclone:
-                            image: registry.redhat.io/rhacm2/volsync-mover-rclone-rhel8:v0.4
-                          restic:
-                            image: registry.redhat.io/rhacm2/volsync-mover-restic-rhel8:v0.4
-                          rsync:
-                            image: registry.redhat.io/rhacm2/volsync-mover-rsync-rhel8:v0.4
+                        - path: spec
+                          value:
+                            image:
+                              image: registry.redhat.io/rhacm2/volsync-rhel8:v0.4
+                            rclone:
+                              image: registry.redhat.io/rhacm2/volsync-mover-rclone-rhel8:v0.4
+                            restic:
+                              image: registry.redhat.io/rhacm2/volsync-mover-restic-rhel8:v0.4
+                            rsync:
+                              image: registry.redhat.io/rhacm2/volsync-mover-rsync-rhel8:v0.4
                   placement:
                     placementRef:
                       name: volsync-placement
@@ -155,9 +155,6 @@ kind: PlacementRule
 metadata:
   name: placement-volsync-policy-app
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchLabels:
       name: local-cluster

--- a/community/CM-Configuration-Management/policy-pod-disruption-budget-templatized.yaml
+++ b/community/CM-Configuration-Management/policy-pod-disruption-budget-templatized.yaml
@@ -41,12 +41,10 @@ spec:
                   name: nginx-pdb
                 spec:
                   #if the environment label on the managedcluster == prod then set maxUnavailable value to 25% then set to 50%
-                  maxUnavailable: '{{- if eq  (lookup "cluster.open-cluster-management.io/v1alpha1" "ClusterClaim" "" "environment").spec.value "prod" -}}
-                    25% {{- else -}} 50% {{- end -}}' 
-                  selector: 
+                  maxUnavailable: '{{- if eq  (lookup "cluster.open-cluster-management.io/v1alpha1" "ClusterClaim" "" "environment").spec.value "prod" -}} 25% {{- else -}} 50% {{- end -}}'
+                  selector:
                     matchLabels:
                       app: nginx
-
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -57,19 +55,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-pod-disruption-budget-templatized
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
-
----  
+  - name: policy-pod-disruption-budget-templatized
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
+---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-pod-disruption-budget-templatized
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: vendor, operator: In, values: ["OpenShift"]}

--- a/community/CM-Configuration-Management/policy-proxy-protocol.yaml
+++ b/community/CM-Configuration-Management/policy-proxy-protocol.yaml
@@ -9,38 +9,35 @@ metadata:
 spec:
   disabled: false
   policy-templates:
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: ConfigurationPolicy
-      metadata:
-        name: policy-proxy-protocol
-      spec:
-        object-templates:
-        - complianceType: musthave
-          objectDefinition:
-            apiVersion: operator.openshift.io/v1
-            kind: IngressController
-            metadata:
-              finalizers:
-              - ingresscontroller.operator.openshift.io/finalizer-ingresscontroller
-              name: default
-              namespace: openshift-ingress-operator
-            spec:
-              endpointPublishingStrategy:
-                hostNetwork:
-                  protocol: PROXY
-                type: HostNetwork
-        remediationAction: inform
-        severity: low
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-proxy-protocol
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operator.openshift.io/v1
+                kind: IngressController
+                metadata:
+                  finalizers:
+                    - ingresscontroller.operator.openshift.io/finalizer-ingresscontroller
+                  name: default
+                  namespace: openshift-ingress-operator
+                spec:
+                  endpointPublishingStrategy:
+                    hostNetwork:
+                      protocol: PROXY
+                    type: HostNetwork
+          remediationAction: inform
+          severity: low
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: policy-proxy-protocol-placement
 spec:
-  clusterConditions:
-    - status: "True"
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - key: local-cluster

--- a/community/CM-Configuration-Management/policy-ptp-operator.yaml
+++ b/community/CM-Configuration-Management/policy-ptp-operator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: policy-ptp-operator
   annotations:
     policy.open-cluster-management.io/standards: NIST SP 800-53
-    policy.open-cluster-management.io/categories: CM Configuration Management 
+    policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
 spec:
   remediationAction: enforce
@@ -47,7 +47,7 @@ spec:
                   namespace: openshift-ptp
                 spec:
                   targetNamespaces:
-                  - openshift-ptp
+                    - openshift-ptp
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
@@ -88,7 +88,7 @@ spec:
                   namespace: openshift-ptp
                 spec:
                   daemonNodeSelector:
-                    node-role.kubernetes.io/worker-cnf: ""             
+                    node-role.kubernetes.io/worker-cnf: ""
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
@@ -112,7 +112,7 @@ spec:
                     matchExpressions:
                       - key: machineconfiguration.openshift.io/role
                         operator: In
-                        values: [worker,worker-cnf]
+                        values: [worker, worker-cnf]
                   nodeSelector:
                     matchLabels:
                       node-role.kubernetes.io/worker-cnf: ""
@@ -126,18 +126,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-ptp-operator
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-ptp-operator
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-ptp
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: ptp, operator: In, values: ["true"]}

--- a/community/CM-Configuration-Management/policy-resiliency-image-pruner.yaml
+++ b/community/CM-Configuration-Management/policy-resiliency-image-pruner.yaml
@@ -56,13 +56,9 @@ kind: PlacementRule
 metadata:
   name: placement-policy-resiliency-image-pruner
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - key: environment
         operator: In
         values:
           - dev
-

--- a/community/CM-Configuration-Management/policy-rhoda-operator.yaml
+++ b/community/CM-Configuration-Management/policy-rhoda-operator.yaml
@@ -84,9 +84,6 @@ kind: PlacementRule
 metadata:
   name: placement-policy-rhoda-operator
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - key: local-cluster

--- a/community/CM-Configuration-Management/policy-rhsso-operator.yaml
+++ b/community/CM-Configuration-Management/policy-rhsso-operator.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     policy.open-cluster-management.io/standards: NIST-CSF
     policy.open-cluster-management.io/categories: CM Configuration Management
-    policy.open-cluster-management.io/controls: CM-2 Baseline 
+    policy.open-cluster-management.io/controls: CM-2 Baseline
 spec:
   remediationAction: enforce
   disabled: false
@@ -44,7 +44,7 @@ spec:
                   namespace: keycloak
                 spec:
                   targetNamespaces:
-                  - keycloak
+                    - keycloak
             - complianceType: musthave
               objectDefinition:
                 apiVersion: operators.coreos.com/v1alpha1
@@ -79,9 +79,9 @@ spec:
                   kind: ClusterRole
                   name: route-editor
                 subjects:
-                - kind: ServiceAccount
-                  name: rhsso-operator
-                  namespace: keycloak
+                  - kind: ServiceAccount
+                    name: rhsso-operator
+                    namespace: keycloak
             - complianceType: musthave
               objectDefinition:
                 apiVersion: rbac.authorization.k8s.io/v1
@@ -89,16 +89,16 @@ spec:
                 metadata:
                   name: route-editor
                 rules:
-                - apiGroups:
-                  - route.openshift.io
-                  resources:
-                  - routes/custom-host
-                  verbs:
-                  - create
-                  - update
-                  - list
-                  - get
-                  - patch
+                  - apiGroups:
+                      - route.openshift.io
+                    resources:
+                      - routes/custom-host
+                    verbs:
+                      - create
+                      - update
+                      - list
+                      - get
+                      - patch
             - complianceType: musthave
               objectDefinition:
                 apiVersion: keycloak.org/v1alpha1
@@ -124,20 +124,16 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-rhsso-operator
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-rhsso-operator
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-rhsso-operator
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
-    matchExpressions:
-      []  # selects all clusters if not specified
+    matchExpressions: [] # selects all clusters if not specified
     matchLabels:
       name: local-cluster

--- a/community/CM-Configuration-Management/policy-scheduler.yaml
+++ b/community/CM-Configuration-Management/policy-scheduler.yaml
@@ -48,13 +48,9 @@ kind: PlacementRule
 metadata:
   name: placement-policy-scheduler
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - key: environment
         operator: In
         values:
           - dev
-

--- a/community/CM-Configuration-Management/policy-sriov-operator.yaml
+++ b/community/CM-Configuration-Management/policy-sriov-operator.yaml
@@ -22,7 +22,7 @@ spec:
             - complianceType: musthave
               objectDefinition:
                 apiVersion: v1
-                kind: Namespace 
+                kind: Namespace
                 metadata:
                   name: openshift-sriov-network-operator
     - objectDefinition:
@@ -43,7 +43,7 @@ spec:
                   namespace: openshift-sriov-network-operator
                 spec:
                   targetNamespaces:
-                  - openshift-sriov-network-operator
+                    - openshift-sriov-network-operator
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
@@ -104,14 +104,14 @@ spec:
                   name: cluster
                 spec:
                   additionalNetworks:
-                  - name: dummy-dhcp-network
-                    simpleMacvlanConfig:
-                      ipamConfig:
-                        type: dhcp
-                      master: eth0
-                      mode: bridge
-                      mtu: 1500
-                    type: SimpleMacvlan
+                    - name: dummy-dhcp-network
+                      simpleMacvlanConfig:
+                        ipamConfig:
+                          type: dhcp
+                        master: eth0
+                        mode: bridge
+                        mtu: 1500
+                      type: SimpleMacvlan
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
@@ -135,7 +135,7 @@ spec:
                     matchExpressions:
                       - key: machineconfiguration.openshift.io/role
                         operator: In
-                        values: [worker,worker-cnf]
+                        values: [worker, worker-cnf]
                   nodeSelector:
                     matchLabels:
                       node-role.kubernetes.io/worker-cnf: ""
@@ -149,18 +149,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-sriov-operator
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-sriov-operator
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-sriov
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: sriov, operator: In, values: ["true"]}

--- a/community/CM-Configuration-Management/policy-sriovnetwork-templatized.yaml
+++ b/community/CM-Configuration-Management/policy-sriovnetwork-templatized.yaml
@@ -7,35 +7,35 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
-    name: policy-site-nw-templatized
-    annotations:
-        policy.open-cluster-management.io/categories: CM Configuration Management
-        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
-        policy.open-cluster-management.io/standards: NIST SP 800-53
+  name: policy-site-nw-templatized
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST SP 800-53
 spec:
-    remediationAction: inform
-    disabled: false
-    policy-templates:
-        - objectDefinition:
-            apiVersion: policy.open-cluster-management.io/v1
-            kind: ConfigurationPolicy
-            metadata:
-                name: policy-site-nw-templatized
-            spec:
-                remediationAction: inform
-                severity: low
-                object-templates:
-                    - complianceType: musthave
-                      objectDefinition:
-                        apiVersion: sriovnetwork.openshift.io/v1
-                        kind: SriovNetwork
-                        metadata:
-                            name: sriov-nw
-                            namespace: openshift-sriov-network-operator
-                        spec:
-                            networkNamespace: openshift-sriov-network-operator
-                            resourceName: '{{hub fromConfigMap "" "site-config"  (printf "%s-resourceName" .ManagedClusterName) hub}}'
-                            vlan: '{{hub fromConfigMap "" "site-config"  (printf "%s-vlan" .ManagedClusterName) | toInt hub}}'
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-site-nw-templatized
+        spec:
+          remediationAction: inform
+          severity: low
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: sriovnetwork.openshift.io/v1
+                kind: SriovNetwork
+                metadata:
+                  name: sriov-nw
+                  namespace: openshift-sriov-network-operator
+                spec:
+                  networkNamespace: openshift-sriov-network-operator
+                  resourceName: '{{hub fromConfigMap "" "site-config"  (printf "%s-resourceName" .ManagedClusterName) hub}}'
+                  vlan: '{{hub fromConfigMap "" "site-config"  (printf "%s-vlan" .ManagedClusterName) | toInt hub}}'
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -55,9 +55,6 @@ kind: PlacementRule
 metadata:
   name: placement-policy-site-nw-templatized-common
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - key: local-cluster
@@ -98,7 +95,6 @@ spec:
                   cluster0001-phc2sysOpts: "-a -r -n 24"
                   cluster0001-resourceName: "du_fh"
                   cluster0001-vlan: "3620"
-
                   cluster0002-interface: "ens5f0"
                   cluster0002-phc2sysOpts: "-a -r -n 24"
                   cluster0002-resourceName: "du_mh"
@@ -122,9 +118,6 @@ kind: PlacementRule
 metadata:
   name: placement-policy-site-nw-templatized-config
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - key: local-cluster
@@ -132,3 +125,4 @@ spec:
         values:
           - 'true'
 ---
+

--- a/community/CM-Configuration-Management/policy-trusted-container.yaml
+++ b/community/CM-Configuration-Management/policy-trusted-container.yaml
@@ -31,18 +31,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-trusted-container
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-trusted-container
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-trusted-container
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/community/CM-Configuration-Management/policy-trusted-node.yaml
+++ b/community/CM-Configuration-Management/policy-trusted-node.yaml
@@ -30,18 +30,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-trusted-node
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-trusted-node
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-trusted-node
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/community/CM-Configuration-Management/policy-update-service-openshift-cluster.yaml
+++ b/community/CM-Configuration-Management/policy-update-service-openshift-cluster.yaml
@@ -10,51 +10,51 @@ spec:
   remediationAction: inform
   disabled: false
   policy-templates:
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: ConfigurationPolicy
-      metadata:
-        name: policy-update-service-subscription
-      spec:
-        remediationAction: enforce
-        severity: medium
-        object-templates:
-          - complianceType: musthave
-            objectDefinition:
-              apiVersion: operators.coreos.com/v1alpha1
-              kind: Subscription
-              metadata:
-                name: cincinnati-operator
-                namespace: openshift-update-service
-                labels:
-                  operators.coreos.com/cincinnati-operator.openshift-update-service: ''
-              spec:
-                channel: v1
-                installPlanApproval: Automatic
-                name: cincinnati-operator
-                source: redhat-operators
-                sourceNamespace: openshift-marketplace
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: ConfigurationPolicy
-      metadata:
-        name: policy-update-service
-      spec:
-        remediationAction: enforce
-        severity: medium
-        object-templates:
-          - complianceType: musthave
-            objectDefinition:
-              apiVersion: updateservice.operator.openshift.io/v1
-              kind: UpdateService
-              metadata:
-                name: sample
-                namespace: openshift-update-service
-              spec:
-                foo: bar
-                graphDataImage: 'quay.io/openshifttest/cincinnati-graph-data-container:4.6'
-                releases: quay.io/openshift-release-dev/ocp-release
-                replicas: 2
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-update-service-subscription
+        spec:
+          remediationAction: enforce
+          severity: medium
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operators.coreos.com/v1alpha1
+                kind: Subscription
+                metadata:
+                  name: cincinnati-operator
+                  namespace: openshift-update-service
+                  labels:
+                    operators.coreos.com/cincinnati-operator.openshift-update-service: ''
+                spec:
+                  channel: v1
+                  installPlanApproval: Automatic
+                  name: cincinnati-operator
+                  source: redhat-operators
+                  sourceNamespace: openshift-marketplace
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-update-service
+        spec:
+          remediationAction: enforce
+          severity: medium
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: updateservice.operator.openshift.io/v1
+                kind: UpdateService
+                metadata:
+                  name: sample
+                  namespace: openshift-update-service
+                spec:
+                  foo: bar
+                  graphDataImage: 'quay.io/openshifttest/cincinnati-graph-data-container:4.6'
+                  releases: quay.io/openshift-release-dev/ocp-release
+                  replicas: 2
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -65,18 +65,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-update-service
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-update-service
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-update-service
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/community/CM-Configuration-Management/policy-upgrade-openshift-cluster.yaml
+++ b/community/CM-Configuration-Management/policy-upgrade-openshift-cluster.yaml
@@ -84,13 +84,9 @@ kind: PlacementRule
 metadata:
   name: placement-upgrade-cluster
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - key: environment
         operator: In
         values:
           - dev
-

--- a/community/CM-Configuration-Management/policy-vsphere-machine-set.yaml
+++ b/community/CM-Configuration-Management/policy-vsphere-machine-set.yaml
@@ -110,6 +110,3 @@ spec:
         operator: In
         values:
           - dev
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable

--- a/community/CM-Configuration-Management/policy-web-terminal-operator.yaml
+++ b/community/CM-Configuration-Management/policy-web-terminal-operator.yaml
@@ -44,9 +44,6 @@ kind: PlacementRule
 metadata:
   name: policy-web-terminal-operator-placement
 spec:
-  clusterConditions:
-    - status: "True"
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - key: local-cluster

--- a/community/CM-Configuration-Management/policy-ztp-node-add-static.yaml
+++ b/community/CM-Configuration-Management/policy-ztp-node-add-static.yaml
@@ -67,8 +67,8 @@ spec:
                         type: ethernet
                         ipv4:
                           address:
-                          - ip: 10.0.0.10
-                            prefix-length: 24
+                            - ip: 10.0.0.10
+                              prefix-length: 24
                           dhcp: false
                           enabled: true
                         ipv6:
@@ -95,9 +95,6 @@ kind: PlacementRule
 metadata:
   name: policy-ztp-node-add-static-placement
 spec:
-  clusterConditions:
-    - status: "True"
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - key: local-cluster

--- a/community/CM-Configuration-Management/policy-ztp-node-add.yaml
+++ b/community/CM-Configuration-Management/policy-ztp-node-add.yaml
@@ -56,9 +56,6 @@ kind: PlacementRule
 metadata:
   name: policy-ztp-node-add-placement
 spec:
-  clusterConditions:
-    - status: "True"
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - key: local-cluster

--- a/community/CM-Configuration-Management/policy-zts-cmc-deployment.yaml
+++ b/community/CM-Configuration-Management/policy-zts-cmc-deployment.yaml
@@ -61,7 +61,7 @@ spec:
                 kind: ConfigMap
                 apiVersion: v1
                 metadata:
-                 name: zts-cmc-configmap
+                  name: zts-cmc-configmap
                 data:
                   application.properties: |-
                     Application = zts_cmc
@@ -69,7 +69,6 @@ spec:
                     CMC_SERVER_PORT = 8443
                     User = system
                     Password = manager
-
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
@@ -80,7 +79,7 @@ spec:
           severity: low
           namespaceSelector:
             include:
-              - default 
+              - default
           object-templates:
             - complianceType: musthave
               objectDefinition:
@@ -107,11 +106,11 @@ spec:
                           imagePullPolicy: Always
                           image: zettasetimg/test:zts-acm-web-application-0.0.2_commitid-a1b5f9
                           env:
-                           - name: IP_ADDRESS_CMC
-                             valueFrom:
-                               configMapKeyRef:
-                                 name: zts-cmc-configmap
-                                 key: application.properties
+                            - name: IP_ADDRESS_CMC
+                              valueFrom:
+                                configMapKeyRef:
+                                  name: zts-cmc-configmap
+                                  key: application.properties
                           ports:
                             - containerPort: 8080
                       imagePullSecrets:
@@ -126,19 +125,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-zts-cmc
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-zts-cmc
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-deployment-zts-cmc
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}
-

--- a/community/CM-Configuration-Management/policy-zts-xcrypt-deployment.yaml
+++ b/community/CM-Configuration-Management/policy-zts-xcrypt-deployment.yaml
@@ -36,32 +36,28 @@ spec:
                     singular: xcrypt
                   scope: Namespaced
                   versions:
-                  - name: v1alpha1
-                    schema:
-                      openAPIV3Schema:
-                        description: XCrypt is the Schema for the xcrypts API
-                        properties:
-                          apiVersion:
-                            description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                            type: string
-                          kind:
-                            description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          metadata:
-                            type: object
-                          spec:
-                            description: XCryptSpec defines the desired state of XCrypt
-                            type: object
-                          status:
-                            description: XCryptStatus defines the observed state of XCrypt
-                            type: object
-                        type: object
-                    served: true
-                    storage: true
+                    - name: v1alpha1
+                      schema:
+                        openAPIV3Schema:
+                          description: XCrypt is the Schema for the xcrypts API
+                          properties:
+                            apiVersion:
+                              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                              type: string
+                            kind:
+                              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            metadata:
+                              type: object
+                            spec:
+                              description: XCryptSpec defines the desired state of XCrypt
+                              type: object
+                            status:
+                              description: XCryptStatus defines the observed state of XCrypt
+                              type: object
+                          type: object
+                      served: true
+                      storage: true
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
@@ -94,7 +90,7 @@ spec:
                           imagePullPolicy: IfNotPresent
                           image: zettasetimg/zts-xcrypt-operator:zts-xcrypt-operator-13-6f1d3f
                           command:
-                          - zts-xcrypt-operator
+                            - zts-xcrypt-operator
                           env:
                             - name: WATCH_NAMESPACE
                               valueFrom:
@@ -156,19 +152,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-zts-xcrypt-deployment
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-zts-xcrypt-deployment
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-zts-xcrypt-deployment
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}
-

--- a/community/CM-Configuration-Management/policy-zts-xcrypt-rbac.yaml
+++ b/community/CM-Configuration-Management/policy-zts-xcrypt-rbac.yaml
@@ -23,130 +23,130 @@ spec:
             - complianceType: musthave
               objectDefinition:
                 apiVersion: v1
-                kind: Namespace 
+                kind: Namespace
                 metadata:
-                   name: zts-xcrypt
+                  name: zts-xcrypt
             - complianceType: musthave
               objectDefinition:
                 apiVersion: v1
                 kind: ServiceAccount
                 metadata:
-                   name: zts-xcrypt-operator
-                   namespace: zts-xcrypt
+                  name: zts-xcrypt-operator
+                  namespace: zts-xcrypt
             - complianceType: musthave
               objectDefinition:
-                apiVersion: rbac.authorization.k8s.io/v1 
+                apiVersion: rbac.authorization.k8s.io/v1
                 kind: ClusterRole
                 metadata:
-                   name: zts-xcrypt-operator
-                   namespace: zts-xcrypt
+                  name: zts-xcrypt-operator
+                  namespace: zts-xcrypt
                 rules:
-                - apiGroups:
-                  - security.openshift.io
-                  resources:
-                  - securitycontextconstraints
-                  resourceNames:
-                  - privileged
-                  - anyuid
-                  - hostmount-anyuid
-                  - hostnetwork
-                  verbs:
-                  - use
-                - apiGroups:
-                  - ""
-                  resources:
-                  - pods
-                  - services
-                  - services/finalizers
-                  - endpoints
-                  - persistentvolumeclaims
-                  - events
-                  - configmaps
-                  - secrets
-                  verbs:
-                  - create
-                  - delete
-                  - get
-                  - list
-                  - patch
-                  - update
-                  - watch
-                - apiGroups:
-                  - xcrypt.zettaset.com
-                  resources:
-                  - '*'
-                  verbs:
-                  - create
-                  - delete
-                  - get
-                  - list
-                  - patch
-                  - update
-                  - watch
-                - apiGroups:
-                  - apps
-                  resources:
-                  - deployments
-                  - daemonsets
-                  - replicasets
-                  - statefulsets
-                  verbs:
-                  - create
-                  - delete
-                  - get
-                  - list
-                  - patch
-                  - update
-                  - watch
-                - apiGroups:
-                  - apps
-                  resourceNames:
-                  - zts-xcrypt-operator
-                  resources:
-                  - deployments/finalizers
-                  verbs:
-                  - update
-                - apiGroups:
-                  - storage.k8s.io
-                  resources:
-                  - csidrivers
-                  verbs:
-                  - create
-                  - delete
-                  - get
-                  - list
-                  - patch
-                  - update
-                  - watch
+                  - apiGroups:
+                      - security.openshift.io
+                    resources:
+                      - securitycontextconstraints
+                    resourceNames:
+                      - privileged
+                      - anyuid
+                      - hostmount-anyuid
+                      - hostnetwork
+                    verbs:
+                      - use
+                  - apiGroups:
+                      - ""
+                    resources:
+                      - pods
+                      - services
+                      - services/finalizers
+                      - endpoints
+                      - persistentvolumeclaims
+                      - events
+                      - configmaps
+                      - secrets
+                    verbs:
+                      - create
+                      - delete
+                      - get
+                      - list
+                      - patch
+                      - update
+                      - watch
+                  - apiGroups:
+                      - xcrypt.zettaset.com
+                    resources:
+                      - '*'
+                    verbs:
+                      - create
+                      - delete
+                      - get
+                      - list
+                      - patch
+                      - update
+                      - watch
+                  - apiGroups:
+                      - apps
+                    resources:
+                      - deployments
+                      - daemonsets
+                      - replicasets
+                      - statefulsets
+                    verbs:
+                      - create
+                      - delete
+                      - get
+                      - list
+                      - patch
+                      - update
+                      - watch
+                  - apiGroups:
+                      - apps
+                    resourceNames:
+                      - zts-xcrypt-operator
+                    resources:
+                      - deployments/finalizers
+                    verbs:
+                      - update
+                  - apiGroups:
+                      - storage.k8s.io
+                    resources:
+                      - csidrivers
+                    verbs:
+                      - create
+                      - delete
+                      - get
+                      - list
+                      - patch
+                      - update
+                      - watch
             - complianceType: musthave
               objectDefinition:
-                apiVersion: rbac.authorization.k8s.io/v1 
-                kind: ClusterRoleBinding 
+                apiVersion: rbac.authorization.k8s.io/v1
+                kind: ClusterRoleBinding
                 metadata:
-                   name: zts-xcrypt-operator
-                   namespace: zts-xcrypt
+                  name: zts-xcrypt-operator
+                  namespace: zts-xcrypt
                 subjects:
                   - kind: ServiceAccount
                     name: zts-xcrypt-operator
                     namespace: zts-xcrypt
                 roleRef:
-                   kind: ClusterRole
-                   name: zts-xcrypt-operator
-                   apiGroup: rbac.authorization.k8s.io
+                  kind: ClusterRole
+                  name: zts-xcrypt-operator
+                  apiGroup: rbac.authorization.k8s.io
             - complianceType: musthave
               objectDefinition:
                 apiVersion: v1
                 kind: ServiceAccount
                 metadata:
-                   name: zts-csi-controller-sa
-                   namespace: zts-xcrypt
+                  name: zts-csi-controller-sa
+                  namespace: zts-xcrypt
             - complianceType: musthave
               objectDefinition:
-                apiVersion: rbac.authorization.k8s.io/v1 
+                apiVersion: rbac.authorization.k8s.io/v1
                 kind: ClusterRole
                 metadata:
-                   name: zts-external-provisioner-role 
-                   namespace: zts-xcrypt
+                  name: zts-external-provisioner-role
+                  namespace: zts-xcrypt
                 rules:
                   - apiGroups: [""]
                     resources: ["persistentvolumes"]
@@ -170,38 +170,38 @@ spec:
                     resources: ["leases"]
                     verbs: ["get", "watch", "list", "delete", "update", "create"]
                   - verbs:
-                    - use
+                      - use
                     apiGroups:
-                    - security.openshift.io
+                      - security.openshift.io
                     resources:
-                    - securitycontextconstraints
+                      - securitycontextconstraints
                     resourceNames:
-                    - privileged
-                    - anyuid
-                    - hostmount-anyuid
-                    - hostnetwork
+                      - privileged
+                      - anyuid
+                      - hostmount-anyuid
+                      - hostnetwork
             - complianceType: musthave
               objectDefinition:
-                apiVersion: rbac.authorization.k8s.io/v1 
-                kind: ClusterRoleBinding 
+                apiVersion: rbac.authorization.k8s.io/v1
+                kind: ClusterRoleBinding
                 metadata:
-                   name: zts-csi-provisioner-binding 
-                   namespace: zts-xcrypt
+                  name: zts-csi-provisioner-binding
+                  namespace: zts-xcrypt
                 subjects:
                   - kind: ServiceAccount
-                    name: zts-csi-controller-sa 
+                    name: zts-csi-controller-sa
                     namespace: zts-xcrypt
                 roleRef:
-                   kind: ClusterRole
-                   name: zts-external-provisioner-role 
-                   apiGroup: rbac.authorization.k8s.io
+                  kind: ClusterRole
+                  name: zts-external-provisioner-role
+                  apiGroup: rbac.authorization.k8s.io
             - complianceType: musthave
               objectDefinition:
-                apiVersion: rbac.authorization.k8s.io/v1 
+                apiVersion: rbac.authorization.k8s.io/v1
                 kind: ClusterRole
                 metadata:
-                   name: zts-external-attacher-role 
-                   namespace: zts-xcrypt
+                  name: zts-external-attacher-role
+                  namespace: zts-xcrypt
                 rules:
                   - apiGroups: [""]
                     resources: ["persistentvolumes"]
@@ -216,31 +216,31 @@ spec:
                     resources: ["volumeattachments"]
                     verbs: ["get", "list", "watch", "update"]
                   - verbs:
-                    - use
+                      - use
                     apiGroups:
-                    - security.openshift.io
+                      - security.openshift.io
                     resources:
-                    - securitycontextconstraints
+                      - securitycontextconstraints
                     resourceNames:
-                    - privileged
-                    - anyuid
-                    - hostmount-anyuid
-                    - hostnetwork
+                      - privileged
+                      - anyuid
+                      - hostmount-anyuid
+                      - hostnetwork
             - complianceType: musthave
               objectDefinition:
-                apiVersion: rbac.authorization.k8s.io/v1 
-                kind: ClusterRoleBinding 
+                apiVersion: rbac.authorization.k8s.io/v1
+                kind: ClusterRoleBinding
                 metadata:
-                   name: zts-csi-attacher-binding 
-                   namespace: zts-xcrypt
+                  name: zts-csi-attacher-binding
+                  namespace: zts-xcrypt
                 subjects:
                   - kind: ServiceAccount
-                    name: zts-csi-controller-sa 
+                    name: zts-csi-controller-sa
                     namespace: zts-xcrypt
                 roleRef:
-                   kind: ClusterRole
-                   name: zts-external-attacher-role 
-                   apiGroup: rbac.authorization.k8s.io
+                  kind: ClusterRole
+                  name: zts-external-attacher-role
+                  apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -251,19 +251,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-zts-xcrypt-rbac
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-zts-xcrypt-rbac
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-zts-xcrypt-rbac
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}
-

--- a/community/SC-System-and-Communications-Protection/policy-checkclusteroperator.yaml
+++ b/community/SC-System-and-Communications-Protection/policy-checkclusteroperator.yaml
@@ -49,7 +49,7 @@ spec:
                 status:
                   conditions:
                     - status: 'True'
-                      type: Degraded                         
+                      type: Degraded
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -60,18 +60,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-checkclusteroperator
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-checkclusteroperator
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-checkclusteroperator
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/community/SC-System-and-Communications-Protection/policy-checknamespaces-terminating.yaml
+++ b/community/SC-System-and-Communications-Protection/policy-checknamespaces-terminating.yaml
@@ -44,9 +44,6 @@ kind: PlacementRule
 metadata:
   name: placement-checknamespaces-terminating
 spec:
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - key: environment

--- a/community/SC-System-and-Communications-Protection/policy-disable-self-provisioner.yaml
+++ b/community/SC-System-and-Communications-Protection/policy-disable-self-provisioner.yaml
@@ -42,18 +42,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-remove-self-provisioner
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-remove-self-provisioner
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-remove-self-provisioner
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/community/SC-System-and-Communications-Protection/policy-ocp4-certs.yaml
+++ b/community/SC-System-and-Communications-Protection/policy-ocp4-certs.yaml
@@ -10,90 +10,90 @@ spec:
   remediationAction: inform
   disabled: false
   policy-templates:
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: CertificatePolicy
-      metadata:
-        name: openshift-cert-policy
-      spec:
-        namespaceSelector:
-          include:
-          - openshift-service-ca-operator
-          - openshift-service-ca
-          - openshift-operator-lifecycle-manager
-          - openshift-apiserver
-          - openshift-apiserver-operator
-          - openshift-authentication
-          - openshift-authentication-operator
-          - openshift-cluster-machine-approver
-          - openshift-cluster-samples-operator
-          - openshift-cluster-storage-operator
-          - openshift-cluster-version
-          - openshift-config
-          - openshift-config-operator
-          - openshift-console
-          - openshift-console-operator
-          - openshift-controller-manager
-          - openshift-controller-manager-operator
-          - openshift-dns
-          - openshift-dns-operator
-          - openshift-etcd
-          - openshift-etcd-operator
-          - openshift-image-registry
-          - openshift-ingress-operator
-          - openshift-insights
-          - openshift-kube-scheduler-operator
-          - openshift-kube-storage-version-migrator-operator
-          - openshift-machine-api
-          - openshift-machine-config-operator
-          - openshift-marketplace
-          - openshift-monitoring
-          - openshift-multus
-        remediationAction: inform
-        minimumDuration: 400h
-        severity: low
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: CertificatePolicy
-      metadata:
-        name: openshift-cert-policy-ingress
-      spec:
-        namespaceSelector:
-          include:
-          - openshift-ingress
-        remediationAction: inform
-        minimumDuration: 24h
-        minimumCADuration: 400h
-        severity: low
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: CertificatePolicy
-      metadata:
-        name: openshift-cert-policy-csr
-      spec:
-        namespaceSelector:
-          include:
-          - openshift-kube-apiserver-operator
-          - openshift-kube-controller-manager-operator
-        remediationAction: inform
-        minimumDuration: 400h
-        minimumCADuration: 24h
-        severity: low
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: CertificatePolicy
-      metadata:
-        name: openshift-cert-policy-mgr
-      spec:
-        namespaceSelector:
-          include:
-          - openshift-config-managed
-          - openshift-kube-apiserver
-          - openshift-kube-scheduler
-          - openshift-kube-controller-manager
-        remediationAction: inform
-        minimumDuration: 24h
-        severity: low
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: CertificatePolicy
+        metadata:
+          name: openshift-cert-policy
+        spec:
+          namespaceSelector:
+            include:
+              - openshift-service-ca-operator
+              - openshift-service-ca
+              - openshift-operator-lifecycle-manager
+              - openshift-apiserver
+              - openshift-apiserver-operator
+              - openshift-authentication
+              - openshift-authentication-operator
+              - openshift-cluster-machine-approver
+              - openshift-cluster-samples-operator
+              - openshift-cluster-storage-operator
+              - openshift-cluster-version
+              - openshift-config
+              - openshift-config-operator
+              - openshift-console
+              - openshift-console-operator
+              - openshift-controller-manager
+              - openshift-controller-manager-operator
+              - openshift-dns
+              - openshift-dns-operator
+              - openshift-etcd
+              - openshift-etcd-operator
+              - openshift-image-registry
+              - openshift-ingress-operator
+              - openshift-insights
+              - openshift-kube-scheduler-operator
+              - openshift-kube-storage-version-migrator-operator
+              - openshift-machine-api
+              - openshift-machine-config-operator
+              - openshift-marketplace
+              - openshift-monitoring
+              - openshift-multus
+          remediationAction: inform
+          minimumDuration: 400h
+          severity: low
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: CertificatePolicy
+        metadata:
+          name: openshift-cert-policy-ingress
+        spec:
+          namespaceSelector:
+            include:
+              - openshift-ingress
+          remediationAction: inform
+          minimumDuration: 24h
+          minimumCADuration: 400h
+          severity: low
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: CertificatePolicy
+        metadata:
+          name: openshift-cert-policy-csr
+        spec:
+          namespaceSelector:
+            include:
+              - openshift-kube-apiserver-operator
+              - openshift-kube-controller-manager-operator
+          remediationAction: inform
+          minimumDuration: 400h
+          minimumCADuration: 24h
+          severity: low
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: CertificatePolicy
+        metadata:
+          name: openshift-cert-policy-mgr
+        spec:
+          namespaceSelector:
+            include:
+              - openshift-config-managed
+              - openshift-kube-apiserver
+              - openshift-kube-scheduler
+              - openshift-kube-controller-manager
+          remediationAction: inform
+          minimumDuration: 24h
+          severity: low
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -104,18 +104,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-cert-ocp4
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-cert-ocp4
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-cert-ocp4
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: vendor, operator: In, values: ["OpenShift"]}

--- a/community/SC-System-and-Communications-Protection/policy-remove-kubeadmin.yaml
+++ b/community/SC-System-and-Communications-Protection/policy-remove-kubeadmin.yaml
@@ -37,18 +37,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-remove-kubeadmin
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-remove-kubeadmin
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-remove-kubeadmin
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/community/SI-System-and-Information-Integrity/policy-blackduck.yaml
+++ b/community/SI-System-and-Information-Integrity/policy-blackduck.yaml
@@ -18,160 +18,160 @@ spec:
   remediationAction: enforce
   disabled: false
   policy-templates:
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: ConfigurationPolicy
-      metadata:
-        name: policy-blackduck-operator
-      spec:
-        remediationAction: inform
-        severity: high
-        object-templates:
-          - complianceType: musthave # Makes sure operators are installed on all clusters
-            objectDefinition:
-              apiVersion: operators.coreos.com/v1alpha1
-              kind: Subscription
-              metadata:
-                name: blackduck-connector-operator
-                namespace: openshift-operators
-              spec:
-                channel: alpha
-                installPlanApproval: Automatic
-                name: blackduck-connector-operator
-                source: certified-operators
-                sourceNamespace: openshift-marketplace
-                startingCSV: blackduck-connector-operator.v1.0.0
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: ConfigurationPolicy
-      metadata:
-        name: policy-blackduck-connector
-      spec:
-        remediationAction: inform
-        severity: high
-        object-templates:
-          - complianceType: musthave # Makes sure connectors are installed on all clusters
-            objectDefinition:
-              apiVersion: charts.synopsys.com/v1alpha1
-              kind: BlackduckConnector
-              metadata:
-                name: blackduckconnector
-                namespace: openshift-operators
-              spec:
-                externalBlackDuck:
-                  - scheme: https
-                    domain: example.blackduck.synopsys.com # users need to fill this out
-                    port: 443
-                    user: example_admin # users need to fill this out
-                    password: example_password # users need to fill this out
-                    concurrentScanLimit: 3
-                logLevel: debug
-                podProcessor:
-                  nameSpaceFilter: 'default' # users need to fill this out
-                  enabled: true
-                  resources:
-                    requests:
-                      cpu: 300m
-                      memory: 1300Mi
-                securedRegistries: []
-                artifactoryProcessor:
-                  dumper: false
-                  enabled: false
-                  expose: None
-                  resources:
-                    requests:
-                      cpu: 300m
-                      memory: 1300Mi
-                blackduck:
-                  connectionsEnvironmentVariableName: blackduck.json
-                  tlsVerification: false
-                core:
-                  expose: None
-                  port: 3001
-                  resources:
-                    requests:
-                      cpu: 300m
-                      memory: 1300Mi
-                  timings:
-                    checkForStalledScansPauseHours: 999999
-                    clientTimeoutMilliseconds: 100000
-                    modelMetricsPauseSeconds: 15
-                    stalledScanClientTimeoutHours: 999999
-                    unknownImagePauseMilliseconds: 15000
-                  useMockMode: false
-                fullnameOverride: ''
-                imageGetter:
-                  createImagesOnly: false
-                  host: localhost
-                  imagePullerType: skopeo
-                  port: 3004
-                  resources:
-                    requests:
-                      cpu: 300m
-                      memory: 1300Mi
-                imageProcessor:
-                  enabled: false
-                  resources:
-                    requests:
-                      cpu: 300m
-                      memory: 1300Mi
-                imagePullSecrets: []
-                imageTag: 2.2.5
-                nameOverride: ''
-                processor:
-                  annotationIntervalSeconds: 30
-                  certificate: ''
-                  certificateKey: ''
-                  dumpIntervalMinutes: 30
-                  port: 3002
-                prometheus:
-                  affinity: {}
-                  enabled: false
-                  expose: None
-                  imageTag: v2.1.0
-                  nodeSelector: {}
-                  podSecurityContext: {}
-                  registry: docker.io/prom
-                  resources:
-                    requests:
-                      cpu: 300m
-                      memory: 1300Mi
-                  securityContext: {}
-                  tolerations: []
-                quayProcessor:
-                  enabled: false
-                  expose: None
-                  resources:
-                    requests:
-                      cpu: 300m
-                      memory: 1300Mi
-                registry: docker.io/blackducksoftware
-                scanner:
-                  blackDuckClientTimeoutSeconds: 600
-                  imageDirectory: /var/images
-                  port: 3003
-                  replicas: 1
-                  resources:
-                    requests:
-                      cpu: 300m
-                      memory: 1300Mi
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: ConfigurationPolicy
-      metadata:
-        name: policy-blackduck-labels
-      spec:
-        remediationAction: inform 
-        severity: high
-        object-templates:
-          - complianceType: mustnothave # Makes sure pods are not in any kind of black duck policy violations
-            objectDefinition:
-              apiVersion: v1
-              kind: Pod
-              metadata:
-                labels:
-                  com.blackducksoftware.com.pod.overall-status: IN_VIOLATION
-                namespace: default
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-blackduck-operator
+        spec:
+          remediationAction: inform
+          severity: high
+          object-templates:
+            - complianceType: musthave # Makes sure operators are installed on all clusters
+              objectDefinition:
+                apiVersion: operators.coreos.com/v1alpha1
+                kind: Subscription
+                metadata:
+                  name: blackduck-connector-operator
+                  namespace: openshift-operators
+                spec:
+                  channel: alpha
+                  installPlanApproval: Automatic
+                  name: blackduck-connector-operator
+                  source: certified-operators
+                  sourceNamespace: openshift-marketplace
+                  startingCSV: blackduck-connector-operator.v1.0.0
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-blackduck-connector
+        spec:
+          remediationAction: inform
+          severity: high
+          object-templates:
+            - complianceType: musthave # Makes sure connectors are installed on all clusters
+              objectDefinition:
+                apiVersion: charts.synopsys.com/v1alpha1
+                kind: BlackduckConnector
+                metadata:
+                  name: blackduckconnector
+                  namespace: openshift-operators
+                spec:
+                  externalBlackDuck:
+                    - scheme: https
+                      domain: example.blackduck.synopsys.com # users need to fill this out
+                      port: 443
+                      user: example_admin # users need to fill this out
+                      password: example_password # users need to fill this out
+                      concurrentScanLimit: 3
+                  logLevel: debug
+                  podProcessor:
+                    nameSpaceFilter: 'default' # users need to fill this out
+                    enabled: true
+                    resources:
+                      requests:
+                        cpu: 300m
+                        memory: 1300Mi
+                  securedRegistries: []
+                  artifactoryProcessor:
+                    dumper: false
+                    enabled: false
+                    expose: None
+                    resources:
+                      requests:
+                        cpu: 300m
+                        memory: 1300Mi
+                  blackduck:
+                    connectionsEnvironmentVariableName: blackduck.json
+                    tlsVerification: false
+                  core:
+                    expose: None
+                    port: 3001
+                    resources:
+                      requests:
+                        cpu: 300m
+                        memory: 1300Mi
+                    timings:
+                      checkForStalledScansPauseHours: 999999
+                      clientTimeoutMilliseconds: 100000
+                      modelMetricsPauseSeconds: 15
+                      stalledScanClientTimeoutHours: 999999
+                      unknownImagePauseMilliseconds: 15000
+                    useMockMode: false
+                  fullnameOverride: ''
+                  imageGetter:
+                    createImagesOnly: false
+                    host: localhost
+                    imagePullerType: skopeo
+                    port: 3004
+                    resources:
+                      requests:
+                        cpu: 300m
+                        memory: 1300Mi
+                  imageProcessor:
+                    enabled: false
+                    resources:
+                      requests:
+                        cpu: 300m
+                        memory: 1300Mi
+                  imagePullSecrets: []
+                  imageTag: 2.2.5
+                  nameOverride: ''
+                  processor:
+                    annotationIntervalSeconds: 30
+                    certificate: ''
+                    certificateKey: ''
+                    dumpIntervalMinutes: 30
+                    port: 3002
+                  prometheus:
+                    affinity: {}
+                    enabled: false
+                    expose: None
+                    imageTag: v2.1.0
+                    nodeSelector: {}
+                    podSecurityContext: {}
+                    registry: docker.io/prom
+                    resources:
+                      requests:
+                        cpu: 300m
+                        memory: 1300Mi
+                    securityContext: {}
+                    tolerations: []
+                  quayProcessor:
+                    enabled: false
+                    expose: None
+                    resources:
+                      requests:
+                        cpu: 300m
+                        memory: 1300Mi
+                  registry: docker.io/blackducksoftware
+                  scanner:
+                    blackDuckClientTimeoutSeconds: 600
+                    imageDirectory: /var/images
+                    port: 3003
+                    replicas: 1
+                    resources:
+                      requests:
+                        cpu: 300m
+                        memory: 1300Mi
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-blackduck-labels
+        spec:
+          remediationAction: inform
+          severity: high
+          object-templates:
+            - complianceType: mustnothave # Makes sure pods are not in any kind of black duck policy violations
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  labels:
+                    com.blackducksoftware.com.pod.overall-status: IN_VIOLATION
+                  namespace: default
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -182,18 +182,14 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: blackduck-operator
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: blackduck-operator
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-blackduck-operator
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
-    matchExpressions:
-      []  # selects all clusters if not specified
+    matchExpressions: [] # selects all clusters if not specified

--- a/community/SI-System-and-Information-Integrity/policy-falco-auditing.yaml
+++ b/community/SI-System-and-Information-Integrity/policy-falco-auditing.yaml
@@ -53,11 +53,11 @@ spec:
                       version: 3.2.0
                     storage:
                       files:
-                      - contents:
-                          source: data:text/plain;charset=utf-8;base64,YXBpVmVyc2lvbjogdjEKa2luZDogQ29uZmlnCmNsdXN0ZXJzOgotIG5hbWU6IGZhbGNvCiAgY2x1c3RlcjoKICAgICMgY2VydGlmaWNhdGUtYXV0aG9yaXR5OiAvcGF0aC90by9jYS5jcnQgIyBmb3IgaHR0cHMKICAgIHNlcnZlcjogaHR0cDovL2FwaS5jbHVzdGVyLmRldi5teWRvbWFpbi5jb206MzI3NjUvazhzLWF1ZGl0CmNvbnRleHRzOgotIGNvbnRleHQ6CiAgICBjbHVzdGVyOiBmYWxjbwogICAgdXNlcjogIiIKICBuYW1lOiBkZWZhdWx0LWNvbnRleHQKY3VycmVudC1jb250ZXh0OiBkZWZhdWx0LWNvbnRleHQKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOiBbXQo=
-                        filesystem: root
-                        mode: 384
-                        path: /var/log/kube-apiserver/webhook-config.yaml
+                        - contents:
+                            source: data:text/plain;charset=utf-8;base64,YXBpVmVyc2lvbjogdjEKa2luZDogQ29uZmlnCmNsdXN0ZXJzOgotIG5hbWU6IGZhbGNvCiAgY2x1c3RlcjoKICAgICMgY2VydGlmaWNhdGUtYXV0aG9yaXR5OiAvcGF0aC90by9jYS5jcnQgIyBmb3IgaHR0cHMKICAgIHNlcnZlcjogaHR0cDovL2FwaS5jbHVzdGVyLmRldi5teWRvbWFpbi5jb206MzI3NjUvazhzLWF1ZGl0CmNvbnRleHRzOgotIGNvbnRleHQ6CiAgICBjbHVzdGVyOiBmYWxjbwogICAgdXNlcjogIiIKICBuYW1lOiBkZWZhdWx0LWNvbnRleHQKY3VycmVudC1jb250ZXh0OiBkZWZhdWx0LWNvbnRleHQKcHJlZmVyZW5jZXM6IHt9CnVzZXJzOiBbXQo=
+                          filesystem: root
+                          mode: 384
+                          path: /var/log/kube-apiserver/webhook-config.yaml
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
@@ -77,7 +77,7 @@ spec:
                   unsupportedConfigOverrides:
                     apiServerArguments:
                       audit-webhook-config-file:
-                      - /var/log/kube-apiserver/webhook-config.yaml
+                        - /var/log/kube-apiserver/webhook-config.yaml
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -88,18 +88,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-falco-auditing
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-falco-auditing
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-falco-auditing
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/community/SI-System-and-Information-Integrity/policy-falco.yaml
+++ b/community/SI-System-and-Information-Integrity/policy-falco.yaml
@@ -59,7 +59,7 @@ spec:
                   namespace: falco-operator
                 spec:
                   targetNamespaces:
-                  - falco-operator
+                    - falco-operator
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
@@ -116,19 +116,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-falco
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-falco
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-falco
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}
-

--- a/community/SI-System-and-Information-Integrity/policy-sysdig.yaml
+++ b/community/SI-System-and-Information-Integrity/policy-sysdig.yaml
@@ -53,7 +53,7 @@ spec:
                   namespace: sysdig-operator
                 spec:
                   targetNamespaces:
-                  - sysdig-operator
+                    - sysdig-operator
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
@@ -113,18 +113,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-sysdig
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-sysdig
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-sysdig
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/deploy/placement.yaml
+++ b/deploy/placement.yaml
@@ -3,9 +3,6 @@ kind: PlacementRule
 metadata:
   name: demo-stable-policies-placement
 spec:
-  clusterConditions:
-    - status: "True"
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - key: local-cluster

--- a/policygenerator/policy-sets/community/zts-xcrypt/input/placementrule.yaml
+++ b/policygenerator/policy-sets/community/zts-xcrypt/input/placementrule.yaml
@@ -6,9 +6,6 @@ metadata:
   name: placement-dev
   namespace: zts-xcrypt
 spec:
-  clusterConditions:
-    - status: "True"
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/policygenerator/policy-sets/community/zts-xcrypt/policy-zts-xcrypt-version-1.yaml
+++ b/policygenerator/policy-sets/community/zts-xcrypt/policy-zts-xcrypt-version-1.yaml
@@ -2,555 +2,552 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
-    annotations:
-        policy.open-cluster-management.io/categories: CM Configuration Management
-        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
-        policy.open-cluster-management.io/standards: NIST 800-53
-    name: policy-zts-rbac
-    namespace: zts-xcrypt
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST 800-53
+  name: policy-zts-rbac
+  namespace: zts-xcrypt
 spec:
-    disabled: false
-    policy-templates:
-        - objectDefinition:
-            apiVersion: policy.open-cluster-management.io/v1
-            kind: ConfigurationPolicy
-            metadata:
-                name: policy-zts-rbac
-            spec:
-                object-templates:
-                    - complianceType: musthave
-                      objectDefinition:
-                        apiVersion: v1
-                        kind: Namespace
-                        metadata:
-                            name: zts-xcrypt
-                    - complianceType: musthave
-                      objectDefinition:
-                        apiVersion: v1
-                        kind: ServiceAccount
-                        metadata:
-                            name: zts-xcrypt-operator
-                            namespace: zts-xcrypt
-                    - complianceType: musthave
-                      objectDefinition:
-                        apiVersion: rbac.authorization.k8s.io/v1
-                        kind: ClusterRole
-                        metadata:
-                            name: zts-xcrypt-operator
-                            namespace: zts-xcrypt
-                        rules:
-                            - apiGroups:
-                                - security.openshift.io
-                              resourceNames:
-                                - privileged
-                                - anyuid
-                                - hostmount-anyuid
-                                - hostnetwork
-                              resources:
-                                - securitycontextconstraints
-                              verbs:
-                                - use
-                            - apiGroups:
-                                - ""
-                              resources:
-                                - pods
-                                - services
-                                - services/finalizers
-                                - endpoints
-                                - persistentvolumeclaims
-                                - events
-                                - configmaps
-                                - secrets
-                              verbs:
-                                - create
-                                - delete
-                                - get
-                                - list
-                                - patch
-                                - update
-                                - watch
-                            - apiGroups:
-                                - xcrypt.zettaset.com
-                              resources:
-                                - '*'
-                              verbs:
-                                - create
-                                - delete
-                                - get
-                                - list
-                                - patch
-                                - update
-                                - watch
-                            - apiGroups:
-                                - apps
-                              resources:
-                                - deployments
-                                - daemonsets
-                                - replicasets
-                                - statefulsets
-                              verbs:
-                                - create
-                                - delete
-                                - get
-                                - list
-                                - patch
-                                - update
-                                - watch
-                            - apiGroups:
-                                - apps
-                              resourceNames:
-                                - zts-xcrypt-operator
-                              resources:
-                                - deployments/finalizers
-                              verbs:
-                                - update
-                            - apiGroups:
-                                - storage.k8s.io
-                              resources:
-                                - csidrivers
-                              verbs:
-                                - create
-                                - delete
-                                - get
-                                - list
-                                - patch
-                                - update
-                                - watch
-                    - complianceType: musthave
-                      objectDefinition:
-                        apiVersion: rbac.authorization.k8s.io/v1
-                        kind: ClusterRoleBinding
-                        metadata:
-                            name: zts-xcrypt-operator
-                            namespace: zts-xcrypt
-                        roleRef:
-                            apiGroup: rbac.authorization.k8s.io
-                            kind: ClusterRole
-                            name: zts-xcrypt-operator
-                        subjects:
-                            - kind: ServiceAccount
-                              name: zts-xcrypt-operator
-                              namespace: zts-xcrypt
-                    - complianceType: musthave
-                      objectDefinition:
-                        apiVersion: v1
-                        kind: ServiceAccount
-                        metadata:
-                            name: zts-csi-controller-sa
-                            namespace: zts-xcrypt
-                    - complianceType: musthave
-                      objectDefinition:
-                        apiVersion: rbac.authorization.k8s.io/v1
-                        kind: ClusterRole
-                        metadata:
-                            name: zts-external-provisioner-role
-                            namespace: zts-xcrypt
-                        rules:
-                            - apiGroups:
-                                - ""
-                              resources:
-                                - persistentvolumes
-                              verbs:
-                                - get
-                                - list
-                                - watch
-                                - create
-                                - delete
-                                - patch
-                            - apiGroups:
-                                - ""
-                              resources:
-                                - persistentvolumeclaims
-                              verbs:
-                                - get
-                                - list
-                                - watch
-                                - update
-                            - apiGroups:
-                                - storage.k8s.io
-                              resources:
-                                - storageclasses
-                              verbs:
-                                - get
-                                - list
-                                - watch
-                            - apiGroups:
-                                - ""
-                              resources:
-                                - events
-                              verbs:
-                                - list
-                                - watch
-                                - create
-                                - update
-                                - patch
-                            - apiGroups:
-                                - storage.k8s.io
-                              resources:
-                                - csinodes
-                              verbs:
-                                - get
-                                - list
-                                - watch
-                            - apiGroups:
-                                - ""
-                              resources:
-                                - nodes
-                              verbs:
-                                - get
-                                - list
-                                - watch
-                            - apiGroups:
-                                - coordination.k8s.io
-                              resources:
-                                - leases
-                              verbs:
-                                - get
-                                - watch
-                                - list
-                                - delete
-                                - update
-                                - create
-                            - apiGroups:
-                                - security.openshift.io
-                              resourceNames:
-                                - privileged
-                                - anyuid
-                                - hostmount-anyuid
-                                - hostnetwork
-                              resources:
-                                - securitycontextconstraints
-                              verbs:
-                                - use
-                    - complianceType: musthave
-                      objectDefinition:
-                        apiVersion: rbac.authorization.k8s.io/v1
-                        kind: ClusterRoleBinding
-                        metadata:
-                            name: zts-csi-provisioner-binding
-                        roleRef:
-                            apiGroup: rbac.authorization.k8s.io
-                            kind: ClusterRole
-                            name: zts-external-provisioner-role
-                        subjects:
-                            - kind: ServiceAccount
-                              name: zts-csi-controller-sa
-                              namespace: zts-xcrypt
-                    - complianceType: musthave
-                      objectDefinition:
-                        apiVersion: rbac.authorization.k8s.io/v1
-                        kind: ClusterRole
-                        metadata:
-                            name: zts-external-attacher-role
-                            namespace: zts-xcrypt
-                        rules:
-                            - apiGroups:
-                                - ""
-                              resources:
-                                - persistentvolumes
-                              verbs:
-                                - get
-                                - list
-                                - watch
-                                - update
-                                - patch
-                            - apiGroups:
-                                - ""
-                              resources:
-                                - nodes
-                              verbs:
-                                - get
-                                - list
-                                - watch
-                            - apiGroups:
-                                - csi.storage.k8s.io
-                              resources:
-                                - csinodeinfos
-                              verbs:
-                                - get
-                                - list
-                                - watch
-                            - apiGroups:
-                                - storage.k8s.io
-                              resources:
-                                - volumeattachments
-                              verbs:
-                                - get
-                                - list
-                                - watch
-                                - update
-                                - patch
-                            - apiGroups:
-                                - storage.k8s.io
-                              resources:
-                                - volumeattachments/status
-                              verbs:
-                                - patch
-                            - apiGroups:
-                                - security.openshift.io
-                              resourceNames:
-                                - privileged
-                                - anyuid
-                                - hostmount-anyuid
-                                - hostnetwork
-                              resources:
-                                - securitycontextconstraints
-                              verbs:
-                                - use
-                    - complianceType: musthave
-                      objectDefinition:
-                        apiVersion: rbac.authorization.k8s.io/v1
-                        kind: ClusterRoleBinding
-                        metadata:
-                            name: zts-csi-attacher-binding
-                            namespace: zts-xcrypt
-                        roleRef:
-                            apiGroup: rbac.authorization.k8s.io
-                            kind: ClusterRole
-                            name: zts-external-attacher-role
-                        subjects:
-                            - kind: ServiceAccount
-                              name: zts-csi-controller-sa
-                              namespace: zts-xcrypt
-                remediationAction: enforce
-                severity: medium
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-zts-rbac
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Namespace
+                metadata:
+                  name: zts-xcrypt
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: ServiceAccount
+                metadata:
+                  name: zts-xcrypt-operator
+                  namespace: zts-xcrypt
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: rbac.authorization.k8s.io/v1
+                kind: ClusterRole
+                metadata:
+                  name: zts-xcrypt-operator
+                  namespace: zts-xcrypt
+                rules:
+                  - apiGroups:
+                      - security.openshift.io
+                    resourceNames:
+                      - privileged
+                      - anyuid
+                      - hostmount-anyuid
+                      - hostnetwork
+                    resources:
+                      - securitycontextconstraints
+                    verbs:
+                      - use
+                  - apiGroups:
+                      - ""
+                    resources:
+                      - pods
+                      - services
+                      - services/finalizers
+                      - endpoints
+                      - persistentvolumeclaims
+                      - events
+                      - configmaps
+                      - secrets
+                    verbs:
+                      - create
+                      - delete
+                      - get
+                      - list
+                      - patch
+                      - update
+                      - watch
+                  - apiGroups:
+                      - xcrypt.zettaset.com
+                    resources:
+                      - '*'
+                    verbs:
+                      - create
+                      - delete
+                      - get
+                      - list
+                      - patch
+                      - update
+                      - watch
+                  - apiGroups:
+                      - apps
+                    resources:
+                      - deployments
+                      - daemonsets
+                      - replicasets
+                      - statefulsets
+                    verbs:
+                      - create
+                      - delete
+                      - get
+                      - list
+                      - patch
+                      - update
+                      - watch
+                  - apiGroups:
+                      - apps
+                    resourceNames:
+                      - zts-xcrypt-operator
+                    resources:
+                      - deployments/finalizers
+                    verbs:
+                      - update
+                  - apiGroups:
+                      - storage.k8s.io
+                    resources:
+                      - csidrivers
+                    verbs:
+                      - create
+                      - delete
+                      - get
+                      - list
+                      - patch
+                      - update
+                      - watch
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: rbac.authorization.k8s.io/v1
+                kind: ClusterRoleBinding
+                metadata:
+                  name: zts-xcrypt-operator
+                  namespace: zts-xcrypt
+                roleRef:
+                  apiGroup: rbac.authorization.k8s.io
+                  kind: ClusterRole
+                  name: zts-xcrypt-operator
+                subjects:
+                  - kind: ServiceAccount
+                    name: zts-xcrypt-operator
+                    namespace: zts-xcrypt
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: ServiceAccount
+                metadata:
+                  name: zts-csi-controller-sa
+                  namespace: zts-xcrypt
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: rbac.authorization.k8s.io/v1
+                kind: ClusterRole
+                metadata:
+                  name: zts-external-provisioner-role
+                  namespace: zts-xcrypt
+                rules:
+                  - apiGroups:
+                      - ""
+                    resources:
+                      - persistentvolumes
+                    verbs:
+                      - get
+                      - list
+                      - watch
+                      - create
+                      - delete
+                      - patch
+                  - apiGroups:
+                      - ""
+                    resources:
+                      - persistentvolumeclaims
+                    verbs:
+                      - get
+                      - list
+                      - watch
+                      - update
+                  - apiGroups:
+                      - storage.k8s.io
+                    resources:
+                      - storageclasses
+                    verbs:
+                      - get
+                      - list
+                      - watch
+                  - apiGroups:
+                      - ""
+                    resources:
+                      - events
+                    verbs:
+                      - list
+                      - watch
+                      - create
+                      - update
+                      - patch
+                  - apiGroups:
+                      - storage.k8s.io
+                    resources:
+                      - csinodes
+                    verbs:
+                      - get
+                      - list
+                      - watch
+                  - apiGroups:
+                      - ""
+                    resources:
+                      - nodes
+                    verbs:
+                      - get
+                      - list
+                      - watch
+                  - apiGroups:
+                      - coordination.k8s.io
+                    resources:
+                      - leases
+                    verbs:
+                      - get
+                      - watch
+                      - list
+                      - delete
+                      - update
+                      - create
+                  - apiGroups:
+                      - security.openshift.io
+                    resourceNames:
+                      - privileged
+                      - anyuid
+                      - hostmount-anyuid
+                      - hostnetwork
+                    resources:
+                      - securitycontextconstraints
+                    verbs:
+                      - use
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: rbac.authorization.k8s.io/v1
+                kind: ClusterRoleBinding
+                metadata:
+                  name: zts-csi-provisioner-binding
+                roleRef:
+                  apiGroup: rbac.authorization.k8s.io
+                  kind: ClusterRole
+                  name: zts-external-provisioner-role
+                subjects:
+                  - kind: ServiceAccount
+                    name: zts-csi-controller-sa
+                    namespace: zts-xcrypt
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: rbac.authorization.k8s.io/v1
+                kind: ClusterRole
+                metadata:
+                  name: zts-external-attacher-role
+                  namespace: zts-xcrypt
+                rules:
+                  - apiGroups:
+                      - ""
+                    resources:
+                      - persistentvolumes
+                    verbs:
+                      - get
+                      - list
+                      - watch
+                      - update
+                      - patch
+                  - apiGroups:
+                      - ""
+                    resources:
+                      - nodes
+                    verbs:
+                      - get
+                      - list
+                      - watch
+                  - apiGroups:
+                      - csi.storage.k8s.io
+                    resources:
+                      - csinodeinfos
+                    verbs:
+                      - get
+                      - list
+                      - watch
+                  - apiGroups:
+                      - storage.k8s.io
+                    resources:
+                      - volumeattachments
+                    verbs:
+                      - get
+                      - list
+                      - watch
+                      - update
+                      - patch
+                  - apiGroups:
+                      - storage.k8s.io
+                    resources:
+                      - volumeattachments/status
+                    verbs:
+                      - patch
+                  - apiGroups:
+                      - security.openshift.io
+                    resourceNames:
+                      - privileged
+                      - anyuid
+                      - hostmount-anyuid
+                      - hostnetwork
+                    resources:
+                      - securitycontextconstraints
+                    verbs:
+                      - use
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: rbac.authorization.k8s.io/v1
+                kind: ClusterRoleBinding
+                metadata:
+                  name: zts-csi-attacher-binding
+                  namespace: zts-xcrypt
+                roleRef:
+                  apiGroup: rbac.authorization.k8s.io
+                  kind: ClusterRole
+                  name: zts-external-attacher-role
+                subjects:
+                  - kind: ServiceAccount
+                    name: zts-csi-controller-sa
+                    namespace: zts-xcrypt
+          remediationAction: enforce
+          severity: medium
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
-    annotations:
-        policy.open-cluster-management.io/categories: CM Configuration Management
-        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
-        policy.open-cluster-management.io/standards: NIST 800-53
-    name: policy-zts-install-xcrypts-crd-v1
-    namespace: zts-xcrypt
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST 800-53
+  name: policy-zts-install-xcrypts-crd-v1
+  namespace: zts-xcrypt
 spec:
-    disabled: false
-    policy-templates:
-        - objectDefinition:
-            apiVersion: policy.open-cluster-management.io/v1
-            kind: ConfigurationPolicy
-            metadata:
-                name: policy-zts-install-xcrypts-crd-v1
-            spec:
-                object-templates:
-                    - complianceType: musthave
-                      objectDefinition:
-                        apiVersion: apiextensions.k8s.io/v1
-                        kind: CustomResourceDefinition
-                        metadata:
-                            name: xcrypts.xcrypt.zettaset.com
-                        spec:
-                            group: xcrypt.zettaset.com
-                            names:
-                                kind: XCrypt
-                                listKind: XCryptList
-                                plural: xcrypts
-                                singular: xcrypt
-                            scope: Namespaced
-                            versions:
-                                - name: v1
-                                  schema:
-                                    openAPIV3Schema:
-                                        description: XCrypt is the Schema for the xcrypts API
-                                        properties:
-                                            apiVersion:
-                                                description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                                                type: string
-                                            kind:
-                                                description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                                                type: string
-                                            metadata:
-                                                type: object
-                                            spec:
-                                                description: XCryptSpec defines the desired state of XCrypt
-                                                properties:
-                                                    replicas:
-                                                        format: int32
-                                                        type: integer
-                                                required:
-                                                    - replicas
-                                                type: object
-                                            status:
-                                                description: XCryptStatus defines the observed state of XCrypt
-                                                properties:
-                                                    podNames:
-                                                        items:
-                                                            type: string
-                                                        type: array
-                                                    replicas:
-                                                        format: int32
-                                                        type: integer
-                                                required:
-                                                    - podNames
-                                                    - replicas
-                                                type: object
-                                        type: object
-                                  served: true
-                                  storage: true
-                remediationAction: enforce
-                severity: medium
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-zts-install-xcrypts-crd-v1
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: apiextensions.k8s.io/v1
+                kind: CustomResourceDefinition
+                metadata:
+                  name: xcrypts.xcrypt.zettaset.com
+                spec:
+                  group: xcrypt.zettaset.com
+                  names:
+                    kind: XCrypt
+                    listKind: XCryptList
+                    plural: xcrypts
+                    singular: xcrypt
+                  scope: Namespaced
+                  versions:
+                    - name: v1
+                      schema:
+                        openAPIV3Schema:
+                          description: XCrypt is the Schema for the xcrypts API
+                          properties:
+                            apiVersion:
+                              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                              type: string
+                            kind:
+                              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            metadata:
+                              type: object
+                            spec:
+                              description: XCryptSpec defines the desired state of XCrypt
+                              properties:
+                                replicas:
+                                  format: int32
+                                  type: integer
+                              required:
+                                - replicas
+                              type: object
+                            status:
+                              description: XCryptStatus defines the observed state of XCrypt
+                              properties:
+                                podNames:
+                                  items:
+                                    type: string
+                                  type: array
+                                replicas:
+                                  format: int32
+                                  type: integer
+                              required:
+                                - podNames
+                                - replicas
+                              type: object
+                          type: object
+                      served: true
+                      storage: true
+          remediationAction: enforce
+          severity: medium
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
-    annotations:
-        policy.open-cluster-management.io/categories: CM Configuration Management
-        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
-        policy.open-cluster-management.io/standards: NIST 800-53
-    name: policy-zts-xcrypts-deployment
-    namespace: zts-xcrypt
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST 800-53
+  name: policy-zts-xcrypts-deployment
+  namespace: zts-xcrypt
 spec:
-    disabled: false
-    policy-templates:
-        - objectDefinition:
-            apiVersion: policy.open-cluster-management.io/v1
-            kind: ConfigurationPolicy
-            metadata:
-                name: policy-zts-xcrypts-deployment
-            spec:
-                object-templates:
-                    - complianceType: musthave
-                      objectDefinition:
-                        apiVersion: apps/v1
-                        kind: Deployment
-                        metadata:
-                            name: zts-xcrypt-operator
-                            namespace: zts-xcrypt
-                        spec:
-                            replicas: 1
-                            selector:
-                                matchLabels:
-                                    name: zts-xcrypt-operator
-                            template:
-                                metadata:
-                                    labels:
-                                        name: zts-xcrypt-operator
-                                spec:
-                                    affinity:
-                                        nodeAffinity:
-                                            requiredDuringSchedulingIgnoredDuringExecution:
-                                                nodeSelectorTerms:
-                                                    - matchExpressions:
-                                                        - key: zts-master
-                                                          operator: In
-                                                          values:
-                                                            - "true"
-                                    containers:
-                                        - command:
-                                            - zts-xcrypt-operator
-                                          env:
-                                            - name: WATCH_NAMESPACE
-                                              valueFrom:
-                                                fieldRef:
-                                                    fieldPath: metadata.namespace
-                                            - name: POD_NAME
-                                              valueFrom:
-                                                fieldRef:
-                                                    fieldPath: metadata.name
-                                            - name: OPERATOR_NAME
-                                              value: zts-xcrypt-operator
-                                            - name: AUTH_TOKEN_NAME
-                                              value: zts-dockerhub-token
-                                            - name: RELATED_IMAGE_CA
-                                              value: zettasetimg/zts-ca-server:zts-ca-server-14
-                                            - name: RELATED_IMAGE_KMIP
-                                              value: zettasetimg/zts-kmip-server:zts-kmip-server-7-f4fbeb69a
-                                            - name: RELATED_IMAGE_LS
-                                              value: zettasetimg/zts-license-server:zts-license-server-6
-                                            - name: RELATED_IMAGE_HM
-                                              value: zettasetimg/zts-host-manager:zts-host-manager-13-local-bec5a4
-                                            - name: RELATED_IMAGE_CSI_DRIVER
-                                              value: zettasetimg/zts-csi-driver:zts-csi-driver-v1.0.6-167006
-                                            - name: RELATED_IMAGE_CSI_PROVISIONER
-                                              value: quay.io/k8scsi/csi-provisioner:v1.6.0
-                                            - name: RELATED_IMAGE_CSI_ATTACHER
-                                              value: quay.io/k8scsi/csi-attacher:v3.1.0
-                                            - name: RELATED_IMAGE_LIVENSSPROBE
-                                              value: quay.io/k8scsi/livenessprobe:v1.1.0
-                                            - name: RELATED_IMAGE_CSI_NODE_DRIVER_REGISTRAR
-                                              value: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
-                                          image: zettasetimg/zts-xcrypt-operator:zts-xcrypt-operator-v1.0.3-c4fd66
-                                          imagePullPolicy: IfNotPresent
-                                          name: zts-xcrypt-operator
-                                    imagePullSecrets:
-                                        - name: zts-dockerhub-token
-                                    serviceAccountName: zts-xcrypt-operator
-                remediationAction: enforce
-                severity: medium
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-zts-xcrypts-deployment
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: apps/v1
+                kind: Deployment
+                metadata:
+                  name: zts-xcrypt-operator
+                  namespace: zts-xcrypt
+                spec:
+                  replicas: 1
+                  selector:
+                    matchLabels:
+                      name: zts-xcrypt-operator
+                  template:
+                    metadata:
+                      labels:
+                        name: zts-xcrypt-operator
+                    spec:
+                      affinity:
+                        nodeAffinity:
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            nodeSelectorTerms:
+                              - matchExpressions:
+                                  - key: zts-master
+                                    operator: In
+                                    values:
+                                      - "true"
+                      containers:
+                        - command:
+                            - zts-xcrypt-operator
+                          env:
+                            - name: WATCH_NAMESPACE
+                              valueFrom:
+                                fieldRef:
+                                  fieldPath: metadata.namespace
+                            - name: POD_NAME
+                              valueFrom:
+                                fieldRef:
+                                  fieldPath: metadata.name
+                            - name: OPERATOR_NAME
+                              value: zts-xcrypt-operator
+                            - name: AUTH_TOKEN_NAME
+                              value: zts-dockerhub-token
+                            - name: RELATED_IMAGE_CA
+                              value: zettasetimg/zts-ca-server:zts-ca-server-14
+                            - name: RELATED_IMAGE_KMIP
+                              value: zettasetimg/zts-kmip-server:zts-kmip-server-7-f4fbeb69a
+                            - name: RELATED_IMAGE_LS
+                              value: zettasetimg/zts-license-server:zts-license-server-6
+                            - name: RELATED_IMAGE_HM
+                              value: zettasetimg/zts-host-manager:zts-host-manager-13-local-bec5a4
+                            - name: RELATED_IMAGE_CSI_DRIVER
+                              value: zettasetimg/zts-csi-driver:zts-csi-driver-v1.0.6-167006
+                            - name: RELATED_IMAGE_CSI_PROVISIONER
+                              value: quay.io/k8scsi/csi-provisioner:v1.6.0
+                            - name: RELATED_IMAGE_CSI_ATTACHER
+                              value: quay.io/k8scsi/csi-attacher:v3.1.0
+                            - name: RELATED_IMAGE_LIVENSSPROBE
+                              value: quay.io/k8scsi/livenessprobe:v1.1.0
+                            - name: RELATED_IMAGE_CSI_NODE_DRIVER_REGISTRAR
+                              value: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+                          image: zettasetimg/zts-xcrypt-operator:zts-xcrypt-operator-v1.0.3-c4fd66
+                          imagePullPolicy: IfNotPresent
+                          name: zts-xcrypt-operator
+                      imagePullSecrets:
+                        - name: zts-dockerhub-token
+                      serviceAccountName: zts-xcrypt-operator
+          remediationAction: enforce
+          severity: medium
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
-    annotations:
-        policy.open-cluster-management.io/categories: CM Configuration Management
-        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
-        policy.open-cluster-management.io/standards: NIST 800-53
-    name: policy-zts-xcrypt-operator-executor-deployment
-    namespace: zts-xcrypt
+  annotations:
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    policy.open-cluster-management.io/standards: NIST 800-53
+  name: policy-zts-xcrypt-operator-executor-deployment
+  namespace: zts-xcrypt
 spec:
-    disabled: false
-    policy-templates:
-        - objectDefinition:
-            apiVersion: policy.open-cluster-management.io/v1
-            kind: ConfigurationPolicy
-            metadata:
-                name: policy-zts-xcrypt-operator-executor-deployment
-            spec:
-                object-templates:
-                    - complianceType: musthave
-                      objectDefinition:
-                        apiVersion: xcrypt.zettaset.com/v1
-                        kind: XCrypt
-                        metadata:
-                            name: xcrypt-launcher
-                            namespace: zts-xcrypt
-                        spec:
-                            replicas: 1
-                remediationAction: enforce
-                severity: medium
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-zts-xcrypt-operator-executor-deployment
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: xcrypt.zettaset.com/v1
+                kind: XCrypt
+                metadata:
+                  name: xcrypt-launcher
+                  namespace: zts-xcrypt
+                spec:
+                  replicas: 1
+          remediationAction: enforce
+          severity: medium
 ---
 apiVersion: policy.open-cluster-management.io/v1beta1
 kind: PolicySet
 metadata:
-    name: policyset-xcrypt
-    namespace: zts-xcrypt
+  name: policyset-xcrypt
+  namespace: zts-xcrypt
 spec:
-    description: this is a zts-xcrypt
-    policies:
-        - policy-zts-install-xcrypts-crd-v1
-        - policy-zts-rbac
-        - policy-zts-xcrypt-operator-executor-deployment
-        - policy-zts-xcrypts-deployment
+  description: this is a zts-xcrypt
+  policies:
+    - policy-zts-install-xcrypts-crd-v1
+    - policy-zts-rbac
+    - policy-zts-xcrypt-operator-executor-deployment
+    - policy-zts-xcrypts-deployment
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
-    labels:
-        custom: myApp
-    name: placement-dev
-    namespace: zts-xcrypt
+  labels:
+    custom: myApp
+  name: placement-dev
+  namespace: zts-xcrypt
 spec:
-    clusterConditions:
-        - status: "True"
-          type: ManagedClusterConditionAvailable
-    clusterSelector:
-        matchExpressions:
-            - key: environment
-              operator: In
-              values:
-                - dev
+  clusterSelector:
+    matchExpressions:
+      - key: environment
+        operator: In
+        values:
+          - dev
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-xcrypt
-    namespace: zts-xcrypt
+  name: binding-xcrypt
+  namespace: zts-xcrypt
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
-    name: placement-dev
+  apiGroup: apps.open-cluster-management.io
+  kind: PlacementRule
+  name: placement-dev
 subjects:
-    - apiGroup: policy.open-cluster-management.io
-      kind: PolicySet
-      name: policyset-xcrypt
+  - apiGroup: policy.open-cluster-management.io
+    kind: PolicySet
+    name: policyset-xcrypt

--- a/policygenerator/subscription.yaml
+++ b/policygenerator/subscription.yaml
@@ -56,9 +56,6 @@ metadata:
   name: policy-generator-demo-placement
   namespace: policy-generator-demo
 spec:
-  clusterConditions:
-    - status: "True"
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - key: local-cluster

--- a/stable/AC-Access-Control/policy-limitclusteradmin.yaml
+++ b/stable/AC-Access-Control/policy-limitclusteradmin.yaml
@@ -29,18 +29,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-limitclusteradmin
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-limitclusteradmin
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-limitclusteradmin
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/stable/AC-Access-Control/policy-role.yaml
+++ b/stable/AC-Access-Control/policy-role.yaml
@@ -30,7 +30,7 @@ spec:
                 rules:
                   - apiGroups: ["extensions", "apps"]
                     resources: ["deployments"]
-                    verbs: ["get", "list", "watch", "delete","patch"]
+                    verbs: ["get", "list", "watch", "delete", "patch"]
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -41,18 +41,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-role
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-role
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-role
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/stable/AC-Access-Control/policy-rolebinding.yaml
+++ b/stable/AC-Access-Control/policy-rolebinding.yaml
@@ -28,9 +28,9 @@ spec:
                 metadata:
                   name: sample-rolebinding
                 subjects:
-                - kind: User
-                  name: admin # Name is case sensitive
-                  apiGroup: rbac.authorization.k8s.io
+                  - kind: User
+                    name: admin # Name is case sensitive
+                    apiGroup: rbac.authorization.k8s.io
                 roleRef:
                   kind: Role #this must be Role or ClusterRole
                   name: operator # this must match the name of the Role or ClusterRole you wish to bind to
@@ -45,18 +45,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-rolebinding
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-rolebinding
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-rolebinding
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/stable/CA-Security-Assessment-and-Authorization/policy-compliance-operator-install.yaml
+++ b/stable/CA-Security-Assessment-and-Authorization/policy-compliance-operator-install.yaml
@@ -56,7 +56,7 @@ spec:
         metadata:
           name: comp-operator-subscription
         spec:
-          remediationAction: inform  # will be overridden by remediationAction in parent policy
+          remediationAction: inform # will be overridden by remediationAction in parent policy
           severity: high
           object-templates:
             - complianceType: musthave
@@ -77,7 +77,7 @@ spec:
         metadata:
           name: comp-operator-status
         spec:
-          remediationAction: inform  # will be overridden by remediationAction in parent policy
+          remediationAction: inform # will be overridden by remediationAction in parent policy
           severity: high
           object-templates:
             - complianceType: musthave
@@ -89,7 +89,7 @@ spec:
                 spec:
                   displayName: Compliance Operator
                 status:
-                  phase: Succeeded   # check the csv status to determine if operator is running or not
+                  phase: Succeeded # check the csv status to determine if operator is running or not
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -109,9 +109,6 @@ kind: PlacementRule
 metadata:
   name: placement-policy-comp-operator
 spec:
-  clusterConditions:
-    - status: "True"
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: vendor, operator: In, values: ["OpenShift"]}

--- a/stable/CM-Configuration-Management/policy-compliance-operator-cis-scan.yaml
+++ b/stable/CM-Configuration-Management/policy-compliance-operator-cis-scan.yaml
@@ -30,17 +30,17 @@ spec:
                   name: cis
                   namespace: openshift-compliance
                 profiles:
-                - apiGroup: compliance.openshift.io/v1alpha1
-                  kind: Profile
-                  name: ocp4-cis
-                - apiGroup: compliance.openshift.io/v1alpha1
-                  kind: Profile
-                  name: ocp4-cis-node
+                  - apiGroup: compliance.openshift.io/v1alpha1
+                    kind: Profile
+                    name: ocp4-cis
+                  - apiGroup: compliance.openshift.io/v1alpha1
+                    kind: Profile
+                    name: ocp4-cis-node
                 settingsRef:
                   apiGroup: compliance.openshift.io/v1alpha1
                   kind: ScanSetting
                   name: default
-    - objectDefinition: 
+    - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
         metadata:
@@ -86,18 +86,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-cis-scan
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-cis-scan
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-cis-scan
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: vendor, operator: In, values: ["OpenShift"]}

--- a/stable/CM-Configuration-Management/policy-compliance-operator-e8-scan.yaml
+++ b/stable/CM-Configuration-Management/policy-compliance-operator-e8-scan.yaml
@@ -27,20 +27,20 @@ spec:
                 apiVersion: compliance.openshift.io/v1alpha1
                 kind: ScanSettingBinding
                 metadata:
-                  name: e8 
+                  name: e8
                   namespace: openshift-compliance
                 profiles:
-                - apiGroup: compliance.openshift.io/v1alpha1
-                  kind: Profile
-                  name: ocp4-e8
-                - apiGroup: compliance.openshift.io/v1alpha1
-                  kind: Profile
-                  name: rhcos4-e8
+                  - apiGroup: compliance.openshift.io/v1alpha1
+                    kind: Profile
+                    name: ocp4-e8
+                  - apiGroup: compliance.openshift.io/v1alpha1
+                    kind: Profile
+                    name: rhcos4-e8
                 settingsRef:
                   apiGroup: compliance.openshift.io/v1alpha1
                   kind: ScanSetting
                   name: default
-    - objectDefinition: 
+    - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
         metadata:
@@ -86,18 +86,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-e8-scan
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-e8-scan
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-e8-scan
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: vendor, operator: In, values: ["OpenShift"]}

--- a/stable/CM-Configuration-Management/policy-gatekeeper-operator-downstream.yaml
+++ b/stable/CM-Configuration-Management/policy-gatekeeper-operator-downstream.yaml
@@ -14,102 +14,102 @@ spec:
   remediationAction: inform
   disabled: false
   policy-templates:
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: ConfigurationPolicy
-      metadata:
-        name: gatekeeper-operator-product-sub
-      spec:
-        remediationAction: inform
-        severity: high
-        object-templates:
-          - complianceType: musthave
-            objectDefinition:
-              apiVersion: operators.coreos.com/v1alpha1
-              kind: Subscription
-              metadata:
-                name: gatekeeper-operator-product
-                namespace: openshift-operators
-              spec:
-                channel: stable
-                installPlanApproval: Automatic
-                name: gatekeeper-operator-product
-                source: redhat-operators
-                sourceNamespace: openshift-marketplace
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: ConfigurationPolicy
-      metadata:
-        name: gatekeeper-operator-status
-      spec:
-        remediationAction: inform
-        severity: high
-        object-templates:
-          - complianceType: musthave
-            objectDefinition:
-              apiVersion: operators.coreos.com/v1alpha1
-              kind: ClusterServiceVersion
-              metadata:
-                namespace: openshift-gatekeeper-system
-              spec:
-                displayName: Gatekeeper Operator
-              status:
-                phase: Succeeded   # check the csv status to determine if operator is running or not
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: ConfigurationPolicy
-      metadata:
-        name: gatekeeper
-      spec:
-        remediationAction: inform
-        severity: high
-        object-templates:
-          - complianceType: musthave
-            objectDefinition:
-              apiVersion: operator.gatekeeper.sh/v1alpha1
-              kind: Gatekeeper
-              metadata:
-                name: gatekeeper
-              spec:
-                audit:
-                  auditChunkSize: 500
-                  logLevel: INFO
-                  replicas: 1
-                validatingWebhook: Enabled
-                mutatingWebhook: Disabled
-                webhook:
-                  emitAdmissionEvents: Enabled
-                  logLevel: INFO
-                  replicas: 2
-  - objectDefinition:
-      apiVersion: policy.open-cluster-management.io/v1
-      kind: ConfigurationPolicy
-      metadata:
-        name: gatekeeper-status
-      spec:
-        remediationAction: inform
-        severity: high
-        object-templates:
-          - complianceType: musthave
-            objectDefinition:
-              apiVersion: v1
-              kind: Pod
-              metadata:
-                namespace: openshift-gatekeeper-system
-                labels:
-                  control-plane: audit-controller
-              status:
-                phase: Running   # check the pod status to determine if operator is running or not
-          - complianceType: musthave
-            objectDefinition:
-              apiVersion: v1
-              kind: Pod
-              metadata:
-                namespace: openshift-gatekeeper-system
-                labels:
-                  control-plane: controller-manager
-              status:
-                phase: Running   # check the pod status to determine if operator is running or not
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: gatekeeper-operator-product-sub
+        spec:
+          remediationAction: inform
+          severity: high
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operators.coreos.com/v1alpha1
+                kind: Subscription
+                metadata:
+                  name: gatekeeper-operator-product
+                  namespace: openshift-operators
+                spec:
+                  channel: stable
+                  installPlanApproval: Automatic
+                  name: gatekeeper-operator-product
+                  source: redhat-operators
+                  sourceNamespace: openshift-marketplace
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: gatekeeper-operator-status
+        spec:
+          remediationAction: inform
+          severity: high
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operators.coreos.com/v1alpha1
+                kind: ClusterServiceVersion
+                metadata:
+                  namespace: openshift-gatekeeper-system
+                spec:
+                  displayName: Gatekeeper Operator
+                status:
+                  phase: Succeeded # check the csv status to determine if operator is running or not
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: gatekeeper
+        spec:
+          remediationAction: inform
+          severity: high
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operator.gatekeeper.sh/v1alpha1
+                kind: Gatekeeper
+                metadata:
+                  name: gatekeeper
+                spec:
+                  audit:
+                    auditChunkSize: 500
+                    logLevel: INFO
+                    replicas: 1
+                  validatingWebhook: Enabled
+                  mutatingWebhook: Disabled
+                  webhook:
+                    emitAdmissionEvents: Enabled
+                    logLevel: INFO
+                    replicas: 2
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: gatekeeper-status
+        spec:
+          remediationAction: inform
+          severity: high
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  namespace: openshift-gatekeeper-system
+                  labels:
+                    control-plane: audit-controller
+                status:
+                  phase: Running # check the pod status to determine if operator is running or not
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  namespace: openshift-gatekeeper-system
+                  labels:
+                    control-plane: controller-manager
+                status:
+                  phase: Running # check the pod status to determine if operator is running or not
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -120,18 +120,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-gatekeeper-operator
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-gatekeeper-operator
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-gatekeeper-operator
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/stable/CM-Configuration-Management/policy-kyverno-add-network-policy.yaml
+++ b/stable/CM-Configuration-Management/policy-kyverno-add-network-policy.yaml
@@ -43,25 +43,25 @@ spec:
                       named `default-deny` which will deny all traffic anytime a new Namespace is created.      
                 spec:
                   rules:
-                  - name: default-deny
-                    match:
-                      resources:
-                        kinds:
-                        - Namespace
-                    generate:
-                      apiVersion: networking.k8s.io/v1
-                      kind: NetworkPolicy
-                      name: default-deny
-                      namespace: "{{ `{{request.object.metadata.name}}` }}"
-                      synchronize: true
-                      data:
-                        spec:
-                          # select all pods in the namespace
-                          podSelector: {}
-                          # deny all traffic
-                          policyTypes:
-                          - Ingress
-                          - Egress
+                    - name: default-deny
+                      match:
+                        resources:
+                          kinds:
+                            - Namespace
+                      generate:
+                        apiVersion: networking.k8s.io/v1
+                        kind: NetworkPolicy
+                        name: default-deny
+                        namespace: "{{ `{{request.object.metadata.name}}` }}"
+                        synchronize: true
+                        data:
+                          spec:
+                            # select all pods in the namespace
+                            podSelector: {}
+                            # deny all traffic
+                            policyTypes:
+                              - Ingress
+                              - Egress
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -81,9 +81,6 @@ kind: PlacementRule
 metadata:
   name: placement-policy-kyverno-add-network-policy
 spec:
-  clusterConditions:
-    - status: "True"
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/stable/CM-Configuration-Management/policy-kyverno-add-quota.yaml
+++ b/stable/CM-Configuration-Management/policy-kyverno-add-quota.yaml
@@ -41,45 +41,45 @@ spec:
                       a new Namespace is created.      
                 spec:
                   rules:
-                  - name: generate-resourcequota
-                    match:
-                      resources:
-                        kinds:
-                        - Namespace
-                    generate:
-                      apiVersion: v1
-                      kind: ResourceQuota
-                      name: default-resourcequota
-                      synchronize: true
-                      namespace: "{{ `{{request.object.metadata.name}}` }}"
-                      data:
-                        spec:
-                          hard:
-                            requests.cpu: '4'
-                            requests.memory: '16Gi'
-                            limits.cpu: '4'
-                            limits.memory: '16Gi'
-                  - name: generate-limitrange
-                    match:
-                      resources:
-                        kinds:
-                        - Namespace
-                    generate:
-                      apiVersion: v1
-                      kind: LimitRange
-                      name: default-limitrange
-                      synchronize: true
-                      namespace: "{{ `{{request.object.metadata.name}}` }}"
-                      data:
-                        spec:
-                          limits:
-                          - default:
-                              cpu: 500m
-                              memory: 1Gi
-                            defaultRequest:
-                              cpu: 200m
-                              memory: 256Mi
-                            type: Container
+                    - name: generate-resourcequota
+                      match:
+                        resources:
+                          kinds:
+                            - Namespace
+                      generate:
+                        apiVersion: v1
+                        kind: ResourceQuota
+                        name: default-resourcequota
+                        synchronize: true
+                        namespace: "{{ `{{request.object.metadata.name}}` }}"
+                        data:
+                          spec:
+                            hard:
+                              requests.cpu: '4'
+                              requests.memory: '16Gi'
+                              limits.cpu: '4'
+                              limits.memory: '16Gi'
+                    - name: generate-limitrange
+                      match:
+                        resources:
+                          kinds:
+                            - Namespace
+                      generate:
+                        apiVersion: v1
+                        kind: LimitRange
+                        name: default-limitrange
+                        synchronize: true
+                        namespace: "{{ `{{request.object.metadata.name}}` }}"
+                        data:
+                          spec:
+                            limits:
+                              - default:
+                                  cpu: 500m
+                                  memory: 1Gi
+                                defaultRequest:
+                                  cpu: 200m
+                                  memory: 256Mi
+                                type: Container
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -99,9 +99,6 @@ kind: PlacementRule
 metadata:
   name: placement-policy-kyverno-add-quota
 spec:
-  clusterConditions:
-    - status: "True"
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/stable/CM-Configuration-Management/policy-kyverno-sync-secrets.yaml
+++ b/stable/CM-Configuration-Management/policy-kyverno-sync-secrets.yaml
@@ -42,20 +42,20 @@ spec:
                       the copied Secrets should the source Secret be changed.      
                 spec:
                   rules:
-                  - name: sync-image-pull-secret
-                    match:
-                      resources:
-                        kinds:
-                        - Namespace
-                    generate:
-                      apiVersion: v1
-                      kind: Secret
-                      name: regcred
-                      namespace: "{{ `{{request.object.metadata.name}}` }}"
-                      synchronize: true
-                      clone:
-                        namespace: default
+                    - name: sync-image-pull-secret
+                      match:
+                        resources:
+                          kinds:
+                            - Namespace
+                      generate:
+                        apiVersion: v1
+                        kind: Secret
                         name: regcred
+                        namespace: "{{ `{{request.object.metadata.name}}` }}"
+                        synchronize: true
+                        clone:
+                          namespace: default
+                          name: regcred
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -75,9 +75,6 @@ kind: PlacementRule
 metadata:
   name: placement-policy-kyverno-sync-secrets
 spec:
-  clusterConditions:
-    - status: "True"
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/stable/CM-Configuration-Management/policy-namespace.yaml
+++ b/stable/CM-Configuration-Management/policy-namespace.yaml
@@ -35,18 +35,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-namespace
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-namespace
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-namespace
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/stable/CM-Configuration-Management/policy-pod.yaml
+++ b/stable/CM-Configuration-Management/policy-pod.yaml
@@ -29,10 +29,10 @@ spec:
                   name: sample-nginx-pod
                 spec:
                   containers:
-                  - image: nginx:1.18.0
-                    name: nginx
-                    ports:
-                    - containerPort: 80
+                    - image: nginx:1.18.0
+                      name: nginx
+                      ports:
+                        - containerPort: 80
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -43,18 +43,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-pod
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-pod
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-pod
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/stable/CM-Configuration-Management/policy-zts-cmc.yaml
+++ b/stable/CM-Configuration-Management/policy-zts-cmc.yaml
@@ -53,11 +53,11 @@ spec:
         metadata:
           name: policy-zts-cmc
         spec:
-          remediationAction: inform 
+          remediationAction: inform
           severity: low
           namespaceSelector:
             include:
-              - default 
+              - default
           object-templates:
             - complianceType: musthave
               objectDefinition:
@@ -84,11 +84,11 @@ spec:
                           imagePullPolicy: Always
                           image: zettasetimg/test:zts-acm-web-application-0.0.2_commitid-a1b5f9
                           env:
-                           - name: IP_ADDRESS_CMC
-                             valueFrom:
-                               configMapKeyRef:
-                                 name: zts-cmc-configmap
-                                 key: application.properties
+                            - name: IP_ADDRESS_CMC
+                              valueFrom:
+                                configMapKeyRef:
+                                  name: zts-cmc-configmap
+                                  key: application.properties
                           ports:
                             - containerPort: 8080
                       imagePullSecrets:
@@ -103,19 +103,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-zts-cmc
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-zts-cmc
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-zts-cmc
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}
-

--- a/stable/SC-System-and-Communications-Protection/policy-certificate.yaml
+++ b/stable/SC-System-and-Communications-Protection/policy-certificate.yaml
@@ -31,18 +31,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-certificate
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-certificate
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-certificate
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/stable/SC-System-and-Communications-Protection/policy-etcdencryption.yaml
+++ b/stable/SC-System-and-Communications-Protection/policy-etcdencryption.yaml
@@ -57,19 +57,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-etcdencryption
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-etcdencryption
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-etcdencryption
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}
-

--- a/stable/SC-System-and-Communications-Protection/policy-limitmemory.yaml
+++ b/stable/SC-System-and-Communications-Protection/policy-limitmemory.yaml
@@ -29,11 +29,11 @@ spec:
                   name: mem-limit-range
                 spec:
                   limits:
-                  - default:
-                      memory: 512Mi
-                    defaultRequest:
-                      memory: 256Mi
-                    type: Container
+                    - default:
+                        memory: 512Mi
+                      defaultRequest:
+                        memory: 256Mi
+                      type: Container
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -44,18 +44,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-limitmemory
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-limitmemory
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-limitmemory
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/stable/SC-System-and-Communications-Protection/policy-psp.yaml
+++ b/stable/SC-System-and-Communications-Protection/policy-psp.yaml
@@ -33,13 +33,13 @@ spec:
                   privileged: false # no privileged pods
                   allowPrivilegeEscalation: false
                   allowedCapabilities:
-                  - '*'
+                    - '*'
                   volumes:
-                  - '*'
+                    - '*'
                   hostNetwork: true
                   hostPorts:
-                  - min: 1000 # ports < 1000 are reserved
-                    max: 65535
+                    - min: 1000 # ports < 1000 are reserved
+                      max: 65535
                   hostIPC: false
                   hostPID: false
                   runAsUser:
@@ -60,18 +60,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-podsecuritypolicy
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-podsecuritypolicy
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-podsecuritypolicy
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/stable/SC-System-and-Communications-Protection/policy-scc.yaml
+++ b/stable/SC-System-and-Communications-Protection/policy-scc.yaml
@@ -39,10 +39,10 @@ spec:
                   type: MustRunAs
                 readOnlyRootFilesystem: false
                 requiredDropCapabilities:
-                - KILL
-                - MKNOD
-                - SETUID
-                - SETGID
+                  - KILL
+                  - MKNOD
+                  - SETUID
+                  - SETGID
                 runAsUser:
                   type: MustRunAsRange
                 seLinuxContext:
@@ -51,12 +51,12 @@ spec:
                   type: RunAsAny
                 users: []
                 volumes:
-                - configMap
-                - downwardAPI
-                - emptyDir
-                - persistentVolumeClaim
-                - projected
-                - secret
+                  - configMap
+                  - downwardAPI
+                  - emptyDir
+                  - persistentVolumeClaim
+                  - projected
+                  - secret
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -67,18 +67,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-securitycontextconstraints
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-securitycontextconstraints
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-securitycontextconstraints
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}

--- a/stable/SI-System-and-Information-Integrity/policy-imagemanifestvuln.yaml
+++ b/stable/SI-System-and-Information-Integrity/policy-imagemanifestvuln.yaml
@@ -38,7 +38,7 @@ spec:
         metadata:
           name: policy-imagemanifestvuln-status
         spec:
-          remediationAction: inform  # will be overridden by remediationAction in parent policy
+          remediationAction: inform # will be overridden by remediationAction in parent policy
           severity: high
           object-templates:
             - complianceType: musthave
@@ -50,7 +50,7 @@ spec:
                 spec:
                   displayName: Red Hat Quay Container Security Operator
                 status:
-                  phase: Succeeded   # check the csv status to determine if operator is running or not
+                  phase: Succeeded # check the csv status to determine if operator is running or not
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
@@ -77,18 +77,15 @@ placementRef:
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-- name: policy-imagemanifestvuln
-  kind: Policy
-  apiGroup: policy.open-cluster-management.io
+  - name: policy-imagemanifestvuln
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: placement-policy-imagemanifestvuln
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}


### PR DESCRIPTION
Setting `ManagedClusterConditionAvailable` in a `PlacementRule` is tumultuous in Policy if managed clusters become unavailable because the Policy will be removed from the managed cluster.