### PR TITLE
Change the OPP policies to adopt OperatorPolicy

### DIFF
--- a/policygenerator/policy-sets/stable/openshift-plus/input-acs-central/policy-acs-operator-central.yaml
+++ b/policygenerator/policy-sets/stable/openshift-plus/input-acs-central/policy-acs-operator-central.yaml
@@ -8,24 +8,24 @@ kind: Namespace
 metadata:
   name: rhacs-operator
 ---
-apiVersion: operators.coreos.com/v1
-kind: OperatorGroup
+apiVersion: policy.open-cluster-management.io/v1beta1
+kind: OperatorPolicy
 metadata:
-  name: rhacs-operator-group
-  namespace: rhacs-operator
-spec: {}
----
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
-metadata:
-  name: rhacs-operator
-  namespace: rhacs-operator
+  name: operatorpolicy-rhacs-operator
 spec:
-  channel: stable
-  installPlanApproval: Automatic
-  name: rhacs-operator
-  source: redhat-operators
-  sourceNamespace: openshift-marketplace
+  remediationAction: enforce
+  severity: high
+  complianceType: musthave
+  upgradeApproval: Automatic
+  operatorGroup:
+    name: rhacs-operator-group
+    namespace: rhacs-operator
+  subscription:
+    channel: stable
+    name: rhacs-operator
+    namespace: rhacs-operator
+    source: redhat-operators
+    sourceNamespace: openshift-marketplace
 ---
 apiVersion: platform.stackrox.io/v1alpha1
 kind: Central

--- a/policygenerator/policy-sets/stable/openshift-plus/input-compliance/policy-compliance-operator-install.yaml
+++ b/policygenerator/policy-sets/stable/openshift-plus/input-compliance/policy-compliance-operator-install.yaml
@@ -3,31 +3,23 @@ kind: Namespace
 metadata:
   name: openshift-compliance
 ---
-apiVersion: operators.coreos.com/v1
-kind: OperatorGroup
+apiVersion: policy.open-cluster-management.io/v1beta1
+kind: OperatorPolicy
 metadata:
-  name: compliance-operator
-  namespace: openshift-compliance
+  name: operatorpolicy-comp-operator
 spec:
-  targetNamespaces:
-    - openshift-compliance
----
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
-metadata:
-  name: compliance-operator
-  namespace: openshift-compliance
-spec:
-  installPlanApproval: Automatic
-  name: compliance-operator
-  source: redhat-operators
-  sourceNamespace: openshift-marketplace
----
-apiVersion: operators.coreos.com/v1alpha1
-kind: ClusterServiceVersion
-metadata:
-  namespace: openshift-compliance
-spec:
-  displayName: Compliance Operator
-status:
-  phase: Succeeded   # check the csv status to determine if operator is running or not
+  remediationAction: enforce
+  severity: high
+  complianceType: musthave
+  upgradeApproval: Automatic
+  operatorGroup:
+    name: compliance-operator
+    namespace: openshift-compliance
+    targetNamespaces:
+      - openshift-compliance
+  subscription:
+    channel: stable
+    name: compliance-operator
+    namespace: openshift-compliance
+    source: redhat-operators
+    sourceNamespace: openshift-marketplace

--- a/policygenerator/policy-sets/stable/openshift-plus/input-odf/policy-odf-status.yaml
+++ b/policygenerator/policy-sets/stable/openshift-plus/input-odf/policy-odf-status.yaml
@@ -18,16 +18,6 @@ status:
     - status: "True"
       type: Available
 ---
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: odf-operator-controller-manager
-  namespace: openshift-storage
-status:
-  conditions:
-    - status: "True"
-      type: Available
----
 apiVersion: ocs.openshift.io/v1
 kind: StorageCluster
 metadata:

--- a/policygenerator/policy-sets/stable/openshift-plus/input-odf/policy-odf.yaml
+++ b/policygenerator/policy-sets/stable/openshift-plus/input-odf/policy-odf.yaml
@@ -5,25 +5,25 @@ metadata:
     openshift.io/cluster-monitoring: "true"
   name: openshift-storage
 ---
-apiVersion: operators.coreos.com/v1alpha2
-kind: OperatorGroup
+apiVersion: policy.open-cluster-management.io/v1beta1
+kind: OperatorPolicy
 metadata:
-  name: openshift-storage-operatorgroup
-  namespace: openshift-storage
+  name: operatorpolicy-odf-operator
 spec:
-  targetNamespaces:
-    - openshift-storage
----
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
-metadata:
-  name: odf-operator
-  namespace: openshift-storage
-spec:
-  installPlanApproval: Automatic
-  name: odf-operator
-  source: redhat-operators
-  sourceNamespace: openshift-marketplace
+  remediationAction: enforce
+  severity: high
+  complianceType: musthave
+  upgradeApproval: Automatic
+  operatorGroup:
+    name: openshift-storage-operatorgroup
+    namespace: openshift-storage
+    targetNamespaces:
+      - openshift-storage
+  subscription:
+    name: odf-operator
+    namespace: openshift-storage
+    source: redhat-operators
+    sourceNamespace: openshift-marketplace
 ---
 apiVersion: odf.openshift.io/v1alpha1
 kind: StorageSystem

