### PR TITLE
delete restore when policy is disabled

### DIFF
--- a/community/CM-Configuration-Management/acm-app-pv-backup/resources/policies/oadp-hdr-app-install.yaml
+++ b/community/CM-Configuration-Management/acm-app-pv-backup/resources/policies/oadp-hdr-app-install.yaml
@@ -45,6 +45,7 @@ spec:
                   name: '{{hub $configMap.data.backupNS hub}}'
             {{hub end hub}}
           remediationAction: enforce
+          pruneObjectBehavior: DeleteIfCreated
           severity: high
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1

--- a/community/CM-Configuration-Management/acm-app-pv-backup/resources/policies/oadp-hdr-app-restore.yaml
+++ b/community/CM-Configuration-Management/acm-app-pv-backup/resources/policies/oadp-hdr-app-restore.yaml
@@ -71,6 +71,7 @@ spec:
                   restorePVs: '{{hub $configMap.data.restoreRestorePVs | toBool hub}}'
             {{hub end hub}}
           remediationAction: enforce
+          pruneObjectBehavior: DeleteIfCreated
           severity: high
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-12080

Since the oadp install namespace cannot be deleted due to the restore resource finalizer, prune any restore resource created by the policy, when the policy is disabled; using the `pruneObjectBehavior: DeleteIfCreated` 
Still going to delete the namespace because the OADP ClusterServiceVersion is not created by the policy so it cannot be removed by the policy using the `pruneObjectBehavior: DeleteIfCreated` option 

Changes:
- add `pruneObjectBehavior: DeleteIfCreated` option to the Restore creation template; this will allow the ns to be deleted
- add `pruneObjectBehavior: DeleteIfCreated` option to the Namespace creation template; this will clean up the OADP CSV