### PR TITLE
Adjust machine sets to work on ocp 4.16

### DIFF
--- a/policygenerator/policy-sets/community/openshift-plus-setup/machine-sets.yaml
+++ b/policygenerator/policy-sets/community/openshift-plus-setup/machine-sets.yaml
@@ -77,6 +77,17 @@ spec:
                     - name: tag:Name
                       values:
                       - '{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").status.infrastructureName }}-worker-sg'
+                  {{- $ocpversion := semver (fromClusterClaim "version.openshift.io") }}
+                  {{- if gt $ocpversion.Minor 15 }}
+                  - filters:
+                    - name: tag:Name
+                      values:
+                      - '{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").status.infrastructureName }}-node'
+                  - filters:
+                    - name: tag:Name
+                      values:
+                      - '{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").status.infrastructureName }}-lb'
+                  {{- end }}
                   subnet:
                     filters:
                     - name: tag:Name


### PR DESCRIPTION
The machineset no longer works on ocp 4.16.  This pr adds in some filters which seem to be additional required configuration that resolves the issue.

Refs:
 - https://issues.redhat.com/browse/OCPQE-22447