### PR TITLE
Fix issues for integraton-test

### DIFF
--- a/stable/CM-Configuration-Management/policy-namespace.yaml
+++ b/stable/CM-Configuration-Management/policy-namespace.yaml
@@ -24,3 +24,4 @@ spec:
                 kind: Namespace # must have namespace 'prod'
                 apiVersion: v1
                 metadata:
+                  name: prod

--- a/stable/SC-System-and-Communications-Protection/policy-scc.yaml
+++ b/stable/SC-System-and-Communications-Protection/policy-scc.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
-  name: policy-securitycontextconstraints
+  name: policy-scc
   annotations:
     policy.open-cluster-management.io/standards: NIST SP 800-53
     policy.open-cluster-management.io/categories: SC System and Communications Protection
@@ -14,7 +14,7 @@ spec:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
         metadata:
-          name: policy-securitycontextconstraints-example
+          name: policy-scc-example
         spec:
           remediationAction: inform # the policy-template spec.remediationAction is overridden by the preceding parameter value for spec.remediationAction.
           severity: high


### PR DESCRIPTION
- Accidentally removed `name`. Recovering `name`.
- policy-scc's policy name is too long. Shorten the name
This block integration test.
related to https://redhat-internal.slack.com/archives/CUS1VB8P3/p1724693607035989
Signed-off-by: yiraeChristineKim <yikim@redhat.com>
Ref: https://issues.redhat.com/browse/ACM-13584