### PR TITLE
Switch back to the storage class that vsphere uses

### DIFF
--- a/policygenerator/policy-sets/stable/openshift-plus/input-odf/policy-odf-cluster.yaml
+++ b/policygenerator/policy-sets/stable/openshift-plus/input-odf/policy-odf-cluster.yaml
@@ -47,6 +47,10 @@ spec:
             cephRBDMirror: {}
             cephToolbox: {}
           multiCloudGateway:
+    {{- if (eq (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type "VSphere") }}
+            dbStorageClassName: thin-csi-odf
+    {{- else }}
             dbStorageClassName: gp3-csi
+    {{- end }}
             reconcileStrategy: standalone
           resourceProfile: balanced


### PR DESCRIPTION
Some changes recently to odf caused a storage class to be set to gp3-csi which needs to be thin-csi-odf for vsphere.