### PR TITLE
Use unique subnet name for OCP 4.16 machinesets

### DIFF
--- a/policygenerator/policy-sets/community/openshift-plus-setup/machine-sets.yaml
+++ b/policygenerator/policy-sets/community/openshift-plus-setup/machine-sets.yaml
@@ -92,7 +92,10 @@ spec:
                     filters:
                     - name: tag:Name
                       values:
-                      - {{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").status.infrastructureName }}-private-{{ list (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").status.platformStatus.aws.region $zone | join "" }}
+                      - '{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").status.infrastructureName }}-private-{{ list (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").status.platformStatus.aws.region $zone | join "" }}'
+                  {{- if gt $ocpversion.Minor 15 }}
+                      - '{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").status.infrastructureName }}-subnet-private-{{ list (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").status.platformStatus.aws.region $zone | join "" }}'
+                  {{- end }}
                   tags:
                   - name: 'kubernetes.io/cluster/{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").status.infrastructureName }}'
                     value: owned


### PR DESCRIPTION
This is required to work with 4.16 clusters. It was missed or not required for some reason in the first attempt.