### PR TITLE
chore: shift to use acm-cli for policy generator binary

### DIFF
--- a/community/CM-Configuration-Management/policy-openshift-gitops-policygenerator.yaml
+++ b/community/CM-Configuration-Management/policy-openshift-gitops-policygenerator.yaml
@@ -36,14 +36,14 @@ spec:
                     initContainers:
                     - args:
                       - -c
-                      - cp /policy-generator/PolicyGenerator-not-fips-compliant /policy-generator-tmp/PolicyGenerator
+                      - tar -xzf /acm-cli/PolicyGenerator-rhel9.tar.gz -C /tmp/
                       command:
                       - /bin/bash
-                      image: '{{ (index (lookup "apps/v1" "Deployment" "open-cluster-management" "multicluster-operators-hub-subscription").spec.template.spec.containers 0).image }}'
+                      image: '{{ (index (lookup "apps/v1" "Deployment" "open-cluster-management" "acm-cli-downloads").spec.template.spec.containers 0).image }}'
                       name: policy-generator-install
                       volumeMounts:
-                      - mountPath: /policy-generator
-                        name: policy-generator-tmp
+                      - mountPath: /tmp
+                        name: policy-generator
                     volumeMounts:
                     - mountPath: /etc/kustomize/plugin/policy.open-cluster-management.io/v1/policygenerator
                       name: policy-generator

--- a/policygenerator/policy-sets/community/openshift-gitops/policy-openshift-gitops-grc.yaml
+++ b/policygenerator/policy-sets/community/openshift-gitops/policy-openshift-gitops-grc.yaml
@@ -13,14 +13,13 @@ spec:
     initContainers:
     - args:
       - -c
-      - cp /etc/kustomize/plugin/policy.open-cluster-management.io/v1/policygenerator/PolicyGenerator
-        /policy-generator/PolicyGenerator
+      - tar -xzf /acm-cli/PolicyGenerator-rhel9.tar.gz -C /tmp/
       command:
       - /bin/bash
-      image: 'registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel8:v{{ (lookup "operator.open-cluster-management.io/v1" "MultiClusterHub" "open-cluster-management" "multiclusterhub").status.currentVersion }}'
+      image: '{{ (index (lookup "apps/v1" "Deployment" "open-cluster-management" "acm-cli-downloads").spec.template.spec.containers 0).image }}'
       name: policy-generator-install
       volumeMounts:
-      - mountPath: /policy-generator
+      - mountPath: /tmp
         name: policy-generator
     volumeMounts:
     - mountPath: /etc/kustomize/plugin/policy.open-cluster-management.io/v1/policygenerator

--- a/policygenerator/policy-sets/community/policygenerator-download/deployment.yml
+++ b/policygenerator/policy-sets/community/policygenerator-download/deployment.yml
@@ -7,10 +7,10 @@ spec:
   remediationAction: enforce
   severity: low
   object-templates-raw: |
-    {{- $ocmDeployment := (lookup "apps/v1" "Deployment" "open-cluster-management" "multicluster-operators-hub-subscription") }}
+    {{- $ocmDeployment := (lookup "apps/v1" "Deployment" "open-cluster-management" "acm-cli-downloads") }}
     {{- $ocmContainer := "" }}
     {{- range $cn := $ocmDeployment.spec.template.spec.containers }}
-      {{- if eq $cn.name "multicluster-operators-hub-subscription" }}
+      {{- if eq $cn.name "acm-cli-downloads" }}
         {{- $ocmContainer = $cn }}
         {{- break }}
       {{- end }}
@@ -45,14 +45,13 @@ spec:
               initContainers:
               - args:
                 - -c
-                - cp /etc/kustomize/plugin/policy.open-cluster-management.io/v1/policygenerator/PolicyGenerator
-                  /policy-generator/PolicyGenerator
+                - tar -xzf /acm-cli/PolicyGenerator-rhel9.tar.gz -C /tmp/
                 command:
                 - /bin/bash
                 image: {{ $ocmContainer.image }}
                 name: policy-generator-install
                 volumeMounts:
-                - mountPath: /policy-generator
+                - mountPath: /tmp
                   name: policy-generator
               containers:
                 - name: policygen-downloader


### PR DESCRIPTION
Blocked by:
- https://github.com/stolostron/acm-cli/pull/317

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * PolicyGenerator deployment updated to extract from tarball archives instead of copying pre-built binaries.
  * Artifact sourcing moved to the ACM CLI downloads deployment for centralized retrieval.
  * Improved compatibility with RHEL9 across policy generation and OpenShift GitOps workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->