### PR TITLE
Use local-cluster label

### DIFF
--- a/community/CM-Configuration-Management/acm-hub-pvc-backup/acm-hub-pvc-backup-config.yaml
+++ b/community/CM-Configuration-Management/acm-hub-pvc-backup/acm-hub-pvc-backup-config.yaml
@@ -123,13 +123,12 @@ spec:
             {{- $volsync_pvcs := "hub-pvc-backup-pvcs" }}
             {{- $volsync_restore_cond := eq ( lookup "v1" "ConfigMap" $ns $volsync_pvcs ).metadata.name $volsync_pvcs }}
             {{- $has_local_cluster_ns := eq (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" "local-cluster").metadata.name "local-cluster" }}
-            {{- $is_hub := "is-hub" }}
-            {{- $local_cls := "local-cluster" }}
+            {{- $local_cls_name := index (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" "" "local-cluster=true") "items" 0 "metadata" "name" }}
 
             {{- /* Create the volsync addon - if BackupSchedule exists and there are PVCs with volsync label */ -}}
             {{ if or (and $pv_claim_cond $volsync_backup_cond) $volsync_restore_cond  }}
-                {{- range $hub_managed_cls := (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" "" $is_hub).items }}
-                  {{ if not ( eq $hub_managed_cls.metadata.name $local_cls ) }}
+                {{- range $hub_managed_cls := (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" "" "is-hub").items }}
+                  {{ if not ( eq $hub_managed_cls.metadata.name $local_cls_name ) }}
                 - complianceType: musthave
                   objectDefinition:
                     apiVersion: addon.open-cluster-management.io/v1alpha1
@@ -147,14 +146,14 @@ spec:
                           type: Available  
                   {{- end }}      
                 {{- end }}
-                {{ if $has_local_cluster_ns }}
+                {{ if $local_cls_name }}
                 - complianceType: musthave
                   objectDefinition:
                     apiVersion: addon.open-cluster-management.io/v1alpha1
                     kind: ManagedClusterAddOn
                     metadata:
                       name: volsync
-                      namespace: {{ $local_cls }}
+                      namespace: {{ $local_cls_name }}
                       labels:
                         cluster.open-cluster-management.io/backup: volsync
                     spec:

--- a/community/CM-Configuration-Management/acm-hub-pvc-backup/acm-hub-pvc-placement.yaml
+++ b/community/CM-Configuration-Management/acm-hub-pvc-backup/acm-hub-pvc-placement.yaml
@@ -9,10 +9,10 @@ spec:
     - requiredClusterSelector:
         labelSelector:
           matchExpressions:
-            - key: name
+            - key: local-cluster
               operator: In
               values:
-                - local-cluster
+                - 'true'
     - requiredClusterSelector:
         labelSelector:
           matchExpressions:

--- a/policygenerator/kustomize/policyGenerator.yaml
+++ b/policygenerator/kustomize/policyGenerator.yaml
@@ -8,8 +8,9 @@ policyDefaults:
   namespace: policies
   placement:
     name: demo-placement-rule
-    clusterSelectors:
-      name: local-cluster
+    labelSelector:
+      matchExpressions:
+        - {key: "local-cluster", operator: In, values: ["true"]}
   remediationAction: inform
   severity: medium
 policies:

--- a/policygenerator/policy-sets/community/acs-secure/policyGenerator.yaml
+++ b/policygenerator/policy-sets/community/acs-secure/policyGenerator.yaml
@@ -41,7 +41,7 @@ policySets:
     placement:
       labelSelector:
         matchExpressions:
-          - {key: name, operator: In, values: ["local-cluster"]}
+          - {key: "local-cluster", operator: In, values: ["true"]}
   - description: The Advanced Cluster Security components distributed to all OpenShift
       managed clusters to secure the clusters.
     name: acs-sensor-clusters
@@ -49,4 +49,4 @@ policySets:
       labelSelector:
         matchExpressions:
           - {key: vendor, operator: In, values: ["OpenShift"]}
-          - {key: name, operator: NotIn, values: ["local-cluster"]}
+          - {key: "local-cluster", operator: NotIn, values: ["true"]}

--- a/policygenerator/policy-sets/community/gatekeeper/placement.yaml
+++ b/policygenerator/policy-sets/community/gatekeeper/placement.yaml
@@ -8,4 +8,4 @@ spec:
   - requiredClusterSelector:
       labelSelector:
         matchExpressions:
-          - {key: name, operator: In, values: ["local-cluster"]}
+          - {key: "local-cluster", operator: In, values: ["true"]}

--- a/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/placement.yaml
+++ b/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/placement.yaml
@@ -8,4 +8,4 @@ spec:
   - requiredClusterSelector:
       labelSelector:
         matchExpressions:
-          - {key: name, operator: In, values: ["local-cluster"]}
+          - {key: "local-cluster", operator: In, values: ["true"]}

--- a/policygenerator/policy-sets/community/kyverno/multitenancy/placement.yaml
+++ b/policygenerator/policy-sets/community/kyverno/multitenancy/placement.yaml
@@ -8,4 +8,4 @@ spec:
   - requiredClusterSelector:
       labelSelector:
         matchExpressions:
-          - {key: name, operator: In, values: ["local-cluster"]}
+          - {key: "local-cluster", operator: In, values: ["true"]}

--- a/policygenerator/policy-sets/community/kyverno/security/placement.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/placement.yaml
@@ -8,4 +8,4 @@ spec:
   - requiredClusterSelector:
       labelSelector:
         matchExpressions:
-          - {key: name, operator: In, values: ["local-cluster"]}
+          - {key: "local-cluster", operator: In, values: ["true"]}

--- a/policygenerator/policy-sets/community/openshift-gitops/placement.yaml
+++ b/policygenerator/policy-sets/community/openshift-gitops/placement.yaml
@@ -8,4 +8,4 @@ spec:
   - requiredClusterSelector:
       labelSelector:
         matchExpressions:
-          - {key: name, operator: In, values: ["local-cluster"]}
+          - {key: "local-cluster", operator: In, values: ["true"]}

--- a/policygenerator/policy-sets/community/openshift-plus-setup/placement.yaml
+++ b/policygenerator/policy-sets/community/openshift-plus-setup/placement.yaml
@@ -8,4 +8,4 @@ spec:
   - requiredClusterSelector:
       labelSelector:
         matchExpressions:
-          - {key: name, operator: In, values: ["local-cluster"]}
+          - {key: "local-cluster", operator: In, values: ["true"]}

--- a/policygenerator/policy-sets/community/policygenerator-download/generator.yml
+++ b/policygenerator/policy-sets/community/policygenerator-download/generator.yml
@@ -17,7 +17,7 @@ policyDefaults:
   placement:
     labelSelector:
       matchLabels:
-        name: local-cluster
+        local-cluster: 'true'
 
 policies:
   - name: acm-policygenerator-downloader

--- a/policygenerator/policy-sets/stable/acm-hardening/input/placement.yaml
+++ b/policygenerator/policy-sets/stable/acm-hardening/input/placement.yaml
@@ -8,4 +8,4 @@ spec:
   - requiredClusterSelector:
       labelSelector:
         matchExpressions:
-          - {key: name, operator: In, values: ["local-cluster"]}
+          - {key: "local-cluster", operator: In, values: ["true"]}

--- a/policygenerator/policy-sets/stable/openshift-plus/input/clusters-placement.yaml
+++ b/policygenerator/policy-sets/stable/openshift-plus/input/clusters-placement.yaml
@@ -9,4 +9,4 @@ spec:
       labelSelector:
         matchExpressions:
           - {key: vendor, operator: In, values: ["OpenShift"]}
-          - {key: name, operator: NotIn, values: ["local-cluster"]}
+          - {key: "local-cluster", operator: NotIn, values: ["true"]}

--- a/policygenerator/policy-sets/stable/openshift-plus/input/hub-placement.yaml
+++ b/policygenerator/policy-sets/stable/openshift-plus/input/hub-placement.yaml
@@ -8,4 +8,4 @@ spec:
   - requiredClusterSelector:
       labelSelector:
         matchExpressions:
-          - {key: name, operator: In, values: ["local-cluster"]}
+          - {key: "local-cluster", operator: In, values: ["true"]}


### PR DESCRIPTION
For a while now, self-managed hub ManagedCluster resources have had the `local-cluster='true'` label, and we may start seeing those clusters have different names. This PR adjusts many occurrences in the collection of using the name; now they use the label.

The change to the backup policy to avoid a named lookup is in a [separate commit](https://github.com/JustinKuli/policy-collection/commit/605888411104c3deb0d66b75de1ae18c3531867e) because I think it needs extra attention, it's less obvious than the other changes.