### PR TITLE
Remove ODF StorageSystem in 4.19

### DIFF
--- a/policygenerator/policy-sets/stable/openshift-plus/input-odf/policy-odf.yaml
+++ b/policygenerator/policy-sets/stable/openshift-plus/input-odf/policy-odf.yaml
@@ -30,6 +30,8 @@ kind: StorageSystem
 metadata:
   name: ocs-storagecluster-storagesystem
   namespace: openshift-storage
+  labels:
+    removed-in-ocp419: '{{ skipObject (semverCompare  ">= 4.19" (fromClusterClaim "version.openshift.io")) }}'
 spec:
   kind: storagecluster.ocs.openshift.io/v1
   name: ocs-storagecluster


### PR DESCRIPTION
ODF 4.19 introduced a breaking change by removing the StorageSystem CR.  This change skips that component in the case where it is being deployed to OCP 4.19+