--- a/policygenerator/policy-sets/stable/openshift-plus/input-quay/policy-hub-quay-bridge.yaml
+++ b/policygenerator/policy-sets/stable/openshift-plus/input-quay/policy-hub-quay-bridge.yaml
@@ -1,15 +1,18 @@
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
+apiVersion: policy.open-cluster-management.io/v1beta1
+kind: OperatorPolicy
 metadata:
+  name: operatorpolicy-quay-bridge-operator
   labels:
     operators.coreos.com/quay-bridge-operator.openshift-operators: ""
-  name: quay-bridge-operator
-  namespace: openshift-operators
 spec:
-  installPlanApproval: Automatic
-  name: quay-bridge-operator
-  source: redhat-operators
-  sourceNamespace: openshift-marketplace
+  remediationAction: enforce
+  severity: high
+  complianceType: musthave
+  upgradeApproval: Automatic
+  subscription:
+    name: quay-bridge-operator
+    source: redhat-operators
+    sourceNamespace: openshift-marketplace
 ---
 kind: Secret
 type: Opaque

--- a/policygenerator/policy-sets/stable/openshift-plus/input-quay/policy-install-quay.yaml
+++ b/policygenerator/policy-sets/stable/openshift-plus/input-quay/policy-install-quay.yaml
@@ -58,27 +58,27 @@ subjects:
   name: create-admin-user
   namespace: local-quay
 ---
-apiVersion: operators.coreos.com/v1
-kind: OperatorGroup
+apiVersion: policy.open-cluster-management.io/v1beta1
+kind: OperatorPolicy
 metadata:
-  name: local-quay
-  namespace: local-quay
-spec:
-  targetNamespaces:
-  - local-quay
----
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
-metadata:
+  name: operatorpolicy-quay-operator
   labels:
     operators.coreos.com/quay-operator.local-quay: ""
-  name: quay-operator
-  namespace: local-quay
 spec:
-  installPlanApproval: Automatic
-  name: quay-operator
-  source: redhat-operators
-  sourceNamespace: openshift-marketplace
+  remediationAction: enforce
+  severity: high
+  complianceType: musthave
+  upgradeApproval: Automatic
+  operatorGroup:
+    name: local-quay
+    namespace: local-quay
+    targetNamespaces:
+      - local-quay
+  subscription:
+    name: quay-operator
+    namespace: local-quay
+    source: redhat-operators
+    sourceNamespace: openshift-marketplace
 ---
 apiVersion: v1
 data:

--- a/policygenerator/policy-sets/stable/openshift-plus/input-quay/policy-quay-bridge.yaml
+++ b/policygenerator/policy-sets/stable/openshift-plus/input-quay/policy-quay-bridge.yaml
@@ -1,15 +1,18 @@
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
+apiVersion: policy.open-cluster-management.io/v1beta1
+kind: OperatorPolicy
 metadata:
+  name: operatorpolicy-quay-bridge-operator
   labels:
     operators.coreos.com/quay-bridge-operator.openshift-operators: ""
-  name: quay-bridge-operator
-  namespace: openshift-operators
 spec:
-  installPlanApproval: Automatic
-  name: quay-bridge-operator
-  source: redhat-operators
-  sourceNamespace: openshift-marketplace
+  remediationAction: enforce
+  severity: high
+  complianceType: musthave
+  upgradeApproval: Automatic
+  subscription:
+    name: quay-bridge-operator
+    source: redhat-operators
+    sourceNamespace: openshift-marketplace
 ---
 apiVersion: quay.redhat.com/v1
 kind: QuayIntegration

--- a/policygenerator/policy-sets/stable/openshift-plus/input-sensor/policy-advanced-managed-cluster-security.yaml
+++ b/policygenerator/policy-sets/stable/openshift-plus/input-sensor/policy-advanced-managed-cluster-security.yaml
@@ -8,24 +8,24 @@ kind: Namespace
 metadata:
   name: rhacs-operator
 ---
-apiVersion: operators.coreos.com/v1
-kind: OperatorGroup
+apiVersion: policy.open-cluster-management.io/v1beta1
+kind: OperatorPolicy
 metadata:
-  name: rhacs-operator-group
-  namespace: rhacs-operator
-spec: {}
----
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
-metadata:
-  name: rhacs-operator
-  namespace: rhacs-operator
+  name: operatorpolicy-rhacs-operator
 spec:
-  channel: stable
-  installPlanApproval: Automatic
-  name: rhacs-operator
-  source: redhat-operators
-  sourceNamespace: openshift-marketplace
+  remediationAction: enforce
+  severity: high
+  complianceType: musthave
+  upgradeApproval: Automatic
+  operatorGroup:
+    name: rhacs-operator-group
+    namespace: rhacs-operator
+  subscription:
+    channel: stable
+    name: rhacs-operator
+    namespace: rhacs-operator
+    source: redhat-operators
+    sourceNamespace: openshift-marketplace
 ---
 apiVersion: v1
 data:


### PR DESCRIPTION
Deploying operators with OperatorPolicy has benefits that should be adopted to help customers get better visibility into the operator status automatically.

Refs:
 - https://issues.redhat.com/browse/OCPQE-25041