### PR TITLE
Add scanner v4 config

### DIFF
--- a/policygenerator/policy-sets/stable/openshift-plus/input-acs-central/policy-acs-operator-central.yaml
+++ b/policygenerator/policy-sets/stable/openshift-plus/input-acs-central/policy-acs-operator-central.yaml
@@ -47,6 +47,24 @@ spec:
         claimName: stackrox-db
   egress:
     connectivityPolicy: Online
+  scannerV4:
+    db:
+      persistence:
+        persistentVolumeClaim:
+          claimName: scanner-v4-db
+    indexer:
+      scaling:
+        autoScaling: Enabled
+        maxReplicas: 5
+        minReplicas: 2
+        replicas: 3
+    matcher:
+      scaling:
+        autoScaling: Enabled
+        maxReplicas: 5
+        minReplicas: 2
+        replicas: 3
+    scannerComponent: Default
   scanner:
     analyzer:
       scaling:


### PR DESCRIPTION
Adds config for RHACS Scanner V4, though does not enable it per the current RHACS 4.7.2. default config.

Scanner V4 can be enabled by changing the `scannerComponent` to `Enabled`, and optionally disabling the StackRox Scanner.