### PR TITLE
Dynamic AMI and instance type lookup from existing MachineSets with fallback to ConfigMap values

### DIFF
--- a/policygenerator/policy-sets/community/openshift-plus-setup/machine-sets.yaml
+++ b/policygenerator/policy-sets/community/openshift-plus-setup/machine-sets.yaml
@@ -52,7 +52,18 @@ spec:
               providerSpec:
                 value:
                   ami:
-                    id: '{{ fromConfigMap "policies" "opp-settings" (printf "%s-%s" (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").status.platformStatus.aws.region (fromClusterClaim "openshiftversion-major-minor")) }}'
+                    id: '{{- $dynamicAMI := "" -}}
+                         {{- $machinesets := (lookup "machine.openshift.io/v1beta1" "MachineSet" "openshift-machine-api" "") -}}
+                         {{- if $machinesets.items -}}
+                           {{- if gt (len $machinesets.items) 0 -}}
+                             {{- $dynamicAMI = (index $machinesets.items 0).spec.template.spec.providerSpec.value.ami.id -}}
+                           {{- end -}}
+                         {{- end -}}
+                         {{- if $dynamicAMI -}}
+                           {{ $dynamicAMI }}
+                         {{- else -}}
+                           {{ fromConfigMap "policies" "opp-settings" (printf "%s-%s" (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").status.platformStatus.aws.region (fromClusterClaim "openshiftversion-major-minor")) }}
+                         {{- end -}}'
                   apiVersion: awsproviderconfig.openshift.io/v1beta1
                   blockDevices:
                   - ebs:
@@ -64,7 +75,19 @@ spec:
                   deviceIndex: 0
                   iamInstanceProfile:
                     id: '{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").status.infrastructureName }}-worker-profile'
-                  instanceType: '{{ fromConfigMap "policies" "opp-settings" "awsInstanceType" }}'
+                  instanceType: '{{- $dynamicInstanceType := "" -}}
+                                 {{- $machinesets := (lookup "machine.openshift.io/v1beta1" "MachineSet" "openshift-machine-api" "") -}}
+                                 {{- if $machinesets.items -}}
+                                   {{- if gt (len $machinesets.items) 0 -}}
+                                     {{- $dynamicInstanceType = (index $machinesets.items 0).spec.template.spec.providerSpec.value.instanceType -}}
+                                     {{- $dynamicInstanceType = replace ".metal" ".2xlarge" $dynamicInstanceType -}}
+                                   {{- end -}}
+                                 {{- end -}}
+                                 {{- if $dynamicInstanceType -}}
+                                   {{ $dynamicInstanceType }}
+                                 {{- else -}}
+                                   {{ fromConfigMap "policies" "opp-settings" "awsInstanceType" }}
+                                 {{- end -}}'
                   kind: AWSMachineProviderConfig
                   metadata:
                     creationTimestamp: null


### PR DESCRIPTION
  1. Dynamic AMI Lookup

  - Queries existing MachineSets in openshift-machine-api namespace
  - Extracts AMI ID from the first MachineSet's providerSpec.value.ami.id
  - Falls back to region+version-based ConfigMap lookup if no MachineSets exist
  - Ensures storage nodes use the same AMI as compute nodes (matching architecture)

  2. Dynamic Instance Type Lookup

  - Extracts instance type from existing MachineSets
  - Automatically handles bare metal by replacing .metal with .2xlarge
  - Falls back to awsInstanceType ConfigMap value if no MachineSets found
  - Ensures architecture compatibility between AMI and instance type 
