### PR TITLE
Removing annotations that are handled by the operator

### DIFF
--- a/policygenerator/policy-sets/stable/openshift-plus/input-odf/policy-odf-cluster.yaml
+++ b/policygenerator/policy-sets/stable/openshift-plus/input-odf/policy-odf-cluster.yaml
@@ -28,9 +28,6 @@ spec:
         apiVersion: ocs.openshift.io/v1
         kind: StorageCluster
         metadata:
-          annotations:
-            uninstall.ocs.openshift.io/cleanup-policy: delete
-            uninstall.ocs.openshift.io/mode: graceful
           name: ocs-storagecluster
           namespace: openshift-storage
         spec:


### PR DESCRIPTION
The ACM policies do not need to try to managed the odf storage cluster annotations since I have learned the operator will want to manage them and we don't want to introduce a conflict.