### PR TITLE
Add deprecation comments to ClusterPolicy

### DIFF
--- a/community/CM-Configuration-Management/policy-create-ns-backup-triliovault-for-kubernetes-templatized.yaml
+++ b/community/CM-Configuration-Management/policy-create-ns-backup-triliovault-for-kubernetes-templatized.yaml
@@ -1,3 +1,8 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+# Then convert the Kyverno manifest to an OCM policy with the Policy Generator plugin
+
 # This policy creates a namespace based backup using Triliovault for Kubernetes (TVK)
 # on all OpenShift managed clusters with a label "protected-by=triliovault".
 #

--- a/community/CM-Configuration-Management/policy-kyverno-add-network-policy.yaml
+++ b/community/CM-Configuration-Management/policy-kyverno-add-network-policy.yaml
@@ -1,3 +1,8 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+# Then convert the Kyverno manifest to an OCM policy with the Policy Generator plugin
+
 # Use this policy to create NetworkPolicies in new namespaces.
 # This policy requires the Kyverno policy enforcement point to be installed
 # separately.  The policy is based off of a kyverno community policy 

--- a/community/CM-Configuration-Management/policy-kyverno-add-quota.yaml
+++ b/community/CM-Configuration-Management/policy-kyverno-add-quota.yaml
@@ -1,3 +1,8 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+# Then convert the Kyverno manifest to an OCM policy with the Policy Generator plugin
+
 # Use this policy to control quota limits in new namespaces.
 # This policy requires the Kyverno policy enforcement point to be installed
 # separately.  The policy is based off of a kyverno community policy

--- a/community/CM-Configuration-Management/policy-kyverno-container-tgps.yaml
+++ b/community/CM-Configuration-Management/policy-kyverno-container-tgps.yaml
@@ -1,3 +1,8 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+# Then convert the Kyverno manifest to an OCM policy with the Policy Generator plugin
+
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:

--- a/community/CM-Configuration-Management/policy-kyverno-image-pull-policy.yaml
+++ b/community/CM-Configuration-Management/policy-kyverno-image-pull-policy.yaml
@@ -1,3 +1,8 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+# Then convert the Kyverno manifest to an OCM policy with the Policy Generator plugin
+
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:

--- a/community/CM-Configuration-Management/policy-kyverno-sample.yaml
+++ b/community/CM-Configuration-Management/policy-kyverno-sample.yaml
@@ -1,3 +1,8 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+# Then convert the Kyverno manifest to an OCM policy with the Policy Generator plugin
+
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:

--- a/community/CM-Configuration-Management/policy-kyverno-sync-secrets.yaml
+++ b/community/CM-Configuration-Management/policy-kyverno-sync-secrets.yaml
@@ -1,3 +1,8 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+# Then convert the Kyverno manifest to an OCM policy with the Policy Generator plugin
+
 # Use this policy to sync secrets between namespaces.
 # This policy requires the Kyverno policy enforcement point to be installed
 # separately.  The policy is based off of a kyverno community policy

