### PR TITLE
Add directory recursion to Argo deployment script

### DIFF
--- a/deploy/argoDeploy.sh
+++ b/deploy/argoDeploy.sh
@@ -116,6 +116,8 @@ spec:
     path: $GH_PATH
     repoURL: $GH_URL
     targetRevision: $GH_BRANCH
+    directory:
+      recurse: true
   syncPolicy:
     automated: {}
     syncOptions:


### PR DESCRIPTION
Without this the policies in subfolders of `stable` or `community` are not applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deployment**
  * Argo CD now automatically discovers application manifests within nested subdirectories under the configured source path.
  * Existing deployment behavior and configuration options remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->