### PR TITLE
check completion only when time matches (https://issues.redhat.com/browse/ACM-14460)

### DIFF
--- a/community/CM-Configuration-Management/acm-app-pv-backup/resources/policies/oadp-hdr-app-backup.yaml
+++ b/community/CM-Configuration-Management/acm-app-pv-backup/resources/policies/oadp-hdr-app-backup.yaml
@@ -78,11 +78,6 @@ spec:
             {{hub end hub}}
           remediationAction: inform
           severity: high
-          customMessage:
-            compliant: |
-              The schedule {{hub with $configMap := (lookup "v1" "ConfigMap" "" "hdr-app-configmap") hub}} {{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}-<clusterName> phase is not FailedValidation.{{hub end hub}}
-            noncompliant: |
-              The schedule {{hub with $configMap := (lookup "v1" "ConfigMap" "" "hdr-app-configmap") hub}} {{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}-<clusterName> phase is FailedValidation. {{hub end hub}}
 
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
@@ -107,11 +102,6 @@ spec:
                   startTimestamp: '{{ (lookup "velero.io/v1" "Schedule" "{{hub $configMap.data.backupNS hub}}" "{{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}{{hub end hub}}-{{hub (printf "%s" .ManagedClusterName) hub}}").status.lastBackup }}'
           remediationAction: inform
           severity: high
-          customMessage:
-            compliant: |
-              There is no Backup with a startTimestamp matching the schedule {{hub with $configMap := (lookup "v1" "ConfigMap" "" "hdr-app-configmap") hub}} {{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}-<clusterName> Schedule.status.lastBackup and having an Error phase.{{hub end hub}}
-            noncompliant: |
-              The Backup with a startTimestamp matching the {{hub with $configMap := (lookup "v1" "ConfigMap" "" "hdr-app-configmap") hub}} {{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}-<clusterName> Schedule.status.lastBackup was found and has an Error phase. {{hub end hub}}
 
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
@@ -136,11 +126,6 @@ spec:
                   startTimestamp: '{{ (lookup "velero.io/v1" "Schedule" "{{hub $configMap.data.backupNS hub}}" "{{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}{{hub end hub}}-{{hub (printf "%s" .ManagedClusterName) hub}}").status.lastBackup }}'
           remediationAction: inform
           severity: high
-          customMessage:
-            compliant: |
-              There is no Backup with a startTimestamp matching the schedule {{hub with $configMap := (lookup "v1" "ConfigMap" "" "hdr-app-configmap") hub}} {{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}-<clusterName> Schedule.status.lastBackup and having a FailedValidation phase.{{hub end hub}}
-            noncompliant: |
-              The Backup with a startTimestamp matching the {{hub with $configMap := (lookup "v1" "ConfigMap" "" "hdr-app-configmap") hub}} {{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}-<clusterName> Schedule.status.lastBackup was found and has a FailedValidation phase. {{hub end hub}}
 
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
@@ -165,11 +150,6 @@ spec:
                   startTimestamp: '{{ (lookup "velero.io/v1" "Schedule" "{{hub $configMap.data.backupNS hub}}" "{{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}{{hub end hub}}-{{hub (printf "%s" .ManagedClusterName) hub}}").status.lastBackup }}'
           remediationAction: inform
           severity: high
-          customMessage:
-            compliant: |
-              There is no Backup with a startTimestamp matching the schedule {{hub with $configMap := (lookup "v1" "ConfigMap" "" "hdr-app-configmap") hub}} {{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}-<clusterName> Schedule.status.lastBackup and having a PartiallyFailed phase.{{hub end hub}}
-            noncompliant: |
-              The Backup with a startTimestamp matching the {{hub with $configMap := (lookup "v1" "ConfigMap" "" "hdr-app-configmap") hub}} {{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}-<clusterName> Schedule.status.lastBackup was found and has a PartiallyFailed phase. {{hub end hub}}
 
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
@@ -194,11 +174,6 @@ spec:
                   startTimestamp: '{{ (lookup "velero.io/v1" "Schedule" "{{hub $configMap.data.backupNS hub}}" "{{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}{{hub end hub}}-{{hub (printf "%s" .ManagedClusterName) hub}}").status.lastBackup }}'
           remediationAction: inform
           severity: low
-          customMessage:
-            compliant: |
-              There is no Backup with a startTimestamp matching the schedule {{hub with $configMap := (lookup "v1" "ConfigMap" "" "hdr-app-configmap") hub}} {{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}-<clusterName> Schedule.status.lastBackup and having an empty phase.{{hub end hub}}
-            noncompliant: |
-              The Backup with a startTimestamp matching the {{hub with $configMap := (lookup "v1" "ConfigMap" "" "hdr-app-configmap") hub}} {{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}-<clusterName> Schedule.status.lastBackup was found and has an empty state. {{hub end hub}}
 
     - objectDefinition:
         apiVersion: policy.open-cluster-management.io/v1
@@ -207,24 +182,34 @@ spec:
           name: check-backup-completed
         spec:
           object-templates-raw: |
-            {{hub with $configMap := (lookup "v1" "ConfigMap" "" "hdr-app-configmap") hub}}
+           {{hub $clusterName := (printf "%s" .ManagedClusterName) hub}}
+           {{hub $configMap := (lookup "v1" "ConfigMap" "" "hdr-app-configmap") hub}}
+           {{hub $backupNS := $configMap.data.backupNS hub}}
+           {{hub $backupPrefix := $configMap.data.backupPrefix hub}}
+           {{hub $backupVolumeSnapshotLocation := $configMap.data.backupVolumeSnapshotLocation hub}}
+           {{hub $scheduleName := ((cat $backupPrefix "-" $backupVolumeSnapshotLocation "-" $clusterName) | replace " " "") hub}}
+
+           {{- $scheduleObj := (lookup "velero.io/v1" "Schedule" "{{hub $backupNS hub}}" "{{hub $scheduleName hub}}") }}
+           {{- $scheduleObjName := $scheduleObj.metadata.name }}
+           {{- $scheduleExists := eq $scheduleObjName "{{hub $scheduleName hub}}" }}
+
+            {{- if $scheduleExists }}
+              {{- $scheduleObjLastBckTime := ($scheduleObj.status.lastBackup) }}
+              {{- range $backupList := (lookup "velero.io/v1" "Backup" "{{hub $backupNS hub}}" "").items }}
+                {{- $backupCreation := $backupList.status.startTimestamp  }}
+                {{- if eq $backupCreation $scheduleObjLastBckTime }}
+
             - complianceType: musthave
               objectDefinition:
                 apiVersion: velero.io/v1
                 kind: Backup
                 metadata:
-                  namespace: '{{hub $configMap.data.backupNS hub}}'
-                  labels:
-                    velero.io/schedule-name: '{{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}-{{ fromClusterClaim "name" }}'
-                    cluster-id: '{{ fromClusterClaim "id.openshift.io" }}'
-                    cluster-name: '{{ fromClusterClaim "name" }}'
+                  namespace: '{{hub $backupNS hub}}'
+                  name: {{ $backupList.metadata.name }}
                 status:
                   phase: Completed
-              {{hub end hub}}
+                {{- end }}
+              {{- end }}
+            {{- end }}
           remediationAction: inform
           severity: high
-          customMessage:
-            compliant: |
-              There is at least one completed Backup generated by the {{hub with $configMap := (lookup "v1" "ConfigMap" "" "hdr-app-configmap") hub}} {{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}-<clusterName> Schedule.{{hub end hub}}
-            noncompliant: |
-              There is no completed Backup generated by the {{hub with $configMap := (lookup "v1" "ConfigMap" "" "hdr-app-configmap") hub}} {{hub $configMap.data.backupPrefix hub}}-{{hub $configMap.data.backupVolumeSnapshotLocation hub}}-<clusterName> Schedule.{{hub end hub}}


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-14460

related to https://github.com/open-cluster-management-io/policy-collection/pull/502

Updated the policies to address just the `check-backup-completed` template, since QE considered the changes related to https://github.com/open-cluster-management-io/policy-collection/pull/502 add more complexity to the message status

Changes:
- use the default messages, as before https://github.com/open-cluster-management-io/policy-collection/pull/502
- for the `check-backup-completed` template, to workaround the false negative when the BackupSchedule.status.lastBackup did not match any Backup timestamp, I look for a Backup matching that BackupSchedule.status.lastBackup. If found : check the Completed status; if not found, don't report anything
<img width="1185" alt="Screenshot 2024-10-03 at 1 59 18 PM" src="https://github.com/user-attachments/assets/6b4b3026-53f7-4610-81e5-1db19a2cf629">
