### PR TITLE
Configure Compliance Operator for ROSA HCP

### DIFF
--- a/stable/CA-Security-Assessment-and-Authorization/policy-compliance-operator-install.yaml
+++ b/stable/CA-Security-Assessment-and-Authorization/policy-compliance-operator-install.yaml
@@ -51,3 +51,9 @@ spec:
             namespace: openshift-compliance
             source: redhat-operators
             sourceNamespace: openshift-marketplace
+            # Conditionally configure a nodeSelector for installing on ROSA hosted control planes
+            config: '{{ if and (eq "ROSA" (fromClusterClaim
+              "product.open-cluster-management.io")) (eq "true"
+              (fromClusterClaim "hostedcluster.hypershift.openshift.io"))
+              }}{"nodeSelector":{"node-role.kubernetes.io/worker":""} }{{ else
+              }}{{ "{}" | toLiteral }}{{ end }}'


### PR DESCRIPTION
As mentioned in the [Compliance Operator documentation](https://docs.openshift.com/container-platform/4.17/security/compliance_operator/co-management/compliance-operator-installation.html#installing-compliance-operator-rosa_compliance-operator-installation), when installed on ROSA hosted control planes, a special node selector must be configured for the operator to run. This update uses conditionals to only make this configuration only on those clusters.

Refs:
 - https://issues.redhat.com/browse/ACM-14161