### PR TITLE
no appsub should be present

### DIFF
--- a/policygenerator/policy-sets/stable/acm-hardening/input-subscriptions/policy-subscriptions.yaml
+++ b/policygenerator/policy-sets/stable/acm-hardening/input-subscriptions/policy-subscriptions.yaml
@@ -1,4 +1,2 @@
 apiVersion: apps.open-cluster-management.io/v1
 kind: Subscription
-status:
-  phase: Failed


### PR DESCRIPTION
appsub is deprecated for > 2 years and should not be used anymore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the `Failed` status from the Subscription configuration to prevent it from being treated as an active failure state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->