### PR TITLE
backup ns should not be removed when polciy is disabled

### DIFF
--- a/community/CM-Configuration-Management/acm-app-pv-backup/resources/policies/oadp-hdr-app-install.yaml
+++ b/community/CM-Configuration-Management/acm-app-pv-backup/resources/policies/oadp-hdr-app-install.yaml
@@ -45,7 +45,6 @@ spec:
                   name: '{{hub $configMap.data.backupNS hub}}'
             {{hub end hub}}
           remediationAction: enforce
-          pruneObjectBehavior: DeleteIfCreated
           severity: high
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-12004

Change: 
Don't delete the backup namespace when the install policy is disabled. If any restores are created they need to be cleaned up before the ns is removed. We'll keep the ns so that the user can manually delete the ns after removing the velero restore resources.