### PR TITLE
Changing the ODF configuration for OPP

### DIFF
--- a/policygenerator/policy-sets/stable/openshift-plus/input-odf/policy-odf-cluster.yaml
+++ b/policygenerator/policy-sets/stable/openshift-plus/input-odf/policy-odf-cluster.yaml
@@ -31,26 +31,37 @@ spec:
           name: ocs-storagecluster
           namespace: openshift-storage
         spec:
-          arbiter: {}
-          encryption:
-            kms: {}
-          externalStorage: {}
-          managedResources:
-            cephBlockPools: {}
-            cephCluster: {}
-            cephConfig: {}
-            cephDashboard: {}
-            cephFilesystems: {}
-            cephNonResilientPools: {}
-            cephObjectStoreUsers: {}
-            cephObjectStores: {}
-            cephRBDMirror: {}
-            cephToolbox: {}
-          multiCloudGateway:
+          resources:
+            mds: {}
+            mgr: {}
+            mon: {}
+            noobaa-core: {}
+            noobaa-db: {}
+            noobaa-endpoint:
+              limits:
+                cpu: 1
+                memory: 500Mi
+              requests:
+                cpu: 1
+                memory: 500Mi
+            rgw: {}
+          storageDeviceSets:
+          - count: 1
+            dataPVCTemplate:
+              spec:
+                accessModes:
+                - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: "100Gi"
     {{- if (eq (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.type "VSphere") }}
-            dbStorageClassName: thin-csi-odf
+                storageClassName: "thin-csi-odf"
     {{- else }}
-            dbStorageClassName: gp3-csi
+                storageClassName: "gp3-csi"
     {{- end }}
-            reconcileStrategy: standalone
-          resourceProfile: balanced
+                volumeMode: Block
+            name: ocs-deviceset
+            placement: {}
+            portable: true
+            replica: 3
+            resources: {}

--- a/policygenerator/policy-sets/stable/openshift-plus/kustomization.yml
+++ b/policygenerator/policy-sets/stable/openshift-plus/kustomization.yml
@@ -1,6 +1,10 @@
 generators:
 - ./policyGenerator.yaml
-commonLabels:
-  open-cluster-management.io/policy-set: openshift-plus
 commonAnnotations:
   argocd.argoproj.io/compare-options: IgnoreExtraneous
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- includeSelectors: true
+  pairs:
+    open-cluster-management.io/policy-set: openshift-plus


### PR DESCRIPTION
This is switching the ODF configuration back to the storage device sets that we were using prior to ODF 4.19.  While this was causing problems it is the desired configuration from the ODF team and it appears some fixes on top of ODF 4.19 may have improved the experience.  I have deployed this successfully on OCP 4.19.

Refs:
 - https://steps.ci.openshift.org/reference/odf-apply-storage-cluster
 - https://issues.redhat.com/browse/LPINTEROP-5791