### PR TITLE
Updated policy as per recent changes in ACM 2.10

### DIFF
--- a/community/AC-Access-Control/policy-roles-no-wildcards.yaml
+++ b/community/AC-Access-Control/policy-roles-no-wildcards.yaml
@@ -2,13 +2,14 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
   name: policy-disallowed-roles
+  namespace: default
   annotations:
     policy.open-cluster-management.io/standards: NIST SP 800-53
     policy.open-cluster-management.io/categories: AC Access Control
     policy.open-cluster-management.io/controls: AC-6 Least Privilege
 spec:
-  remediationAction: inform
   disabled: false
+  remediationAction: inform
   policy-templates:
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
@@ -19,7 +20,10 @@ spec:
           remediationAction: inform # will be overridden by remediationAction in parent policy
           severity: high
           namespaceSelector:
-            include: ["default"]
+            exclude:
+              - kube-*
+            include:
+              - default
           object-templates:
             - complianceType: mustnothave
               objectDefinition:
@@ -27,30 +31,42 @@ spec:
                 kind: Role
                 rules:
                   - apiGroups:
-                      - '*'
+                      - "*"
                     resources:
-                      - '*'
+                      - "*"
                     verbs:
-                      - '*'
+                      - "*"
+---
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: policy-disallowed-roles-placement
+  namespace: default
+spec:
+  tolerations:
+    - key: cluster.open-cluster-management.io/unreachable
+      operator: Exists
+    - key: cluster.open-cluster-management.io/unavailable
+      operator: Exists
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchExpressions:
+            - key: environment
+              operator: In
+              values:
+                - dev
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-  name: binding-policy-disallowed-roles
+  name: policy-disallowed-roles-placement
+  namespace: default
 placementRef:
-  name: placement-policy-disallowed-roles
-  kind: PlacementRule
-  apiGroup: apps.open-cluster-management.io
+  name: policy-disallowed-roles-placement
+  apiGroup: cluster.open-cluster-management.io
+  kind: Placement
 subjects:
   - name: policy-disallowed-roles
-    kind: Policy
     apiGroup: policy.open-cluster-management.io
----
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
-metadata:
-  name: placement-policy-disallowed-roles
-spec:
-  clusterSelector:
-    matchExpressions:
-      - {key: environment, operator: In, values: ["dev"]}
+    kind: Policy


### PR DESCRIPTION
Updated policy as per recent changes in ACM 2.10. The "namespace" must be included. The kind "Placement" should be used as "PlacementRule" has been deprecated.

Signed-off-by: Ashish Saket [ashish.saket@gmail.com](mailto:ashish.saket@gmail.com)