### PR TITLE
check for completed backups and update compliant messages (https://issues.redhat.com/browse/ACM-14460)

### DIFF
--- a/community/CM-Configuration-Management/acm-app-pv-backup/resources/policies/oadp-hdr-app-backup.yaml
+++ b/community/CM-Configuration-Management/acm-app-pv-backup/resources/policies/oadp-hdr-app-backup.yaml
@@ -78,29 +78,12 @@ spec:
             {{hub end hub}}
           remediationAction: inform
           severity: high
-    - objectDefinition:
-        apiVersion: policy.open-cluster-management.io/v1
-        kind: ConfigurationPolicy
-        metadata:
-          name: check-backup-completed
-        spec:
-          object-templates-raw: |
-            {{hub with $configMap := (lookup "v1" "ConfigMap" "" "hdr-app-configmap") hub}}
-            - complianceType: musthave
-              objectDefinition:
-                apiVersion: velero.io/v1
-                kind: Backup
-                metadata:
-                  namespace: '{{hub $configMap.data.backupNS hub}}'
-                  labels:
-                    velero.io/schedule-name: '{{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}-{{ fromClusterClaim "name" }}'
-                    cluster-id: '{{ fromClusterClaim "id.openshift.io" }}'
-                    cluster-name: '{{ fromClusterClaim "name" }}'
-                status:
-                  phase: Completed
-                  startTimestamp: '{{ (lookup "velero.io/v1" "Schedule" "{{hub $configMap.data.backupNS hub}}" "{{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}{{hub end hub}}-{{hub (printf "%s" .ManagedClusterName) hub}}").status.lastBackup }}'
-          remediationAction: inform
-          severity: high
+          customMessage:
+            compliant: |
+              The schedule {{hub with $configMap := (lookup "v1" "ConfigMap" "" "hdr-app-configmap") hub}} {{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}-<clusterName> phase is not FailedValidation.{{hub end hub}}
+            noncompliant: |
+              The schedule {{hub with $configMap := (lookup "v1" "ConfigMap" "" "hdr-app-configmap") hub}} {{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}-<clusterName> phase is FailedValidation. {{hub end hub}}
+
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
@@ -124,6 +107,12 @@ spec:
                   startTimestamp: '{{ (lookup "velero.io/v1" "Schedule" "{{hub $configMap.data.backupNS hub}}" "{{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}{{hub end hub}}-{{hub (printf "%s" .ManagedClusterName) hub}}").status.lastBackup }}'
           remediationAction: inform
           severity: high
+          customMessage:
+            compliant: |
+              There is no Backup with a startTimestamp matching the schedule {{hub with $configMap := (lookup "v1" "ConfigMap" "" "hdr-app-configmap") hub}} {{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}-<clusterName> Schedule.status.lastBackup and having an Error phase.{{hub end hub}}
+            noncompliant: |
+              The Backup with a startTimestamp matching the {{hub with $configMap := (lookup "v1" "ConfigMap" "" "hdr-app-configmap") hub}} {{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}-<clusterName> Schedule.status.lastBackup was found and has an Error phase. {{hub end hub}}
+
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
@@ -147,6 +136,12 @@ spec:
                   startTimestamp: '{{ (lookup "velero.io/v1" "Schedule" "{{hub $configMap.data.backupNS hub}}" "{{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}{{hub end hub}}-{{hub (printf "%s" .ManagedClusterName) hub}}").status.lastBackup }}'
           remediationAction: inform
           severity: high
+          customMessage:
+            compliant: |
+              There is no Backup with a startTimestamp matching the schedule {{hub with $configMap := (lookup "v1" "ConfigMap" "" "hdr-app-configmap") hub}} {{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}-<clusterName> Schedule.status.lastBackup and having a FailedValidation phase.{{hub end hub}}
+            noncompliant: |
+              The Backup with a startTimestamp matching the {{hub with $configMap := (lookup "v1" "ConfigMap" "" "hdr-app-configmap") hub}} {{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}-<clusterName> Schedule.status.lastBackup was found and has a FailedValidation phase. {{hub end hub}}
+
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
@@ -170,6 +165,12 @@ spec:
                   startTimestamp: '{{ (lookup "velero.io/v1" "Schedule" "{{hub $configMap.data.backupNS hub}}" "{{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}{{hub end hub}}-{{hub (printf "%s" .ManagedClusterName) hub}}").status.lastBackup }}'
           remediationAction: inform
           severity: high
+          customMessage:
+            compliant: |
+              There is no Backup with a startTimestamp matching the schedule {{hub with $configMap := (lookup "v1" "ConfigMap" "" "hdr-app-configmap") hub}} {{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}-<clusterName> Schedule.status.lastBackup and having a PartiallyFailed phase.{{hub end hub}}
+            noncompliant: |
+              The Backup with a startTimestamp matching the {{hub with $configMap := (lookup "v1" "ConfigMap" "" "hdr-app-configmap") hub}} {{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}-<clusterName> Schedule.status.lastBackup was found and has a PartiallyFailed phase. {{hub end hub}}
+
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
@@ -193,3 +194,37 @@ spec:
                   startTimestamp: '{{ (lookup "velero.io/v1" "Schedule" "{{hub $configMap.data.backupNS hub}}" "{{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}{{hub end hub}}-{{hub (printf "%s" .ManagedClusterName) hub}}").status.lastBackup }}'
           remediationAction: inform
           severity: low
+          customMessage:
+            compliant: |
+              There is no Backup with a startTimestamp matching the schedule {{hub with $configMap := (lookup "v1" "ConfigMap" "" "hdr-app-configmap") hub}} {{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}-<clusterName> Schedule.status.lastBackup and having an empty phase.{{hub end hub}}
+            noncompliant: |
+              The Backup with a startTimestamp matching the {{hub with $configMap := (lookup "v1" "ConfigMap" "" "hdr-app-configmap") hub}} {{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}-<clusterName> Schedule.status.lastBackup was found and has an empty state. {{hub end hub}}
+
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: check-backup-completed
+        spec:
+          object-templates-raw: |
+            {{hub with $configMap := (lookup "v1" "ConfigMap" "" "hdr-app-configmap") hub}}
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: velero.io/v1
+                kind: Backup
+                metadata:
+                  namespace: '{{hub $configMap.data.backupNS hub}}'
+                  labels:
+                    velero.io/schedule-name: '{{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}-{{ fromClusterClaim "name" }}'
+                    cluster-id: '{{ fromClusterClaim "id.openshift.io" }}'
+                    cluster-name: '{{ fromClusterClaim "name" }}'
+                status:
+                  phase: Completed
+              {{hub end hub}}
+          remediationAction: inform
+          severity: high
+          customMessage:
+            compliant: |
+              There is at least one completed Backup generated by the {{hub with $configMap := (lookup "v1" "ConfigMap" "" "hdr-app-configmap") hub}} {{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}-<clusterName> Schedule.{{hub end hub}}
+            noncompliant: |
+              There is no completed Backup generated by the {{hub with $configMap := (lookup "v1" "ConfigMap" "" "hdr-app-configmap") hub}} {{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}-<clusterName> Schedule.{{hub end hub}}


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-14460

Changes:
- Updated the check-backup-completed policy template to look for any backup in completed state, not only for the latest backup.
- The other templates are still validating the latest backup phase ( will show violation if the Backup matching the Schedule.status.lastBackup  has a status of Error, FailedValidation or '')
- Updated compliance messages with a more readable content, see attached image
The reason for the change : sometimes - and it seems that it usually happens first time the Schedule gets created but cannot always be reproduced - the Schedule.status.lastBackup timestamp if off and does not match the generated Backup startTimestamp. 
Because of this we show a violation when we check if the latest backup is completed. The violation is because the Backup was not found based on the Schedule.status.lastBackup timestamp rule, but the Backup exists and is Completed. 
To avoid this false positive, I am just checking if there is a Backup generated by this Schedule, with a status of Completed. This check will show compliant though even if the Completed backup was generated long ago. This should be ok though because we have other templates checking  that the latest backup must not have a status of ( Error, FailedValidation or '' ). So if those are compliant, the latest backup should be completed

<img width="1350" alt="Screenshot 2024-09-25 at 11 17 12 AM" src="https://github.com/user-attachments/assets/bf3ec9d3-92ce-4ec0-868b-766713de6a37">
