### PR TITLE
Add policy for kube-apiserver name clash issue

### DIFF
--- a/community/README.md
+++ b/community/README.md
@@ -249,6 +249,7 @@ Policy  | Description | Prerequisites
 [OpenShift Cluster Operator state policy](./SC-System-and-Communications-Protection/policy-checkclusteroperator.yaml) | This policy alerts when an OpenShift `ClusterOperator` becomes unhealthy. See [ClusterOperator config](https://docs.openshift.com/container-platform/latest/rest_api/config_apis/clusteroperator-config-openshift-io-v1.html) for additional details. | OpenShift 4.x only.
 [Check namespaces in Terminating status](./SC-System-and-Communications-Protection/policy-checknamespaces-terminating.yaml)| check for namespaces in terminating status | check e.g. this [link](https://www.redhat.com/sysadmin/troubleshooting-terminating-namespaces) how to fix this.
 [Disable self-provisioner](./SC-System-and-Communications-Protection/policy-disable-self-provisioner.yaml)| Disable ability to for users to create their own projects | OpenShift 4.x only.
+[ClusterRoleBinding cleanup for kube-apiserver](./SC-System-and-Communications-Protection/policy-remove-legacy-apiserver-binding.yaml)| Remove elevated privileges from regular user kube-apiserver | OpenShift 4.x only.
 
 
 ### System and Information Integrity

--- a/community/SC-System-and-Communications-Protection/policy-remove-legacy-apiserver-binding.yaml
+++ b/community/SC-System-and-Communications-Protection/policy-remove-legacy-apiserver-binding.yaml
@@ -1,0 +1,46 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: remove-legacy-apiserver-binding
+  annotations:
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+    policy.open-cluster-management.io/categories: SC System and Communications Protection
+    policy.open-cluster-management.io/controls: SC-1 SYSTEM AND COMMUNICATIONS PROTECTION POLICY AND PROCEDURES
+    policy.open-cluster-management.io/description: >-
+      This policy removes an obsolete legacy entry in the kube-apiserver
+      ClusterRoleBinding that used to be created during cluster installation
+      by default, and would grant elevated privileges to a regular user
+      whose name happens to match
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: remove-legacy-apiserver-binding
+        spec:
+          remediationAction: inform
+          severity: low
+          customMessage:
+            noncompliant: >-
+              ClusterRoleBinding kube-apiserver includes obsolete legacy entry
+              that should be removed (see
+              <https://access.redhat.com/solutions/7136094>)
+          object-templates:
+            - complianceType: mustonlyhave
+              metadataComplianceType: musthave
+              objectDefinition:
+                apiVersion: rbac.authorization.k8s.io/v1
+                kind: ClusterRoleBinding
+                metadata:
+                  name: kube-apiserver
+                roleRef:
+                  apiGroup: rbac.authorization.k8s.io
+                  kind: ClusterRole
+                  name: kube-apiserver
+                subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: User
+                    name: system:kube-apiserver


### PR DESCRIPTION
An extraneous entry in the default ClusterRoleBinding for the kube-apiserver created during OpenShift cluster bootstrap could be abused to grant elevated privileges to a regular user with a matching name. The legacy entry is no longer required and should be removed.

Reference: <https://access.redhat.com/solutions/7136094>