--- a/policygenerator/kustomize/policy3_kyverno/kyverno.yaml
+++ b/policygenerator/kustomize/policy3_kyverno/kyverno.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/affinity/add_node_affinity.yaml
+++ b/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/affinity/add_node_affinity.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/affinity/create_pod_antiaffinity.yaml
+++ b/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/affinity/create_pod_antiaffinity.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/affinity/spread_pods_across_topology.yaml
+++ b/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/affinity/spread_pods_across_topology.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/base_images/allowed-base-images.yaml
+++ b/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/base_images/allowed-base-images.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/base_images/annotate-base-images.yaml
+++ b/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/base_images/annotate-base-images.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/deployments/add_volume_deployment.yaml
+++ b/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/deployments/add_volume_deployment.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/deployments/mutate-large-termination-gps.yaml
+++ b/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/deployments/mutate-large-termination-gps.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/deployments/restart_deployment_on_secret_change.yaml
+++ b/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/deployments/restart_deployment_on_secret_change.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/deployments/scale_deployment_zero.yaml
+++ b/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/deployments/scale_deployment_zero.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/limitsrequests/require_requests_limits.yaml
+++ b/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/limitsrequests/require_requests_limits.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/poddisruptionbudget/create_default_pdb.yaml
+++ b/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/poddisruptionbudget/create_default_pdb.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/require_deployments_have_multiple_replicas/deployment-musthaverolling-strategy.yaml
+++ b/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/require_deployments_have_multiple_replicas/deployment-musthaverolling-strategy.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/require_deployments_have_multiple_replicas/require_deployments_have_multiple_replicas.yaml
+++ b/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/require_deployments_have_multiple_replicas/require_deployments_have_multiple_replicas.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/require_probes/ensure_probes_different.yaml
+++ b/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/require_probes/ensure_probes_different.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/require_probes/require_probes.yaml
+++ b/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/require_probes/require_probes.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/resource-exhaustion/disallow-self-provisioner/disallow-self-provisioner.yaml
+++ b/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/resource-exhaustion/disallow-self-provisioner/disallow-self-provisioner.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/restrict_controlplane_scheduling/restrict_controlplane_scheduling.yaml
+++ b/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/restrict_controlplane_scheduling/restrict_controlplane_scheduling.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/routes/check-routes.yaml
+++ b/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/routes/check-routes.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/validate_git/validategit.yaml
+++ b/policygenerator/policy-sets/community/kyverno/best-practises-for-apps/input/validate_git/validategit.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/multitenancy/input/addlabelstotenant/add-labels-to-bluetenant.yaml
+++ b/policygenerator/policy-sets/community/kyverno/multitenancy/input/addlabelstotenant/add-labels-to-bluetenant.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/multitenancy/input/addlabelstotenant/add-labels-to-redtenant.yaml
+++ b/policygenerator/policy-sets/community/kyverno/multitenancy/input/addlabelstotenant/add-labels-to-redtenant.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/multitenancy/input/disallowplacementrules/disallow-placementRules.yaml
+++ b/policygenerator/policy-sets/community/kyverno/multitenancy/input/disallowplacementrules/disallow-placementRules.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/multitenancy/input/generateManagedClusterSetBinding/generateManagedClusterSetBindingblueteam-hub.yaml
+++ b/policygenerator/policy-sets/community/kyverno/multitenancy/input/generateManagedClusterSetBinding/generateManagedClusterSetBindingblueteam-hub.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy

--- a/policygenerator/policy-sets/community/kyverno/multitenancy/input/generateManagedClusterSetBinding/generateManagedClusterSetBindingredteam-hub.yaml
+++ b/policygenerator/policy-sets/community/kyverno/multitenancy/input/generateManagedClusterSetBinding/generateManagedClusterSetBindingredteam-hub.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy

--- a/policygenerator/policy-sets/community/kyverno/multitenancy/input/generatePlacementRules/generatePlacementblueteam-hub.yaml
+++ b/policygenerator/policy-sets/community/kyverno/multitenancy/input/generatePlacementRules/generatePlacementblueteam-hub.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy

--- a/policygenerator/policy-sets/community/kyverno/multitenancy/input/generatePlacementRules/generatePlacementredteam-hub.yaml
+++ b/policygenerator/policy-sets/community/kyverno/multitenancy/input/generatePlacementRules/generatePlacementredteam-hub.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy

--- a/policygenerator/policy-sets/community/kyverno/multitenancy/input/generateall/generate-all-blueteam-spoke.yml
+++ b/policygenerator/policy-sets/community/kyverno/multitenancy/input/generateall/generate-all-blueteam-spoke.yml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy

--- a/policygenerator/policy-sets/community/kyverno/multitenancy/input/generateall/generate-all-redteam-spoke.yml
+++ b/policygenerator/policy-sets/community/kyverno/multitenancy/input/generateall/generate-all-redteam-spoke.yml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy

--- a/policygenerator/policy-sets/community/kyverno/multitenancy/input/generateargocdpersmissions/generate-argocd-permissions-blueteam-spoke.yaml
+++ b/policygenerator/policy-sets/community/kyverno/multitenancy/input/generateargocdpersmissions/generate-argocd-permissions-blueteam-spoke.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy

--- a/policygenerator/policy-sets/community/kyverno/multitenancy/input/generateargocdpersmissions/generate-argocd-permissions-redteam-spoke.yaml
+++ b/policygenerator/policy-sets/community/kyverno/multitenancy/input/generateargocdpersmissions/generate-argocd-permissions-redteam-spoke.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/multitenancy/input/other/add-ttl-to-dangling-job.yaml
+++ b/policygenerator/policy-sets/community/kyverno/multitenancy/input/other/add-ttl-to-dangling-job.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/multitenancy/input/preventupdatesappproject/application-prevent-updates-project-all.yaml
+++ b/policygenerator/policy-sets/community/kyverno/multitenancy/input/preventupdatesappproject/application-prevent-updates-project-all.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/multitenancy/input/restrictions/restrict-blueteam-destination-spoke.yaml
+++ b/policygenerator/policy-sets/community/kyverno/multitenancy/input/restrictions/restrict-blueteam-destination-spoke.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/multitenancy/input/restrictions/restrict-blueteam-to-its-appproject-all.yaml
+++ b/policygenerator/policy-sets/community/kyverno/multitenancy/input/restrictions/restrict-blueteam-to-its-appproject-all.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/multitenancy/input/restrictions/restrict-blueteam-to-its-placement-hub.yaml
+++ b/policygenerator/policy-sets/community/kyverno/multitenancy/input/restrictions/restrict-blueteam-to-its-placement-hub.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/multitenancy/input/restrictions/restrict-redteam-destination-spoke.yaml
+++ b/policygenerator/policy-sets/community/kyverno/multitenancy/input/restrictions/restrict-redteam-destination-spoke.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/multitenancy/input/restrictions/restrict-redteam-to-its-appproject-hub.yaml
+++ b/policygenerator/policy-sets/community/kyverno/multitenancy/input/restrictions/restrict-redteam-to-its-appproject-hub.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/multitenancy/input/restrictions/restrict-redteam-to-its-placement-hub.yaml
+++ b/policygenerator/policy-sets/community/kyverno/multitenancy/input/restrictions/restrict-redteam-to-its-placement-hub.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/multitenancy/input/sharedresources/add-managedclustersetbinding-shared-sre-group.yaml
+++ b/policygenerator/policy-sets/community/kyverno/multitenancy/input/sharedresources/add-managedclustersetbinding-shared-sre-group.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy

--- a/policygenerator/policy-sets/community/kyverno/multitenancy/input/validatens/validate-ns-bluesre-spoke.yaml
+++ b/policygenerator/policy-sets/community/kyverno/multitenancy/input/validatens/validate-ns-bluesre-spoke.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/multitenancy/input/validatens/validate-ns-redsre-spoke.yaml
+++ b/policygenerator/policy-sets/community/kyverno/multitenancy/input/validatens/validate-ns-redsre-spoke.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/multitenancy/input/validateplacement/preventupdates-appproject-all.yaml
+++ b/policygenerator/policy-sets/community/kyverno/multitenancy/input/validateplacement/preventupdates-appproject-all.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/multitenancy/input/validateplacement/validateplacementblueteam-hub.yml
+++ b/policygenerator/policy-sets/community/kyverno/multitenancy/input/validateplacement/validateplacementblueteam-hub.yml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/multitenancy/input/validateplacement/validateplacementredteam-hub.yml
+++ b/policygenerator/policy-sets/community/kyverno/multitenancy/input/validateplacement/validateplacementredteam-hub.yml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/authorization/disallow-scc-runasany.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/authorization/disallow-scc-runasany.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/authorization/host-namespaces/disallow-host-ipc.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/authorization/host-namespaces/disallow-host-ipc.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/authorization/host-namespaces/disallow-host-network.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/authorization/host-namespaces/disallow-host-network.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/authorization/host-namespaces/disallow-host-pid.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/authorization/host-namespaces/disallow-host-pid.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/authorization/host-namespaces/disallow-host-ports.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/authorization/host-namespaces/disallow-host-ports.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/authorization/protect-default-scc/protect-default-scc.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/authorization/protect-default-scc/protect-default-scc.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/disallow-host-namespaces/disallow-host-namespaces.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/disallow-host-namespaces/disallow-host-namespaces.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/disallow_latest_tag/disallow_latest_tag.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/disallow_latest_tag/disallow_latest_tag.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/httpsonly/httpsonly.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/httpsonly/httpsonly.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/networking/block-nodeport-services/block-nodeport-services.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/networking/block-nodeport-services/block-nodeport-services.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/require-run-as-non-root-user/require-run-as-non-root-user.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/require-run-as-non-root-user/require-run-as-non-root-user.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/require-run-as-non-root-user/restrictions/restrict-blueteam-destination-spoke.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/require-run-as-non-root-user/restrictions/restrict-blueteam-destination-spoke.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/require-run-as-non-root-user/restrictions/restrict-blueteam-to-its-appproject-all.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/require-run-as-non-root-user/restrictions/restrict-blueteam-to-its-appproject-all.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/require-run-as-non-root-user/restrictions/restrict-blueteam-to-its-placement-hub.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/require-run-as-non-root-user/restrictions/restrict-blueteam-to-its-placement-hub.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/require-run-as-non-root-user/restrictions/restrict-redteam-destination-spoke.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/require-run-as-non-root-user/restrictions/restrict-redteam-destination-spoke.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/require-run-as-non-root-user/restrictions/restrict-redteam-to-its-appproject-hub.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/require-run-as-non-root-user/restrictions/restrict-redteam-to-its-appproject-hub.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/require-run-as-non-root-user/restrictions/restrict-redteam-to-its-placement-hub.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/require-run-as-non-root-user/restrictions/restrict-redteam-to-its-placement-hub.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/restrict-binding-clusteradmin/block-stale-images/block-stale-images.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/restrict-binding-clusteradmin/block-stale-images/block-stale-images.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/restrict-binding-clusteradmin/restrict-binding-clusteradmin.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/restrict-binding-clusteradmin/restrict-binding-clusteradmin.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/restrict-clusterrole-nodesproxy/restrict-clusterrole-nodesproxy.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/restrict-clusterrole-nodesproxy/restrict-clusterrole-nodesproxy.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/restrict-escalation-verbs-roles/restrict-escalation-verbs-roles.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/restrict-escalation-verbs-roles/restrict-escalation-verbs-roles.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/restrict-ingress-wildcard/restrict-ingress-wildcard.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/restrict-ingress-wildcard/restrict-ingress-wildcard.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/restrict-secret-role-verbs/restrict-secret-role-verbs.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/restrict-secret-role-verbs/restrict-secret-role-verbs.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/restrict-service-account/restrict_service_account.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/restrict-service-account/restrict_service_account.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/restrict-wildcard-resources/restrict-wildcard-resources.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/restrict-wildcard-resources/restrict-wildcard-resources.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/restrict-wildcard-verbs/restrict-wildcard-verbs.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/restrict-wildcard-verbs/restrict-wildcard-verbs.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/restrict_annotations/restrict_annotations.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/restrict_annotations/restrict_annotations.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/restrict_automount_sa_token/restrict_automount_sa_token.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/restrict_automount_sa_token/restrict_automount_sa_token.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/restrict_ingress_classes/restrict_ingress_classes.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/restrict_ingress_classes/restrict_ingress_classes.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/restrict_ingress_defaultbackend/restrict_ingress_defaultbackend.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/restrict_ingress_defaultbackend/restrict_ingress_defaultbackend.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/restrict_ingress_host/restrict_ingress_host.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/restrict_ingress_host/restrict_ingress_host.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/restrict_loadbalancer/restrict_loadbalancer.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/restrict_loadbalancer/restrict_loadbalancer.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/restrict_node_selection/restrict_node_selection.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/restrict_node_selection/restrict_node_selection.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/restrict_secrets_by_label/restrict-secrets-by-label.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/restrict_secrets_by_label/restrict-secrets-by-label.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/restrict_secrets_by_name/restrict-secrets-by-name.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/restrict_secrets_by_name/restrict-secrets-by-name.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/restrict_service_port_range/restrict-service-port-range.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/restrict_service_port_range/restrict-service-port-range.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/restrict_usergroup_fsgroup_id/restrict_usergroup_fsgroup_id.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/restrict_usergroup_fsgroup_id/restrict_usergroup_fsgroup_id.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:

--- a/policygenerator/policy-sets/community/kyverno/security/input/security-context-contraint/disallow-security-context-constraint-anyuid.yaml
+++ b/policygenerator/policy-sets/community/kyverno/security/input/security-context-contraint/disallow-security-context-constraint-anyuid.yaml
@@ -1,3 +1,7 @@
+# WARNING: ClusterPolicy was DEPRECATED in Kyverno v1.17
+# To update your policy, browse the official Kyverno policy collection 
+# for current examples: https://kyverno.io/policies
+
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:


### PR DESCRIPTION
ClusterPolicy was deprecated in [Kyverno v1.17](https://kyverno.io/blog/2026/02/02/announcing-kyverno-release-1.17/). Add comments directing users to updated policy examples.

Used ctrl-f for `kind: ClusterPolicy` and Cursor to insert warning comments

ref: https://redhat.atlassian.net/browse/ACM-15886

Edit: depends on https://github.com/open-cluster-management-io/policy-generator-plugin/pull/251