### PR TITLE
ODF 4.19 caused problems with the OPP PolicySet

### DIFF
--- a/policygenerator/policy-sets/stable/openshift-plus/input-odf/policy-odf-cluster.yaml
+++ b/policygenerator/policy-sets/stable/openshift-plus/input-odf/policy-odf-cluster.yaml
@@ -44,46 +44,12 @@ spec:
             cephConfig: {}
             cephDashboard: {}
             cephFilesystems: {}
+            cephNonResilientPools: {}
             cephObjectStoreUsers: {}
             cephObjectStores: {}
+            cephRBDMirror: {}
             cephToolbox: {}
-          mirroring: {}
-          nodeTopologies: {}
-          resources:
-            mds: {}
-            mgr: {}
-            mon: {}
-            noobaa-core: {}
-            noobaa-db: {}
-            noobaa-endpoint:
-              limits:
-                cpu: 1
-                memory: 500Mi
-              requests:
-                cpu: 1
-                memory: 500Mi
-            rgw: {}
-          storageDeviceSets:
-          - config: {}
-            count: 1
-            dataPVCTemplate:
-              metadata: {}
-              spec:
-                accessModes:
-                - ReadWriteOnce
-                resources:
-                  requests:
-                    storage: 100Gi
-    {{- if (eq (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type "VSphere") }}
-                storageClassName: thin-csi-odf
-    {{- else }}
-                storageClassName: gp3-csi
-    {{- end }}
-                volumeMode: Block
-              status: {}
-            name: ocs-deviceset
-            placement: {}
-            portable: true
-            preparePlacement: {}
-            replica: 3
-            resources: {}
+          multiCloudGateway:
+            dbStorageClassName: gp3-csi
+            reconcileStrategy: standalone
+          resourceProfile: balanced

--- a/policygenerator/policy-sets/stable/openshift-plus/input-odf/policy-odf.yaml
+++ b/policygenerator/policy-sets/stable/openshift-plus/input-odf/policy-odf.yaml
@@ -25,18 +25,6 @@ spec:
     source: redhat-operators
     sourceNamespace: openshift-marketplace
 ---
-apiVersion: odf.openshift.io/v1alpha1
-kind: StorageSystem
-metadata:
-  name: ocs-storagecluster-storagesystem
-  namespace: openshift-storage
-  labels:
-    removed-in-ocp419: '{{ skipObject (semverCompare  ">= 4.19" (fromClusterClaim "version.openshift.io")) }}'
-spec:
-  kind: storagecluster.ocs.openshift.io/v1
-  name: ocs-storagecluster
-  namespace: openshift-storage
----
 apiVersion: operator.openshift.io/v1
 kind: Console
 metadata:
@@ -44,3 +32,25 @@ metadata:
 spec:
   plugins:
   - odf-console
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: policy-odf-storagesystem
+spec:
+  remediationAction: enforce
+  severity: low
+  object-templates-raw: |
+    {{- if semverCompare  "< 4.19" (fromClusterClaim "version.openshift.io") }}
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: odf.openshift.io/v1alpha1
+        kind: StorageSystem
+        metadata:
+          name: ocs-storagecluster-storagesystem
+          namespace: openshift-storage
+        spec:
+          kind: storagecluster.ocs.openshift.io/v1
+          name: ocs-storagecluster
+          namespace: openshift-storage
+    {{- end }}


### PR DESCRIPTION
On OCP 4.19, with the release of ODF 4.19, there is a problem that prevents OPP from installing successfully.  The ODF operator no longer provides the StorageSystem CRD.  In ODF 4.19 the customer is expected to create the StorageCluster without a StorageSystem.

Additionally, the StorageCluster could not be created as configured in ODF 4.19.  I had to scope the configuration of ODF back to a more basic install. I have tested the changes on OCP 4.19 and OCP 4.16 successfully.

Refs:
 - https://issues.redhat.com/browse/LPINTEROP-5783