### PR TITLE
Update compliance-operator install config

### DIFF
--- a/stable/CA-Security-Assessment-and-Authorization/policy-compliance-operator-install.yaml
+++ b/stable/CA-Security-Assessment-and-Authorization/policy-compliance-operator-install.yaml
@@ -52,8 +52,9 @@ spec:
             source: redhat-operators
             sourceNamespace: openshift-marketplace
             # Conditionally configure a nodeSelector for installing on ROSA hosted control planes
-            config: '{{ if and (eq "ROSA" (fromClusterClaim
-              "product.open-cluster-management.io")) (eq "true"
-              (fromClusterClaim "hostedcluster.hypershift.openshift.io"))
+            config: '{{ if and (eq "ROSA" (lookup "cluster.open-cluster-management.io/v1alpha1"
+              "ClusterClaim" "" "product.open-cluster-management.io").spec.value) (eq "true"
+              (lookup "cluster.open-cluster-management.io/v1alpha1" "ClusterClaim" ""
+              "hostedcluster.hypershift.openshift.io").spec.value)
               }}{"nodeSelector":{"node-role.kubernetes.io/worker":""} }{{ else
               }}{{ "{}" | toLiteral }}{{ end }}'


### PR DESCRIPTION
Previously, the template used `fromClusterClaim`, but if the cluster claim could not be found, the policy would become noncompliant. Now it uses `lookup` which will return an empty string if the resource can't be found. This allows the template to work in more cases.

Users writing their own policy should consider using the newer `lookupClusterClaim` function, which is easier to read and write. This policy uses `lookup` directly, for more compatability across versions.

Refs:
 - https://issues.redhat.com/browse/ACM-25409