### PR TITLE
The OCP 4.19 AMI ids for AWS machine set needs to be updated

### DIFF
--- a/policygenerator/policy-sets/community/openshift-plus-setup/opp-settings.yaml
+++ b/policygenerator/policy-sets/community/openshift-plus-setup/opp-settings.yaml
@@ -23,10 +23,10 @@ data:
   us-east-2-4.17: ami-022fbb77a3226215f
   us-east-1-4.18: ami-08f1807771f4e468b
   us-east-2-4.18: ami-078e26f293629fe91
-  us-east-1-4.19: ami-0b6b825641a2ea530
-  us-east-2-4.19: ami-0f13d2cbfbca6203b
-  us-east-1-4.20: ami-0b6b825641a2ea530
-  us-east-2-4.20: ami-0f13d2cbfbca6203b
+  us-east-1-4.19: ami-0e8fd9094e487d1ff
+  us-east-2-4.19: ami-0d4a7b7677c0c883f
+  us-east-1-4.20: ami-0e8fd9094e487d1ff
+  us-east-2-4.20: ami-0d4a7b7677c0c883f
   zone1: a
   zone2: b
   zone3: c


### PR DESCRIPTION
The QE testing identified some stability problems with the previous AMI ids so we are updating to the latest.